### PR TITLE
优化popup自适应宽度以显示完整脚本名称

### DIFF
--- a/build/assets/template/popup.html
+++ b/build/assets/template/popup.html
@@ -18,7 +18,8 @@
       margin: 0;
       padding: 0;
       border: 0;
-      width: 320px;
+      min-width: 320px;
+      max-width: 640px;
       /* height: 500px; */
       min-height: 150px;
       max-height: 500px;

--- a/src/pages/components/ScriptMenuList/index.tsx
+++ b/src/pages/components/ScriptMenuList/index.tsx
@@ -136,6 +136,7 @@ const ScriptMenuList: React.FC<{
                       overflow: "hidden",
                       textOverflow: "ellipsis",
                       whiteSpace: "nowrap",
+                      width: "calc(100% + 1px)",
                       color: item.runNum === 0 ? "rgb(var(--gray-5))" : "",
                     }}
                   >


### PR DESCRIPTION
优化`popup`页面固定宽度→自适应宽度，以显示完整脚本名称。
优化前固定宽度`320px`；
优化后最小宽度`320px`，最大宽度`640px`，且小于最大宽度时脚本名不再显示`...` `text-overflow`。
（这里用了个比较傻的`calc(100% + 1px)`不知道哥哥有没有啥其他好的解决办法）




**预览（优化前及优化后）：**
<img width=320 src=https://user-images.githubusercontent.com/34838824/230924677-256778d7-ea75-4d13-8431-4793f5b9426b.png>  
<img width=440 src=https://user-images.githubusercontent.com/34838824/230924696-87bc1410-768e-4046-a81c-534bd2144cc3.png>
