### PR TITLE
更新monaco@0.37.1，修复多编辑器快捷键冲突，修复npm run dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "dayjs": "^1.11.4",
         "dexie": "^3.2.2",
         "jszip": "^3.10.1",
-        "monaco-editor": "^0.31.0",
+        "monaco-editor": "^0.37.1",
         "monaco-vim": "^0.3.4",
         "pako": "^2.0.4",
         "react": "^18.2.0",
@@ -13597,9 +13597,9 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
-      "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q=="
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.37.1.tgz",
+      "integrity": "sha512-jLXEEYSbqMkT/FuJLBZAVWGuhIb4JNwHE9kPTorAVmsdZ4UzHAfgWxLsVtD7pLRFaOwYPhNG9nUCpmFL1t/dIg=="
     },
     "node_modules/monaco-editor-locales-plugin": {
       "version": "0.0.3",
@@ -27552,9 +27552,9 @@
       "dev": true
     },
     "monaco-editor": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
-      "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q=="
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.37.1.tgz",
+      "integrity": "sha512-jLXEEYSbqMkT/FuJLBZAVWGuhIb4JNwHE9kPTorAVmsdZ4UzHAfgWxLsVtD7pLRFaOwYPhNG9nUCpmFL1t/dIg=="
     },
     "monaco-editor-locales-plugin": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest --coverage",
     "lint": "eslint --ext .js,.ts,.tsx src/",
-    "dev": "concurrently \"webpack --mode development --config ./webpack/webpack.dev.ts\" \"npm run dev:linter\"",
+    "dev": "webpack --mode development --config ./webpack/webpack.dev.ts",
     "build": "webpack --mode production --config ./webpack/webpack.prod.ts && concurrently \"npm run build:linter\" \"npm run build:no-split\"",
     "build:linter": "webpack --mode production --config ./webpack/webpack.linter.ts",
     "build:no-split": "webpack --mode production --config ./webpack/webpack.no.split.ts",
@@ -28,7 +28,7 @@
     "dayjs": "^1.11.4",
     "dexie": "^3.2.2",
     "jszip": "^3.10.1",
-    "monaco-editor": "^0.31.0",
+    "monaco-editor": "^0.37.1",
     "monaco-vim": "^0.3.4",
     "pako": "^2.0.4",
     "react": "^18.2.0",

--- a/webpack/webpack.dev.ts
+++ b/webpack/webpack.dev.ts
@@ -3,6 +3,8 @@ import merge from "webpack-merge";
 import CompressionPlugin from "compression-webpack-plugin";
 import common from "../webpack.config";
 
+const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
+
 const src = `${__dirname}/../src`;
 const dist = `${__dirname}/../dist`;
 
@@ -13,6 +15,7 @@ common.entry = {
   inject: `${src}/inject.ts`,
   "editor.worker": "monaco-editor/esm/vs/editor/editor.worker.js",
   "ts.worker": "monaco-editor/esm/vs/language/typescript/ts.worker.js",
+  "linter.worker": `${src}/linter.worker.ts`,
 };
 
 common.output = {
@@ -33,5 +36,9 @@ export default merge(common, {
       test: /ts.worker.js/,
       deleteOriginalAssets: true,
     }),
+    new NodePolyfillPlugin(),
   ],
+  resolve: {
+    mainFields: ["browser", "main", "module"],
+  },
 });


### PR DESCRIPTION
## 改动内容  
### 更新`monaco@0.37.1`
为后续优化ESLint做基础

### 修复多编辑器快捷键冲突
（0.31.0原本就有的多编辑器冲突未修复）
#### 冲突原因：
没有使用闭包局部变量，`Script`、`editor`变量被多编辑器共享，导致新编辑器初始化时会覆盖旧编辑器变量（不清楚是monaco官方bug还是代码实现bug）
#### 解决方案：
声明一个`Map`，以`Script.uuid`为key、`Script`为value，储存`Script`；
初始化`editor`时将`Script`的`uuid`绑定到`editor`上；
监听快捷键事件时获取当前激活的`editor`（通过`editor._focusTracker._hasFocus`判断`editor`激活状态 可能有更好的方法），
仅在获取到激活的`editor`时，通过`editor`上绑定的`uuid`获取`Script`，并指定激活的`editor`执行快捷键`action`

### 修复`npm run dev`
将`linter.worker`文件引入并入`npm run dev`中，可同时编译、热更新
不再需要`npm run dev:linter`了