### PR TITLE
添加GM_openInTab新可选功能

### DIFF
--- a/src/types/scriptcat.d.ts
+++ b/src/types/scriptcat.d.ts
@@ -327,6 +327,7 @@ declare namespace GMTypes {
     active?: boolean;
     insert?: boolean;
     setParent?: boolean;
+    useOpen?: boolean;
   }
 
   interface XHRResponse {

--- a/src/types/scriptcat.d.ts
+++ b/src/types/scriptcat.d.ts
@@ -327,7 +327,7 @@ declare namespace GMTypes {
     active?: boolean;
     insert?: boolean;
     setParent?: boolean;
-    useOpen?: boolean;
+    useOpen?: boolean; // 这是一个实验性/不兼容其他管理器/不兼容Firefox的功能 
   }
 
   interface XHRResponse {


### PR DESCRIPTION
### 改动内容
在background页面使用`window.open`代替`chrome.tabs.create`打开目标`url`
兼容`onclose`

### 使用方法
参数中主动加入`useOpen: true`以启用

### 功能意义
`chrome.tabs.create`在`http`页面表现情况与`https`不同。
这一可选功能能够绕开`http`页面限制，让用户在`extension`插件页面中将`url`打开

### 附注
这是一个实验/不兼容其他管理器的功能
**未测试火狐兼容性**

### 部分应用
上图为`GM_openInTab(url)`，`http`页面运行脚本打开协议`url`每次强制弹出确认框
下图为`GM_openInTab(url,{useOpen:true})`，在`http`页面运行脚本打开协议`url`只会弹出第一次确认框，勾选后后续不会再弹出
![726~1XL{H74O6SJ)7GZI4S7](https://user-images.githubusercontent.com/34838824/234523257-f9ff96ea-136d-47b7-9ea7-d8bac3913ed1.png)
![FOBEQP5)PO$L862VZ$GLEB3](https://user-images.githubusercontent.com/34838824/234523318-15cf5eff-9290-4449-8519-88b5c3b2087f.png)

