### PR TITLE
优化dev环境插件名及logo

### DIFF
--- a/build/pack.js
+++ b/build/pack.js
@@ -39,18 +39,20 @@ let configSystem = fs.readFileSync("./src/app/const.ts").toString();
 // 如果是由github action的分支触发的构建,在版本中再加上commit id
 if (process.env.GITHUB_REF_TYPE === "branch") {
   package.version += `+${process.env.GITHUB_SHA.substring(0, 7)}`;
+  configSystem = configSystem
+    .replace("ExtVersion = version;", `ExtVersion = "${package.version}";`)
+    .replace(`import { version } from "../../package.json";`, "");
+  fs.writeFileSync("./src/app/const.ts", configSystem);
 }
-configSystem = configSystem.replace(
-  /ExtVersion = "(.*?)";/,
-  `ExtVersion = "${package.version}";`
-);
-fs.writeFileSync("./src/app/const.ts", configSystem);
 
 execSync("npm run build", { stdio: "inherit" });
 
 if (version.prerelease.length) {
-  // 替换蓝猫logo
+  // beta时红猫logo
   fs.copyFileSync("./build/assets/logo-beta.png", "./dist/ext/assets/logo.png");
+} else {
+  // 非beta时蓝猫logo
+  fs.copyFileSync("./build/assets/logo.png", "./dist/ext/assets/logo.png");
 }
 
 // 处理firefox和chrome的zip压缩包

--- a/src/app/const.ts
+++ b/src/app/const.ts
@@ -1,4 +1,6 @@
-export const ExtVersion = "0.13.1";
+import { version } from "../../package.json";
+
+export const ExtVersion = version;
 
 export const ExtServer = "https://ext.scriptcat.org/";
 

--- a/src/types/main.d.ts
+++ b/src/types/main.d.ts
@@ -8,6 +8,7 @@ declare let cloneInto: ((detail: any, view: any) => any) | undefined;
 
 declare module "@App/types/scriptcat.d.ts";
 declare module "*.tpl";
+declare module "*.json";
 
 declare namespace GMSend {
   interface XHRDetails {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -11,6 +11,7 @@ import { presetAttributify, presetUno } from "unocss";
 const UnoCSS = require("@unocss/webpack").default;
 const ProgressBarPlugin = require("progress-bar-webpack-plugin");
 const MonacoLocalesPlugin = require("monaco-editor-locales-plugin");
+const { version } = require("./package.json");
 
 const src = `${__dirname}/src`;
 const dist = `${__dirname}/dist`;
@@ -109,9 +110,19 @@ const config: Configuration = {
     }),
     new CopyPlugin({
       patterns: [
-        { from: `${src}/manifest.json`, to: `${dist}/ext` },
+        {
+          from: `${src}/manifest.json`,
+          to: `${dist}/ext`,
+          // 将manifest.json内版本号替换为package.json中版本号
+          transform(content) {
+            return content
+              .toString()
+              .replace(/"version": "(.*?)"/, `"version": "${version}"`)
+              .replace(`"name": "ScriptCat"`, `"name": "ScriptCat - Dev"`);
+          },
+        },
         { from: `${assets}/_locales`, to: `${dist}/ext/_locales` },
-        { from: `${assets}/logo.png`, to: `${dist}/ext/assets` },
+        { from: `${assets}/logo-beta.png`, to: `${dist}/ext/assets/logo.png` },
         { from: `${assets}/logo`, to: `${dist}/ext/assets/logo` },
       ],
     }),


### PR DESCRIPTION
## 改动说明
优化dev环境，以区分生产环境
 - 使用红猫作为logo
 - 插件名增加Dev
 - dev版本号自动获取package.json版本号（同时更新pack环境方法 防止冲突）

## 效果预览
![}Q)H3(SRS( 1P~``MA5H~HA](https://github.com/scriptscat/scriptcat/assets/34838824/23824e1c-f154-4806-9bc2-36be01cf7388)
上图第一个为`npm run pack`，第二个为 `npm run dev`


![image](https://github.com/scriptscat/scriptcat/assets/34838824/30042bce-787c-4ccc-a1ad-8c9589b61886)
上图第一个为EDGE商店版本，第二个为`npm run pack`，第三个为 `npm run dev`