### PR TITLE
增加tools页面滚动条

### DIFF
--- a/src/pages/options/routes/Tools.tsx
+++ b/src/pages/options/routes/Tools.tsx
@@ -43,6 +43,9 @@ function Tools() {
       direction="vertical"
       style={{
         width: "100%",
+        height: "100%",
+        overflow: "auto",
+        position: "relative",
       }}
     >
       <Card title="备份" bordered={false}>


### PR DESCRIPTION
![image](https://github.com/scriptscat/scriptcat/assets/34838824/3c10a4d8-fc08-416f-b311-c56995478619)
高分辨率下tools页面缺失滚动条导致内容无法显示完整
经测试
1600x900@100%分辨率显示正常
2560x1440@175%分辨率如图所示无法显示完整，需要加入滚动条
