### PR TITLE
将UserConfig暴露至GM_info对象中

### DIFF
--- a/example/userconfig.js
+++ b/example/userconfig.js
@@ -71,18 +71,18 @@ group2:
 // 通过GM_info新方法获取UserConfig对象
 const rawUserConfig = GM_info.userConfig;
 // 定义一个对象暂存读取到的UserConfig值
-const userConfig={};
+const userConfig = {};
 // 解构遍历读取UserConfig并赋缺省值
-Object.entries(rawUserConfig).forEach(([mainKey,configs])=>{
-  Object.entries(configs).forEach(([subKey,{default:defaultValue}])=>{
-    userConfig[`${mainKey}.${subKey}`]=GM_getValue(`${mainKey}.${subKey}`,defaultValue)
+Object.entries(rawUserConfig).forEach(([mainKey, configs]) => {
+  Object.entries(configs).forEach(([subKey, { default: defaultValue }]) => {
+    userConfig[`${mainKey}.${subKey}`] = GM_getValue(`${mainKey}.${subKey}`, defaultValue)
   })
 })
 
 setInterval(() => {
   // 传统方法读取UserConfig，每个缺省值需要单独静态声明，修改UserConfig缺省值后代码也需要手动修改
-  console.log(GM_getValue("group1.configA","默认值"));
-  console.log(GM_getValue("group1.configG",11));
+  console.log(GM_getValue("group1.configA", "默认值"));
+  console.log(GM_getValue("group1.configG", 11));
   // GM_info新方法读取UserConfig，可直接关联读取缺省值，无需额外修改
   console.log(userConfig["group1.configA"]);
   console.log(userConfig["group1.configG"]);

--- a/example/userconfig.js
+++ b/example/userconfig.js
@@ -68,8 +68,25 @@ group2:
     default: 默认值
  ==/UserConfig== */
 
+// 通过GM_info新方法获取UserConfig对象
+const rawUserConfig = GM_info.userConfig;
+// 定义一个对象暂存读取到的UserConfig值
+const userConfig={};
+// 解构遍历读取UserConfig并赋缺省值
+Object.entries(rawUserConfig).forEach(([mainKey,configs])=>{
+  Object.entries(configs).forEach(([subKey,{default:defaultValue}])=>{
+    userConfig[`${mainKey}.${subKey}`]=GM_getValue(`${mainKey}.${subKey}`,defaultValue)
+  })
+})
+
 setInterval(() => {
-  console.log(GM_getValue("group1.configA"));
+  // 传统方法读取UserConfig，每个缺省值需要单独静态声明，修改UserConfig缺省值后代码也需要手动修改
+  console.log(GM_getValue("group1.configA","默认值"));
+  console.log(GM_getValue("group1.configG",11));
+  // GM_info新方法读取UserConfig，可直接关联读取缺省值，无需额外修改
+  console.log(userConfig["group1.configA"]);
+  console.log(userConfig["group1.configG"]);
 }, 5000)
 
+// 打开用户配置
 CAT_userConfig();

--- a/src/pkg/utils/script.ts
+++ b/src/pkg/utils/script.ts
@@ -28,7 +28,16 @@ export function getMetadataStr(code: string): string | null {
   if (start === -1 || end === -1) {
     return null;
   }
-  return `// ${code.substring(start, end + 14)}`;
+  return `// ${code.substring(start, end + 15)}`;
+}
+
+export function getUserConfigStr(code: string): string | null {
+  const start = code.indexOf("==UserConfig==");
+  const end = code.indexOf("==/UserConfig==");
+  if (start === -1 || end === -1) {
+    return null;
+  }
+  return `/* ${code.substring(start, end + 15)} */`;
 }
 
 export function parseMetadata(code: string): Metadata | null {

--- a/src/runtime/content/gm_api.ts
+++ b/src/runtime/content/gm_api.ts
@@ -10,6 +10,8 @@ import {
   base64ToBlob,
   blobToBase64,
   getMetadataStr,
+  getUserConfigStr,
+  parseUserConfig,
 } from "@App/pkg/utils/script";
 import { v4 as uuidv4 } from "uuid";
 import { ValueUpdateData } from "./exec_script";
@@ -124,6 +126,7 @@ export default class GMApi {
   // 获取脚本信息和管理器信息
   static GM_info(script: ScriptRunResouce) {
     const metadataStr = getMetadataStr(script.sourceCode);
+    const userConfigStr = getUserConfigStr(script.sourceCode) || "";
     const options = {
       description:
         (script.metadata.description && script.metadata.description[0]) || null,
@@ -145,6 +148,8 @@ export default class GMApi {
       scriptHandler: "ScriptCat",
       scriptUpdateURL: script.downloadUrl,
       scriptMetaStr: metadataStr,
+      userConfig: parseUserConfig(userConfigStr),
+      userConfigStr,
       // scriptSource: script.sourceCode,
       version: ExtVersion,
       script: {

--- a/src/types/scriptcat.d.ts
+++ b/src/types/scriptcat.d.ts
@@ -1,5 +1,7 @@
 // @copyright https://github.com/silverwzw/Tampermonkey-Typescript-Declaration
 
+import { UserConfig } from "@App/app/repo/scripts";
+
 declare const unsafeWindow: Window;
 
 declare const GM_info: {
@@ -7,28 +9,32 @@ declare const GM_info: {
   scriptWillUpdate: boolean;
   scriptHandler: "ScriptCat";
   scriptUpdateURL?: string;
-  scriptSource: string;
+  // scriptSource: string;
   scriptMetaStr?: string;
-  isIncognito: boolean;
-  downloadMode: "native" | "disabled" | "browser";
+  userConfig?: UserConfig | undefined,
+  userConfigStr?: string,
+  // isIncognito: boolean;
+  // downloadMode: "native" | "disabled" | "browser";
   script: {
     author?: string;
     description?: string;
-    excludes: string[];
-    homepage?: string;
+    // excludes: string[];
+    grant: string[];
+    header: string;
+    // homepage?: string;
     icon?: string;
     icon64?: string;
     includes?: string[];
-    lastModified: number;
+    // lastModified: number;
     matches: string[];
     name: string;
     namespace?: string;
-    position: number;
+    // position: number;
     "run-at": string;
-    resources: string[];
-    unwrap: boolean;
+    // resources: string[];
+    // unwrap: boolean;
     version: string;
-    options: {
+    /* options: {
       awareOfChrome: boolean;
       run_at: string;
       noframes?: boolean;
@@ -45,7 +51,7 @@ declare const GM_info: {
         [key: string]: any;
       };
       [key: string]: any;
-    };
+    }; */
     [key: string]: any;
   };
   [key: string]: any;

--- a/src/types/scriptcat.d.ts
+++ b/src/types/scriptcat.d.ts
@@ -1,8 +1,32 @@
 // @copyright https://github.com/silverwzw/Tampermonkey-Typescript-Declaration
 
-import { UserConfig } from "@App/app/repo/scripts";
-
 declare const unsafeWindow: Window;
+
+declare type ConfigType =
+  | "text"
+  | "checkbox"
+  | "select"
+  | "mult-select"
+  | "number"
+  | "textarea"
+  | "time";
+
+declare interface Config {
+  [key: string]: any;
+  title: string;
+  description: string;
+  default?: any;
+  type?: ConfigType;
+  bind?: string;
+  values?: any[];
+  password?: boolean;
+  // 文本类型时是字符串长度,数字类型时是最大值
+  max?: number;
+  min?: number;
+  rows?: number; // textarea行数
+}
+
+declare type UserConfig = { [key: string]: { [key: string]: Config } };
 
 declare const GM_info: {
   version: string;
@@ -11,7 +35,7 @@ declare const GM_info: {
   scriptUpdateURL?: string;
   // scriptSource: string;
   scriptMetaStr?: string;
-  userConfig?: UserConfig | undefined,
+  userConfig?: UserConfig,
   userConfigStr?: string,
   // isIncognito: boolean;
   // downloadMode: "native" | "disabled" | "browser";


### PR DESCRIPTION
 - 增加getUserConfigStr方法截取UserConfig文本
 - 修复getMetadataStr截取少1个字符BUG
 - 将userConfig对象及文本暴露至GM_info对象中
 - 补齐scriptcat.d.ts中GM_info缺失属性
 - 注释scriptcat.d.ts中GM_info实际不存在的属性
 - 根据新方法完善userconfig.js示例