### PR TITLE
:lipstick: 调整Badge颜色

### DIFF
--- a/src/runtime/background/runtime.ts
+++ b/src/runtime/background/runtime.ts
@@ -500,7 +500,7 @@ export default class Runtime extends Manager {
             }
           );
           chrome.browserAction.setBadgeBackgroundColor({
-            color: "#4594d5",
+            color: "#165DFF",
             tabId: sender.tabId,
           });
         });

--- a/src/runtime/background/runtime.ts
+++ b/src/runtime/background/runtime.ts
@@ -500,7 +500,7 @@ export default class Runtime extends Manager {
             }
           );
           chrome.browserAction.setBadgeBackgroundColor({
-            color: "#165DFF",
+            color: "#4e5969",
             tabId: sender.tabId,
           });
         });


### PR DESCRIPTION
一直觉得Badge显示的数量与背景色对比度太低，比较难以看清，chrome.browserAction只能调整背景色，所以选了一个对比度高一些的蓝色

<img width="132" alt="image" src="https://github.com/scriptscat/scriptcat/assets/33169019/36d11743-9cb4-46d1-8289-5f472e84734e">

<img width="75" alt="image" src="https://github.com/scriptscat/scriptcat/assets/33169019/b176ee28-b1c5-44bb-b1c8-2749b8a5dc12">



另外我个人感觉如果不考虑色系的情况下，灰色也是不错的



<img width="114" alt="image" src="https://github.com/scriptscat/scriptcat/assets/33169019/53a54557-e651-42cc-a158-8146ab70e4a2">

<img width="126" alt="image" src="https://github.com/scriptscat/scriptcat/assets/33169019/5c17667f-3fb0-42e4-9b8c-322acbbfe3c7">



