### PR TITLE
实现 window.close / window.focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scriptcat",
-  "version": "0.17.0-alpha.4",
+  "version": "0.17.0-alpha.5",
   "description": "脚本猫,一个可以执行用户脚本的浏览器扩展,万物皆可脚本化,让你的浏览器可以做更多的事情!",
   "author": "CodFrm",
   "license": "GPLv3",

--- a/src/app/service/content/gm_api.ts
+++ b/src/app/service/content/gm_api.ts
@@ -24,11 +24,14 @@ export class GMContext {
   public static API(param: ApiParam = {}) {
     return (target: any, propertyName: string, descriptor: PropertyDescriptor) => {
       const key = propertyName;
-      if (key === "GMDotGetResourceUrl") {
-        GMContext.apis.set("GM.getResourceUrl", {
-          api: descriptor.value,
-          param,
-        });
+      if (/^(GM|window)Dot/.test(key)) {
+        GMContext.apis.set(
+          key.replace(/^(GM|window)Dot(.)/, (_, a, b) => `${a}.${b.toLowerCase()}`),
+          {
+            api: descriptor.value,
+            param,
+          }
+        );
         return;
       }
       GMContext.apis.set(key, {
@@ -822,5 +825,15 @@ export default class GMApi {
       return Promise.resolve(r.base64);
     }
     return Promise.resolve(undefined);
+  }
+
+  @GMContext.API()
+  windowDotClose() {
+    return this.sendMessage("windowDotClose", []);
+  }
+
+  @GMContext.API()
+  windowDotFocus() {
+    return this.sendMessage("windowDotFocus", []);
   }
 }

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -70,6 +70,7 @@ export function createContext(scriptRes: ScriptRunResouce, GMInfo: any, envPrefi
     EE: new EventEmitter(),
     GM: { Info: GMInfo },
     GM_info: GMInfo,
+    window: {},
   };
   if (scriptRes.metadata.grant) {
     scriptRes.metadata.grant.forEach((val) => {
@@ -77,9 +78,9 @@ export function createContext(scriptRes: ScriptRunResouce, GMInfo: any, envPrefi
       if (!api) {
         return;
       }
-      if (val.startsWith("GM.")) {
-        const [, t] = val.split(".");
-        (<{ [key: string]: any }>context.GM)[t] = api.api.bind(context);
+      if (/^(GM|window)\./.test(val)) {
+        const [n, t] = val.split(".");
+        (<{ [key: string]: any }>context[n])[t] = api.api.bind(context);
       } else if (val === "GM_cookie") {
         // 特殊处理GM_cookie.list之类
         context[val] = api.api.bind(context);
@@ -200,6 +201,11 @@ export function proxyContext(global: any, context: any, thisContext?: { [key: st
             return special.global || proxy;
           }
           return global.top;
+        case "close":
+        case "focus":
+          if (context["window"][name]) {
+            return context["window"][name];
+          }
         default:
           break;
       }

--- a/src/app/service/service_worker/gm_api.ts
+++ b/src/app/service/service_worker/gm_api.ts
@@ -890,6 +890,24 @@ export default class GMApi {
     await sendMessage(this.send, "offscreen/gmApi/setClipboard", { data, type });
   }
 
+  @PermissionVerify.API({ alias: ["window.close"] })
+  async windowDotClose(request: Request, sender: GetSender) {
+    /*
+     * Note: for security reasons it is not allowed to close the last tab of a window.
+     * https://www.tampermonkey.net/documentation.php#api:window.close
+     * 暂不清楚安全原因具体指什么
+     * 原生window.close也可能关闭最后一个标签，暂不做限制
+     */
+    await chrome.tabs.remove(sender.getSender().tab?.id as number);
+  }
+
+  @PermissionVerify.API({ alias: ["window.focus"] })
+  async windowDotFocus(request: Request, sender: GetSender) {
+    await chrome.tabs.update(sender.getSender().tab?.id as number, {
+      active: true,
+    });
+  }
+
   handlerNotification() {
     const send = async (event: string, notificationId: string, params?: any) => {
       const ret = (await Cache.getInstance().get(`GM_notification:${notificationId}`)) as NotificationData;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_scriptcat__",
-  "version": "0.17.0.1005",
+  "version": "0.17.0.1006",
   "author": "CodFrm",
   "description": "__MSG_scriptcat_description__",
   "options_ui": {
@@ -10,9 +10,7 @@
   },
   "background": {
     "service_worker": "src/service_worker.js",
-    "scripts": [
-      "src/service_worker.js"
-    ]
+    "scripts": ["src/service_worker.js"]
   },
   "action": {
     "default_popup": "src/popup.html",
@@ -41,12 +39,8 @@
     "unlimitedStorage",
     "declarativeNetRequest"
   ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "host_permissions": ["<all_urls>"],
   "sandbox": {
-    "pages": [
-      "src/sandbox.html"
-    ]
+    "pages": ["src/sandbox.html"]
   }
 }


### PR DESCRIPTION
Close #264 

## 测试脚本
``` js
// ==UserScript==
// @name         Test @grant window
// @namespace    https://bbs.tampermonkey.net.cn/
// @version      0.1.0
// @description  try to take over the world!
// @author       You
// @match        https://bbs.tampermonkey.net.cn/*
// @grant        window.close
// @grant        window.focus
// @noframes
// ==/UserScript==

unsafeWindow.close = window.close;
unsafeWindow.focus = window.focus;
```
在控制台输入：
 - `window.focus()`可使标签从后台转为前台
 - `window.close()`可使标签强制关闭

兼容 `Tampermonkey` API

