### PR TITLE
实现 @run-in / 分离隐身模式

### DIFF
--- a/example/run-in/run-in_both.js
+++ b/example/run-in/run-in_both.js
@@ -1,0 +1,11 @@
+// ==UserScript==
+// @name         Test @run-in both
+// @namespace    https://bbs.tampermonkey.net.cn/
+// @version      0.1.0
+// @description  @run-in normal-tabs & @run-in incognito-tabs 既注入正常标签又注入隐身标签
+// @author       You
+// @match        https://bbs.tampermonkey.net.cn/*
+// @run-in       normal-tabs
+// @run-in       incognito-tabs
+// ==/UserScript==
+console.log(GM_info.script["run-in"]);

--- a/example/run-in/run-in_incognito-tabs.js
+++ b/example/run-in/run-in_incognito-tabs.js
@@ -1,0 +1,10 @@
+// ==UserScript==
+// @name         Test @run-in incognito-tabs
+// @namespace    https://bbs.tampermonkey.net.cn/
+// @version      0.1.0
+// @description  @run-in incognito-tabs 只注入隐身标签
+// @author       You
+// @match        https://bbs.tampermonkey.net.cn/*
+// @run-in       incognito-tabs
+// ==/UserScript==
+console.log(GM_info.script["run-in"]);

--- a/example/run-in/run-in_none.js
+++ b/example/run-in/run-in_none.js
@@ -1,0 +1,9 @@
+// ==UserScript==
+// @name         Test @run-in none
+// @namespace    https://bbs.tampermonkey.net.cn/
+// @version      0.1.0
+// @description  不设置@run-in默认既注入正常标签又注入隐身标签
+// @author       You
+// @match        https://bbs.tampermonkey.net.cn/*
+// ==/UserScript==
+console.log(GM_info.script["run-in"]);

--- a/example/run-in/run-in_normal-tabs.js
+++ b/example/run-in/run-in_normal-tabs.js
@@ -1,0 +1,10 @@
+// ==UserScript==
+// @name         Test @run-in normal-tabs
+// @namespace    https://bbs.tampermonkey.net.cn/
+// @version      0.1.0
+// @description  @run-in normal-tabs 只注入正常标签
+// @author       You
+// @match        https://bbs.tampermonkey.net.cn/*
+// @run-in       normal-tabs
+// ==/UserScript==
+console.log(GM_info.script["run-in"]);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "coverage": "vitest run --coverage",
     "build": "cross-env NODE_ENV=production rspack build",
     "dev": "cross-env NODE_ENV=development rspack",
+    "dev-noMap": "cross-env NODE_ENV=development NO_MAP=true rspack",
     "pack": "node ./scripts/pack.js",
     "format": "prettier --write .",
     "lint": "eslint .",

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     ? {
         watch: true,
         mode: "development",
-        devtool: "inline-source-map",
+        devtool: process.env.NO_MAP === "true" ? false : "inline-source-map",
       }
     : {
         mode: "production",

--- a/src/app/cache.ts
+++ b/src/app/cache.ts
@@ -4,6 +4,7 @@ export interface CacheStorage {
   batchSet(data: { [key: string]: any }): Promise<void>;
   has(key: string): Promise<boolean>;
   del(key: string): Promise<void>;
+  clear(): Promise<void>;
   list(): Promise<string[]>;
 }
 
@@ -53,6 +54,14 @@ export class ExtCache implements CacheStorage {
     });
   }
 
+  clear(): Promise<void> {
+    return new Promise((resolve) => {
+      chrome.storage.session.clear(() => {
+        resolve();
+      });
+    });
+  }
+
   list(): Promise<string[]> {
     return new Promise((resolve) => {
       chrome.storage.session.get(null, (value) => {
@@ -87,6 +96,13 @@ export class MapCache {
   del(key: string): Promise<void> {
     return new Promise((resolve) => {
       this.map.delete(key);
+      resolve();
+    });
+  }
+
+  clear(): Promise<void> {
+    return new Promise((resolve) => {
+      this.map.clear();
       resolve();
     });
   }
@@ -142,6 +158,10 @@ export default class Cache {
 
   public del(key: string): Promise<void> {
     return this.storage.del(key);
+  }
+
+  public clear(): Promise<void> {
+    return this.storage.clear();
   }
 
   public list(): Promise<string[]> {

--- a/src/app/service/content/gm_api.ts
+++ b/src/app/service/content/gm_api.ts
@@ -113,12 +113,13 @@ export default class GMApi {
     const metadataStr = getMetadataStr(script.code);
     const userConfigStr = getUserConfigStr(script.code) || "";
     const options = {
-      description: (script.metadata.description && script.metadata.description[0]) || null,
+      description: script.metadata.description?.[0] || null,
       matches: script.metadata.match || [],
       includes: script.metadata.include || [],
-      "run-at": (script.metadata["run-at"] && script.metadata["run-at"][0]) || "document-idle",
-      icon: (script.metadata.icon && script.metadata.icon[0]) || null,
-      icon64: (script.metadata.icon64 && script.metadata.icon64[0]) || null,
+      "run-at": script.metadata["run-at"]?.[0] || "document-idle",
+      "run-in": script.metadata["run-in"] || [],
+      icon: script.metadata.icon?.[0] || null,
+      icon64: script.metadata.icon64?.[0] || null,
       header: metadataStr,
       grant: script.metadata.grant || [],
       connects: script.metadata.connect || [],
@@ -139,7 +140,7 @@ export default class GMApi {
         // TODO: 更多完整的信息(为了兼容Tampermonkey,后续待定)
         name: script.name,
         namespace: script.namespace,
-        version: script.metadata.version && script.metadata.version[0],
+        version: script.metadata.version?.[0],
         author: script.author,
         ...options,
       },

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -70,7 +70,7 @@ export class RuntimeService {
     // 注：隐身模式初始化时可读取正常模式的chrome.storage.session
     if (chrome.extension.inIncognitoContext) {
       // 判断是否隐身模式第一次初始化
-      const incognitoInited = Cache.getInstance().get("incognitoInited");
+      const incognitoInited = await Cache.getInstance().get("incognitoInited");
       if (!incognitoInited) {
         Cache.getInstance().clear();
         Cache.getInstance().set("incognitoInited", true);

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -182,8 +182,7 @@ export class RuntimeService {
       const registerScripts = await list.reduce(
         async (arr, script) => {
           const result = await arr;
-          // 非普通脚本、未开启则不注册
-          if (script.type !== SCRIPT_TYPE_NORMAL || script.status !== SCRIPT_STATUS_ENABLE) {
+          if (script.type !== SCRIPT_TYPE_NORMAL) {
             return result;
           }
 
@@ -192,6 +191,10 @@ export class RuntimeService {
             return result;
           }
           const { registerScript } = res!;
+          // 如果没开启, 则不注册
+          if (script.status !== SCRIPT_STATUS_ENABLE) {
+            return result;
+          }
 
           // 过滤掉matches为空的脚本
           if (!registerScript.matches || registerScript.matches.length === 0) {

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -68,7 +68,15 @@ export class RuntimeService {
   async init() {
     // 清除缓存防止初始化失败
     // 注：隐身模式初始化时可读取正常模式的chrome.storage.session
-    Cache.getInstance().clear();
+    if (chrome.extension.inIncognitoContext) {
+      // 判断是否隐身模式第一次初始化
+      const incognitoInited = Cache.getInstance().get("incognitoInited");
+      if (!incognitoInited) {
+        Cache.getInstance().clear();
+        Cache.getInstance().set("incognitoInited", true);
+      }
+    }
+
     // 启动gm api
     const permission = new PermissionVerify(this.group.group("permission"), this.mq);
     const gmApi = new GMApi(this.systemConfig, permission, this.group, this.sender, this.mq, this.value, this);

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -66,17 +66,6 @@ export class RuntimeService {
   }
 
   async init() {
-    // 清除缓存防止初始化失败
-    // 注：隐身模式初始化时可读取正常模式的chrome.storage.session
-    if (chrome.extension.inIncognitoContext) {
-      // 判断是否隐身模式第一次初始化
-      const incognitoInited = await Cache.getInstance().get("incognitoInited");
-      if (!incognitoInited) {
-        Cache.getInstance().clear();
-        Cache.getInstance().set("incognitoInited", true);
-      }
-    }
-
     // 启动gm api
     const permission = new PermissionVerify(this.group.group("permission"), this.mq);
     const gmApi = new GMApi(this.systemConfig, permission, this.group, this.sender, this.mq, this.value, this);
@@ -196,15 +185,6 @@ export class RuntimeService {
           // 非普通脚本、未开启则不注册
           if (script.type !== SCRIPT_TYPE_NORMAL || script.status !== SCRIPT_STATUS_ENABLE) {
             return result;
-          }
-
-          // 判断注入标签类型
-          if (script.metadata["run-in"]) {
-            // 判断插件运行环境
-            const contextType = chrome.extension.inIncognitoContext ? "incognito-tabs" : "normal-tabs";
-            if (!script.metadata["run-in"].includes(contextType)) {
-              return result;
-            }
           }
 
           const res = await this.getUserScriptRegister(script);

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -558,7 +558,7 @@ export class RuntimeService {
       id: scriptRes.uuid,
       js: [{ code: scriptRes.code }],
       matches: patternMatches.patternResult,
-      allFrames: !!scriptRes.metadata["noframes"],
+      allFrames: !scriptRes.metadata["noframes"],
       world: "MAIN",
     };
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,9 +9,9 @@
     "open_in_tab": true
   },
   "background": {
-    "service_worker": "src/service_worker.js",
-    "scripts": ["src/service_worker.js"]
+    "service_worker": "src/service_worker.js"
   },
+  "incognito": "split",
   "action": {
     "default_popup": "src/popup.html",
     "default_icon": {

--- a/src/pages/components/layout/SiderGuide.tsx
+++ b/src/pages/components/layout/SiderGuide.tsx
@@ -19,7 +19,7 @@ const SiderGuide: React.ForwardRefRenderFunction<{ open: () => void }, object> =
     if (localStorage.getItem("firstUse") === null) {
       localStorage.setItem("firstUse", "false");
       // 隐身模式不打开引导
-      if (chrome.extension.inIncognitoContext) {
+      if (!chrome.extension.inIncognitoContext) {
         setRun(true);
       }
     }

--- a/src/pages/components/layout/SiderGuide.tsx
+++ b/src/pages/components/layout/SiderGuide.tsx
@@ -4,10 +4,7 @@ import Joyride, { Step } from "react-joyride";
 import { Path, useLocation, useNavigate } from "react-router-dom";
 import CustomTrans from "../CustomTrans";
 
-const SiderGuide: React.ForwardRefRenderFunction<{ open: () => void }, object> = (
-  _props,
-  ref
-) => {
+const SiderGuide: React.ForwardRefRenderFunction<{ open: () => void }, object> = (_props, ref) => {
   const { t } = useTranslation();
   const [stepIndex, setStepIndex] = useState(0);
   const [initRoute, setInitRoute] = useState<Partial<Path>>({ pathname: "/" });
@@ -21,7 +18,10 @@ const SiderGuide: React.ForwardRefRenderFunction<{ open: () => void }, object> =
     // 首次使用时，打开引导
     if (localStorage.getItem("firstUse") === null) {
       localStorage.setItem("firstUse", "false");
-      setRun(true);
+      // 隐身模式不打开引导
+      if (chrome.extension.inIncognitoContext) {
+        setRun(true);
+      }
     }
   }, []);
 
@@ -98,11 +98,7 @@ const SiderGuide: React.ForwardRefRenderFunction<{ open: () => void }, object> =
   return (
     <Joyride
       callback={(data) => {
-        if (
-          data.action === "stop" ||
-          data.action === "close" ||
-          data.status === "finished"
-        ) {
+        if (data.action === "stop" || data.action === "close" || data.status === "finished") {
           setRun(false);
           setStepIndex(0);
           gotoNavigate(initRoute);

--- a/src/template/scriptcat.d.tpl
+++ b/src/template/scriptcat.d.tpl
@@ -48,6 +48,7 @@ declare const GM_info: {
     namespace?: string;
     // position: number;
     "run-at": string;
+    "run-in": string[];
     // resources: string[];
     // unwrap: boolean;
     version: string;

--- a/src/types/scriptcat.d.ts
+++ b/src/types/scriptcat.d.ts
@@ -48,6 +48,7 @@ declare const GM_info: {
     namespace?: string;
     // position: number;
     "run-at": string;
+    "run-in": string[];
     // resources: string[];
     // unwrap: boolean;
     version: string;
@@ -362,7 +363,7 @@ declare namespace GMTypes {
     user?: string;
     password?: string;
     nocache?: boolean;
-    redirect?: "follow" | "error" | "manual";// 为了与tm保持一致, 在v0.17.0后废弃maxRedirects, 使用redirect替代, 会强制使用fetch模式
+    redirect?: "follow" | "error" | "manual"; // 为了与tm保持一致, 在v0.17.0后废弃maxRedirects, 使用redirect替代, 会强制使用fetch模式
 
     onload?: Listener<XHRResponse>;
     onloadstart?: Listener<XHRResponse>;


### PR DESCRIPTION
## `@run-in` api
用于显式声明脚本注入标签类型
 - `normal-tabs` 注入正常标签
 - `incognito-tabs` 注入隐身标签  

缺省时、同时声明时，既注入正常标签又隐身标签
具体用法见新增示例
### TODO
- [ ]  兼容Firefox 特有的`@run-in`特性
<https://www.tampermonkey.net/documentation.php?ext=iikm&version=5.3.3#meta:run_in>

## 同步更新`GM_info`

## 新增 `CacheStorage.prototype.clear` 方法 清除所有缓存

## `manifest.json`显示声明`"incognito": "split"`分离浏览器隐身模式时扩展进程及上下文
注：目前隐身模式的`chrome.storage`操作会影响正常模式
### TODO
- [ ]  新增设置，用于用户选择，是否隔离隐身模式扩展存储

## `package.json`新增`dev-noMap`方法
 - 无`SourceMap`的`development`模式 
 （已知带`SourceMap`的`dev`模式会造成扩展的`service_work.js`无法完成注册，可能是浏览器限制或bug）