### PR TITLE
实现 GM_registerMenuCommand 支持快捷输入交互

### DIFF
--- a/example/gm_bg_menu.js
+++ b/example/gm_bg_menu.js
@@ -5,14 +5,66 @@
 // @description  在后台脚本中使用菜单
 // @author       You
 // @background
-// @grant GM_registerMenuCommand
-// @grant GM_unregisterMenuCommand
+// @grant        GM_registerMenuCommand
+// @grant        GM_unregisterMenuCommand
+// @grant        GM_notification
 // ==/UserScript==
 
 return new Promise((resolve) => {
-  const id = GM_registerMenuCommand("测试菜单", () => {
-    console.log(id);
-    GM_unregisterMenuCommand(id);
-    resolve();
-  }, "z");
+  const id = GM_registerMenuCommand(
+    "测试菜单",
+    () => {
+      console.log(id);
+      GM_unregisterMenuCommand(id);
+    },
+    "z"
+  );
+
+  GM_registerMenuCommand(
+    "测试菜单boolean",
+    (inputValue) => {
+      GM_notification({
+        title: "测试菜单boolean",
+        text: "" + inputValue,
+      });
+    },
+    {
+      inputType: "boolean",
+      inputLabel: "是否通知",
+      inputDefaultValue: true,
+    }
+  );
+
+  GM_registerMenuCommand(
+    "测试菜单text",
+    (inputValue) => {
+      GM_notification({
+        title: "测试菜单text",
+        text: "" + inputValue,
+      });
+    },
+    {
+      inputType: "text",
+      inputLabel: "通知内容",
+    }
+  );
+
+  GM_registerMenuCommand(
+    "测试菜单number",
+    (inputValue) => {
+      setTimeout(() => {
+        GM_notification({
+          title: "测试菜单number",
+          text: "" + (1000 + inputValue),
+        });
+      }, 1000 + inputValue);
+    },
+    {
+      inputType: "number",
+      inputLabel: "延迟ms",
+      inputPlaceholder: "最低1000ms",
+    }
+  );
+
+  resolve();
 });

--- a/src/app/service/content/gm_api.ts
+++ b/src/app/service/content/gm_api.ts
@@ -10,6 +10,7 @@ import EventEmitter from "eventemitter3";
 import { getStorageName } from "@App/pkg/utils/utils";
 import { MessageRequest } from "../service_worker/gm_api";
 import { ScriptLoadInfo } from "../service_worker/runtime";
+import { ScriptMenuItem } from "../service_worker/popup";
 
 interface ApiParam {
   depend?: string[];
@@ -245,20 +246,26 @@ export default class GMApi {
   }
 
   @GMContext.API()
-  GM_registerMenuCommand(name: string, listener: () => void, accessKey?: string | { id?: number }): number {
+  GM_registerMenuCommand(
+    name: string,
+    listener: () => void,
+    options_or_accessKey?: ScriptMenuItem["options"] | string
+  ): number {
     if (!this.menuMap) {
       this.menuMap = new Map();
     }
-    if (typeof accessKey === "object") {
+    if (typeof options_or_accessKey === "object") {
+      const option: ScriptMenuItem["options"] = options_or_accessKey;
       // 如果是对象，并且有id属性,则直接使用id
-      if (accessKey.id && this.menuMap.has(accessKey.id)) {
+      if (option.id && this.menuMap.has(option.id)) {
         // 如果id存在,则直接使用
-        this.EE.removeAllListeners("menuClick:" + accessKey.id);
-        this.EE.addListener("menuClick:" + accessKey.id, listener);
-        this.sendMessage("GM_registerMenuCommand", [accessKey.id, name, accessKey]);
-        return accessKey.id;
+        this.EE.removeAllListeners("menuClick:" + option.id);
+        this.EE.addListener("menuClick:" + option.id, listener);
+        this.sendMessage("GM_registerMenuCommand", [option.id, name, option]);
+        return option.id;
       }
     } else {
+      options_or_accessKey = { accessKey: options_or_accessKey };
       let flag = 0;
       this.menuMap.forEach((val, menuId) => {
         if (val === name) {
@@ -271,9 +278,10 @@ export default class GMApi {
     }
     this.eventId += 1;
     const id = this.eventId;
+    options_or_accessKey.id = id;
     this.menuMap.set(id, name);
     this.EE.addListener("menuClick:" + id, listener);
-    this.sendMessage("GM_registerMenuCommand", [id, name, accessKey]);
+    this.sendMessage("GM_registerMenuCommand", [id, name, options_or_accessKey]);
     return id;
   }
 

--- a/src/app/service/service_worker/client.ts
+++ b/src/app/service/service_worker/client.ts
@@ -228,10 +228,11 @@ export class PopupClient extends Client {
     return this.do("getPopupData", data);
   }
 
-  menuClick(uuid: string, data: ScriptMenuItem) {
+  menuClick(uuid: string, data: ScriptMenuItem, inputValue?: any) {
     return this.do("menuClick", {
       uuid,
       id: data.id,
+      inputValue,
       sender: {
         tabId: data.tabId,
         frameId: data.frameId,

--- a/src/app/service/service_worker/gm_api.ts
+++ b/src/app/service/service_worker/gm_api.ts
@@ -647,13 +647,13 @@ export default class GMApi {
 
   @PermissionVerify.API()
   GM_registerMenuCommand(request: Request, sender: GetSender) {
-    const [id, name, accessKey] = request.params;
+    const [id, name, options] = request.params;
     // 触发菜单注册, 在popup中处理
     this.mq.emit("registerMenuCommand", {
       uuid: request.script.uuid,
-      id: id,
-      name: name,
-      options: typeof accessKey === "object" ? accessKey : { accessKey: accessKey },
+      id,
+      name,
+      options,
       tabId: sender.getSender().tab?.id || -1,
       frameId: sender.getSender().frameId,
       documentId: sender.getSender().documentId,

--- a/src/app/service/service_worker/popup.ts
+++ b/src/app/service/service_worker/popup.ts
@@ -25,7 +25,17 @@ import { getStorageName } from "@App/pkg/utils/utils";
 export type ScriptMenuItem = {
   id: number;
   name: string;
-  options?: { autoClose?: string; title?: string; accessKey?: string };
+  options?: {
+    id?: number;
+    autoClose?: string;
+    title?: string;
+    accessKey?: string;
+    // 可选输入框
+    inputType?: "text" | "number" | "boolean";
+    inputLabel?: string;
+    inputDefaultValue?: string | number | boolean;
+    inputPlaceholder?: string;
+  };
   tabId: number; //-1表示后台脚本
   frameId?: number;
   documentId?: string;
@@ -58,16 +68,18 @@ export class PopupService {
   genScriptMenuByTabMap(menu: ScriptMenu[]) {
     let n = 0;
     menu.forEach((script) => {
+      // 如果是带输入框的菜单则不在页面内注册
+      const nonInputMenus = script.menus.filter((item) => !item.options?.inputType);
       // 创建脚本菜单
-      if (script.menus.length) {
-        n += script.menus.length;
+      if (nonInputMenus.length) {
+        n += nonInputMenus.length;
         chrome.contextMenus.create({
           id: `scriptMenu_` + script.uuid,
           title: script.name,
           contexts: ["all"],
           parentId: "scriptMenu",
         });
-        script.menus.forEach((menu) => {
+        nonInputMenus.forEach((menu) => {
           // 创建菜单
           chrome.contextMenus.create({
             id: `scriptMenu_menu_${script.uuid}_${menu.id}`,
@@ -320,12 +332,23 @@ export class PopupService {
     });
   }
 
-  menuClick({ uuid, id, sender }: { uuid: string; id: number; sender: ExtMessageSender }) {
+  menuClick({
+    uuid,
+    id,
+    sender,
+    inputValue,
+  }: {
+    uuid: string;
+    id: number;
+    sender: ExtMessageSender;
+    inputValue?: any;
+  }) {
     // 菜单点击事件
     this.runtime.emitEventToTab(sender, {
       uuid,
       event: "menuClick",
       eventId: id.toString(),
+      data: inputValue,
     });
     return Promise.resolve(true);
   }


### PR DESCRIPTION
## 改动
 - 实现 用户可通过 `GM_registerMenuCommand` 方法在 `popup 页面`与脚本快捷输入交互
   - 支持 `"text" | "number" | "boolean"` 三种交互方式
   - 新增4个脚本猫独有的`GM_registerMenuCommand.options`可选字段 `inputType` `inputLabel` `inputDefaultValue` `inputPlaceholder` 用于控制 `popup` 交互界面
 - 修复 `autoClose` 字段不生效的bug
 
## 预览
![image](https://github.com/user-attachments/assets/b8960951-7a88-4c73-bec5-fc3721f58e3a)

## 测试脚本
`example\gm_bg_menu.js`

## TODO
- [ ] 支持更多输入方式 如`selcet` `radio` `checkbox`等
- [ ] 样式优化