### PR TITLE
优化 GM_download 实现方式

### DIFF
--- a/src/app/service/content/gm_api.ts
+++ b/src/app/service/content/gm_api.ts
@@ -684,6 +684,7 @@ export default class GMApi {
     this.connect("GM_download", [
       {
         method: details.method,
+        downloadMethod: details.downloadMethod || "xhr", // 默认使用xhr下载
         url: details.url,
         name: details.name,
         headers: details.headers,

--- a/src/app/service/service_worker/gm_api.ts
+++ b/src/app/service/service_worker/gm_api.ts
@@ -971,8 +971,9 @@ export default class GMApi {
   @PermissionVerify.API()
   async GM_download(request: Request, sender: GetSender) {
     const params = <GMTypes.DownloadDetails>request.params[0];
-    // blob本地文件直接下载
-    if (params.url.startsWith("blob:")) {
+    // blob本地文件或基础下载选项直接下载
+    const baseKeys = new Set(["url", "name", "saveAs", "onload"]);
+    if (params.url.startsWith("blob:") || Object.keys(params).every((key) => baseKeys.has(key))) {
       chrome.downloads.download(
         {
           url: params.url,

--- a/src/app/service/service_worker/gm_api.ts
+++ b/src/app/service/service_worker/gm_api.ts
@@ -971,9 +971,8 @@ export default class GMApi {
   @PermissionVerify.API()
   async GM_download(request: Request, sender: GetSender) {
     const params = <GMTypes.DownloadDetails>request.params[0];
-    // blob本地文件或基础下载选项直接下载
-    const baseKeys = new Set(["url", "name", "saveAs", "onload"]);
-    if (params.url.startsWith("blob:") || Object.keys(params).every((key) => baseKeys.has(key))) {
+    // blob本地文件或显示指定downloadMethod为"chrome"则直接下载
+    if (params.url.startsWith("blob:") || params.downloadMethod === "chrome") {
       chrome.downloads.download(
         {
           url: params.url,

--- a/src/app/service/service_worker/gm_api.ts
+++ b/src/app/service/service_worker/gm_api.ts
@@ -981,7 +981,7 @@ export default class GMApi {
           filename: params.name,
         },
         () => {
-          sender.getConnect().sendMessage({ event: "onload" });
+          sender.getConnect().sendMessage({ action: "onload" });
         }
       );
       return;

--- a/src/template/scriptcat.d.tpl
+++ b/src/template/scriptcat.d.tpl
@@ -425,6 +425,7 @@ declare namespace GMTypes {
 
   interface DownloadDetails {
     method?: "GET" | "POST";
+    downloadMethod?: "xhr" | "chrome";
     url: string;
     name: string;
     headers?: { [key: string]: string };

--- a/src/types/scriptcat.d.ts
+++ b/src/types/scriptcat.d.ts
@@ -425,6 +425,7 @@ declare namespace GMTypes {
 
   interface DownloadDetails {
     method?: "GET" | "POST";
+    downloadMethod?: "xhr" | "chrome";
     url: string;
     name: string;
     headers?: { [key: string]: string };


### PR DESCRIPTION
目前的`GM_download`底层以`GM_xmlhttpRequest`实现，必须要将文件完全下载完毕后才能保存到本地，而非直接交由浏览器下载api，这对一些大文件下载很不友好
对于一些基础下载完全没必要依靠`GM_xmlhttpRequest`去实现，可以通过`chrome.downloads`交由浏览器api托管

新增参数`downloadMethod?: "xhr" | "chrome";`用于显式指定下载方式，如果`downloadMethod为"chrome"`则以`chrome.downloads`方式进行下载，缺省或其他则以`GM_xmlhttpRequest`实现，保持和之前相同

另外，修复`chrome.downloads`方式下`onload`不生效的bug