### PR TITLE
新增 脚本储存面板支持批量编辑

### DIFF
--- a/src/app/service/service_worker/value.ts
+++ b/src/app/service/service_worker/value.ts
@@ -163,6 +163,13 @@ export class ValueService {
             valueModel.data[key] = data.values[key];
           }
         }
+        // 处理oldValue有但是没有在data.values中的情况
+        Object.keys(oldValue).forEach((key) => {
+          if (!(key in data.values)) {
+            delete valueModel.data[key]; // 这里使用delete是因为保存不需要这个字段了
+            data.values[key] = undefined; // 而这里使用undefined是为了在推送时能够正确处理
+          }
+        });
         await this.valueDAO.save(storageName, valueModel);
       }
       return true;

--- a/src/pages/components/ScriptStorage/index.tsx
+++ b/src/pages/components/ScriptStorage/index.tsx
@@ -33,16 +33,10 @@ const ScriptStorage: React.FC<{
   const { t } = useTranslation();
 
   // 保存单个键值
-  const saveData = (key: string, value: any, del: boolean = false) => {
-    // GM_setValue最终全量存储，故更新单个键值也通过valueClient.setScriptValues处理
-    if (del) {
-      const newRawData = { ...rawData };
-      delete newRawData[key];
-      saveRawData(newRawData);
-    } else {
-      const newRawData = { ...rawData, [key]: value };
-      saveRawData(newRawData);
-    }
+  const saveData = (key: string, value: any) => {
+    valueClient.setScriptValue(script!.uuid, key, value);
+    const newRawData = { ...rawData, [key]: value };
+    updateRawData(newRawData);
   };
 
   // 保存所有键值
@@ -64,7 +58,7 @@ const ScriptStorage: React.FC<{
 
   // 删除单个键值
   const deleteData = (key: string) => {
-    saveData(key, undefined, true);
+    saveData(key, undefined);
     Message.info({
       content: t("delete_success"),
     });

--- a/src/pages/components/ScriptStorage/index.tsx
+++ b/src/pages/components/ScriptStorage/index.tsx
@@ -23,22 +23,62 @@ const ScriptStorage: React.FC<{
   onCancel: () => void;
 }> = ({ script, visible, onCancel, onOk }) => {
   const [data, setData] = useState<ValueModel[]>([]);
+  const [rawData, setRawData] = useState<{ [key: string]: any }>({});
   const inputRef = useRef<RefInputType>(null);
   const [currentValue, setCurrentValue] = useState<ValueModel>();
   const [visibleEdit, setVisibleEdit] = useState(false);
+  const [isEdit, setIsEdit] = useState(false);
+  const [editValue, setEditValue] = useState("");
   const [form] = Form.useForm();
   const { t } = useTranslation();
+
+  const saveData = (key: string, value: any, del: boolean = false) => {
+    // GM_setValue最终全量存储，故更新单个键值也通过valueClient.setScriptValues处理
+    if (del) {
+      const newRawData = { ...rawData };
+      delete newRawData[key];
+      saveRawData(newRawData);
+    } else {
+      const newRawData = { ...rawData, [key]: value };
+      saveRawData(newRawData);
+    }
+  };
+
+  const saveRawData = (newRawValue: { [key: string]: any }) => {
+    valueClient.setScriptValues(script!.uuid, newRawValue);
+    updateRawData(newRawValue);
+  };
+
+  const updateRawData = (newRawValue: { [key: string]: any }) => {
+    setRawData(newRawValue);
+    setEditValue(JSON.stringify(newRawValue, null, 2));
+    setData(
+      Object.keys(newRawValue).map((key) => {
+        return { key: key, value: newRawValue[key] };
+      })
+    );
+  };
+
+  const deleteData = (key: string) => {
+    saveData(key, undefined, true);
+    Message.info({
+      content: t("delete_success"),
+    });
+  };
+
+  const clearData = () => {
+    saveRawData({});
+    Message.info({
+      content: t("clear_success"),
+    });
+  };
 
   useEffect(() => {
     if (!script) {
       return () => {};
     }
-    valueClient.getScriptValue(script).then((value) => {
-      setData(
-        Object.keys(value).map((key) => {
-          return { key: key, value: value[key] };
-        })
-      );
+    valueClient.getScriptValue(script).then((rawValue) => {
+      updateRawData(rawValue);
     });
   }, [script]);
   const columns: ColumnProps[] = [
@@ -122,11 +162,7 @@ const ScriptStorage: React.FC<{
               iconOnly
               icon={<IconDelete />}
               onClick={() => {
-                valueClient.setScriptValue(script!.uuid, value.key, undefined);
-                Message.info({
-                  content: t("delete_success"),
-                });
-                setData(data.filter((_, i) => i !== index));
+                deleteData(value.key);
               }}
             />
           </Space>
@@ -146,6 +182,7 @@ const ScriptStorage: React.FC<{
       visible={visible}
       onOk={onOk}
       onCancel={onCancel}
+      footer={null}
     >
       <Modal
         title={currentValue ? t("edit_value") : t("add_value")}
@@ -165,34 +202,11 @@ const ScriptStorage: React.FC<{
               default:
                 break;
             }
-            valueClient.setScriptValue(script!.uuid, value.key, value.value);
-            if (currentValue) {
-              Message.info({
-                content: t("update_success"),
-              });
-              setData(
-                data.map((v) => {
-                  if (v.key === value.key) {
-                    return {
-                      ...v,
-                      value: value.value,
-                    };
-                  }
-                  return v;
-                })
-              );
-            } else {
-              Message.info({
-                content: t("add_success"),
-              });
-              setData([
-                {
-                  key: value.key,
-                  value: value.value,
-                },
-                ...data,
-              ]);
-            }
+            saveData(value.key, value.value);
+
+            Message.info({
+              content: currentValue ? t("update_success") : t("add_success"),
+            });
             setVisibleEdit(false);
           });
         }}
@@ -229,36 +243,79 @@ const ScriptStorage: React.FC<{
       </Modal>
       <Space className="w-full" direction="vertical">
         <Space className="!flex justify-end">
-          <Popconfirm
-            focusLock
-            title={t("confirm_clear")}
-            onOk={() => {
-              setData((prev) => {
-                prev.forEach((v) => {
-                  valueClient.setScriptValue(script!.uuid, v.key, undefined);
-                });
-                Message.info({
-                  content: t("clear_success"),
-                });
-                return [];
-              });
-            }}
-          >
-            <Button type="primary" status="warning">
-              {t("clear")}
-            </Button>
-          </Popconfirm>
+          {isEdit ? (
+            <>
+              <Button
+                type="primary"
+                status="warning"
+                onClick={() => {
+                  setEditValue(JSON.stringify(rawData, null, 2));
+                }}
+              >
+                {t("restore")}
+              </Button>
+              <Button
+                type="primary"
+                onClick={() => {
+                  try {
+                    const newValue = JSON.parse(editValue);
+                    saveRawData(newValue);
+                    Message.info({
+                      content: t("save_success"),
+                    });
+                  } catch (err) {
+                    Message.error({
+                      content: `${t("save_failed")}: ${err}`,
+                    });
+                  }
+                }}
+              >
+                {t("save")}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Popconfirm
+                focusLock
+                title={t("confirm_clear")}
+                onOk={() => {
+                  clearData();
+                }}
+              >
+                <Button type="primary" status="warning">
+                  {t("clear")}
+                </Button>
+              </Popconfirm>
+              <Button
+                type="primary"
+                onClick={() => {
+                  setCurrentValue(undefined);
+                  setVisibleEdit(true);
+                }}
+              >
+                {t("add")}
+              </Button>
+            </>
+          )}
           <Button
             type="primary"
+            status="success"
             onClick={() => {
-              setCurrentValue(undefined);
-              setVisibleEdit(true);
+              setIsEdit(!isEdit);
             }}
           >
-            {t("add")}
+            {isEdit ? "单独编辑" : "批量编辑"}
           </Button>
         </Space>
-        <Table columns={columns} data={data} rowKey="id" />
+        {isEdit ? (
+          <Input.TextArea
+            value={editValue}
+            onChange={(value) => setEditValue(value)}
+            style={{ height: "calc(95vh - 100px)" }}
+          />
+        ) : (
+          <Table columns={columns} data={data} rowKey="id" />
+        )}
       </Space>
     </Drawer>
   );

--- a/src/pages/components/ScriptStorage/index.tsx
+++ b/src/pages/components/ScriptStorage/index.tsx
@@ -32,6 +32,7 @@ const ScriptStorage: React.FC<{
   const [form] = Form.useForm();
   const { t } = useTranslation();
 
+  // 保存单个键值
   const saveData = (key: string, value: any, del: boolean = false) => {
     // GM_setValue最终全量存储，故更新单个键值也通过valueClient.setScriptValues处理
     if (del) {
@@ -44,11 +45,13 @@ const ScriptStorage: React.FC<{
     }
   };
 
+  // 保存所有键值
   const saveRawData = (newRawValue: { [key: string]: any }) => {
     valueClient.setScriptValues(script!.uuid, newRawValue);
     updateRawData(newRawValue);
   };
 
+  // 更新UI数据
   const updateRawData = (newRawValue: { [key: string]: any }) => {
     setRawData(newRawValue);
     setEditValue(JSON.stringify(newRawValue, null, 2));
@@ -59,6 +62,7 @@ const ScriptStorage: React.FC<{
     );
   };
 
+  // 删除单个键值
   const deleteData = (key: string) => {
     saveData(key, undefined, true);
     Message.info({
@@ -66,6 +70,7 @@ const ScriptStorage: React.FC<{
     });
   };
 
+  // 清空所有键值
   const clearData = () => {
     saveRawData({});
     Message.info({

--- a/src/pages/components/ScriptStorage/index.tsx
+++ b/src/pages/components/ScriptStorage/index.tsx
@@ -36,6 +36,9 @@ const ScriptStorage: React.FC<{
   const saveData = (key: string, value: any) => {
     valueClient.setScriptValue(script!.uuid, key, value);
     const newRawData = { ...rawData, [key]: value };
+    if (value === undefined) {
+      delete newRawData[key];
+    }
     updateRawData(newRawData);
   };
 


### PR DESCRIPTION
新增 脚本储存面板支持JSON方式批量编辑

优化 脚本储存交互逻辑
 - 现在通过统一内部api实现逻辑复用

删除 脚本储存面板抽屉footer
 - 确认和取消按钮没有实际逻辑 没必要保留 容易误导用户操作