### PR TITLE
修正雙重Promise (double-wrapped)

### DIFF
--- a/packages/chrome-extension-mock/cookies.ts
+++ b/packages/chrome-extension-mock/cookies.ts
@@ -13,12 +13,12 @@ export default class Cookies {
     callback: (cookies: chrome.cookies.Cookie[]) => void
   ) => void | undefined;
 
-  getAll(
+  async getAll(
     details: chrome.cookies.GetAllDetails,
     callback: (cookies: chrome.cookies.Cookie[]) => void
   ): Promise<chrome.cookies.Cookie[]> {
     this.mockGetAll?.(details, callback);
-    return Promise.resolve([]);
+    return [];
   }
 
   set(details: chrome.cookies.SetDetails, callback?: () => void): void {

--- a/packages/filesystem/baidu/baidu.ts
+++ b/packages/filesystem/baidu/baidu.ts
@@ -20,20 +20,20 @@ export default class BaiduFileSystem implements FileSystem {
     return this.list().then();
   }
 
-  open(file: File): Promise<FileReader> {
+  async open(file: File): Promise<FileReader> {
     // 获取fsid
-    return Promise.resolve(new BaiduFileReader(this, file));
+    return new BaiduFileReader(this, file);
   }
 
-  openDir(path: string): Promise<FileSystem> {
-    return Promise.resolve(new BaiduFileSystem(joinPath(this.path, path), this.accessToken));
+  async openDir(path: string): Promise<FileSystem> {
+    return new BaiduFileSystem(joinPath(this.path, path), this.accessToken);
   }
 
-  create(path: string): Promise<FileWriter> {
-    return Promise.resolve(new BaiduFileWriter(this, joinPath(this.path, path)));
+  async create(path: string): Promise<FileWriter> {
+    return new BaiduFileWriter(this, joinPath(this.path, path));
   }
 
-  createDir(dir: string): Promise<void> {
+  async createDir(dir: string): Promise<void> {
     dir = joinPath(this.path, dir);
     const urlencoded = new URLSearchParams();
     urlencoded.append("path", dir);
@@ -42,17 +42,15 @@ export default class BaiduFileSystem implements FileSystem {
     urlencoded.append("rtype", "3");
     const myHeaders = new Headers();
     myHeaders.append("Content-Type", "application/x-www-form-urlencoded");
-    return this.request(`https://pan.baidu.com/rest/2.0/xpan/file?method=create&access_token=${this.accessToken}`, {
+    const data = await this.request(`https://pan.baidu.com/rest/2.0/xpan/file?method=create&access_token=${this.accessToken}`, {
       method: "POST",
       headers: myHeaders,
       body: urlencoded,
       redirect: "follow",
-    }).then((data) => {
-      if (data.errno) {
-        throw new Error(JSON.stringify(data));
-      }
-      return Promise.resolve();
     });
+    if (data.errno) {
+      throw new Error(JSON.stringify(data));
+    }
   }
 
   async request(url: string, config?: RequestInit) {
@@ -148,7 +146,7 @@ export default class BaiduFileSystem implements FileSystem {
     });
   }
 
-  getDirUrl(): Promise<string> {
-    return Promise.resolve(`https://pan.baidu.com/disk/main#/index?category=all&path=${encodeURIComponent(this.path)}`);
+  async getDirUrl(): Promise<string> {
+    return `https://pan.baidu.com/disk/main#/index?category=all&path=${encodeURIComponent(this.path)}`;
   }
 }

--- a/packages/filesystem/onedrive/onedrive.ts
+++ b/packages/filesystem/onedrive/onedrive.ts
@@ -19,22 +19,22 @@ export default class OneDriveFileSystem implements FileSystem {
     return this.list().then();
   }
 
-  open(file: File): Promise<FileReader> {
-    return Promise.resolve(new OneDriveFileReader(this, file));
+  async open(file: File): Promise<FileReader> {
+    return new OneDriveFileReader(this, file);
   }
 
-  openDir(path: string): Promise<FileSystem> {
+  async openDir(path: string): Promise<FileSystem> {
     if (path.startsWith("ScriptCat")) {
       path = path.substring(9);
     }
-    return Promise.resolve(new OneDriveFileSystem(joinPath(this.path, path), this.accessToken));
+    return new OneDriveFileSystem(joinPath(this.path, path), this.accessToken);
   }
 
-  create(path: string): Promise<FileWriter> {
-    return Promise.resolve(new OneDriveFileWriter(this, joinPath(this.path, path)));
+  async create(path: string): Promise<FileWriter> {
+    return new OneDriveFileWriter(this, joinPath(this.path, path));
   }
 
-  createDir(dir: string): Promise<void> {
+  async createDir(dir: string): Promise<void> {
     if (dir && dir.startsWith("ScriptCat")) {
       dir = dir.substring(9);
       if (dir.startsWith("/")) {
@@ -42,7 +42,7 @@ export default class OneDriveFileSystem implements FileSystem {
       }
     }
     if (!dir) {
-      return Promise.resolve();
+      return;
     }
     dir = joinPath(this.path, dir);
     const dirs = dir.split("/");
@@ -55,7 +55,7 @@ export default class OneDriveFileSystem implements FileSystem {
     if (parent !== "") {
       parent = `:${parent}:`;
     }
-    return this.request(`https://graph.microsoft.com/v1.0/me/drive/special/approot${parent}/children`, {
+    const data = await this.request(`https://graph.microsoft.com/v1.0/me/drive/special/approot${parent}/children`, {
       method: "POST",
       headers: myHeaders,
       body: JSON.stringify({
@@ -63,15 +63,13 @@ export default class OneDriveFileSystem implements FileSystem {
         folder: {},
         "@microsoft.graph.conflictBehavior": "replace",
       }),
-    }).then((data: any) => {
-      if (data.errno) {
-        throw new Error(JSON.stringify(data));
-      }
-      return Promise.resolve();
     });
+    if (data.errno) {
+      throw new Error(JSON.stringify(data));
+    }
   }
 
-  request(url: string, config?: RequestInit, nothen?: boolean) {
+  request(url: string, config?: RequestInit, nothen?: boolean): Promise<Response | any> {
     config = config || {};
     const headers = <Headers>config.headers || new Headers();
     if (url.indexOf("uploadSession") === -1) {
@@ -105,42 +103,39 @@ export default class OneDriveFileSystem implements FileSystem {
       });
   }
 
-  delete(path: string): Promise<void> {
-    return this.request(
+  async delete(path: string): Promise<void> {
+    const resp = await this.request(
       `https://graph.microsoft.com/v1.0/me/drive/special/approot:${joinPath(this.path, path)}`,
       {
         method: "DELETE",
       },
       true
-    ).then(async (resp) => {
-      if (resp.status !== 204) {
-        throw new Error(await resp.text());
-      }
-      return resp;
-    });
+    );
+    if (resp.status !== 204) {
+      throw new Error(await resp.text());
+    }
+    return resp;
   }
 
-  list(): Promise<File[]> {
+  async list(): Promise<File[]> {
     let { path } = this;
     if (path === "/") {
       path = "";
     } else {
       path = `:${path}:`;
     }
-    return this.request(`https://graph.microsoft.com/v1.0/me/drive/special/approot${path}/children`).then((data) => {
-      const list: File[] = [];
-      data.value.forEach((val: any) => {
-        list.push({
-          name: val.name,
-          path: this.path,
-          size: val.size,
-          digest: val.eTag,
-          createtime: new Date(val.createdDateTime).getTime(),
-          updatetime: new Date(val.lastModifiedDateTime).getTime(),
-        });
+    const data = await this.request(`https://graph.microsoft.com/v1.0/me/drive/special/approot${path}/children`);
+    const list: File[] = data.value.map((val: any) => {
+      return ({
+        name: val.name,
+        path: this.path,
+        size: val.size,
+        digest: val.eTag,
+        createtime: new Date(val.createdDateTime).getTime(),
+        updatetime: new Date(val.lastModifiedDateTime).getTime(),
       });
-      return list;
     });
+    return list;
   }
 
   getDirUrl(): Promise<string> {

--- a/packages/filesystem/onedrive/rw.ts
+++ b/packages/filesystem/onedrive/rw.ts
@@ -24,7 +24,7 @@ export class OneDriveFileReader implements FileReader {
       true
     );
     if (data.status !== 200) {
-      return Promise.reject(await data.text());
+      throw await data.text();
     }
     switch (type) {
       case "string":

--- a/packages/filesystem/onedrive/rw.ts
+++ b/packages/filesystem/onedrive/rw.ts
@@ -24,7 +24,7 @@ export class OneDriveFileReader implements FileReader {
       true
     );
     if (data.status !== 200) {
-      throw await data.text();
+      throw new Error(await data.text());
     }
     switch (type) {
       case "string":

--- a/packages/filesystem/webdav/webdav.ts
+++ b/packages/filesystem/webdav/webdav.ts
@@ -35,30 +35,29 @@ export default class WebDAVFileSystem implements FileSystem {
       }
       throw new Error("verify failed");
     }
-    return Promise.resolve();
   }
 
-  open(file: File): Promise<FileReader> {
-    return Promise.resolve(new WebDAVFileReader(this.client, joinPath(file.path, file.name)));
+  async open(file: File): Promise<FileReader> {
+    return new WebDAVFileReader(this.client, joinPath(file.path, file.name));
   }
 
-  openDir(path: string): Promise<FileSystem> {
-    return Promise.resolve(new WebDAVFileSystem(this.client, joinPath(this.basePath, path), this.url));
+  async openDir(path: string): Promise<FileSystem> {
+    return new WebDAVFileSystem(this.client, joinPath(this.basePath, path), this.url);
   }
 
-  create(path: string): Promise<FileWriter> {
-    return Promise.resolve(new WebDAVFileWriter(this.client, joinPath(this.basePath, path)));
+  async create(path: string): Promise<FileWriter> {
+    return new WebDAVFileWriter(this.client, joinPath(this.basePath, path));
   }
 
   async createDir(path: string): Promise<void> {
     try {
-      return Promise.resolve(await this.client.createDirectory(joinPath(this.basePath, path)));
+      await this.client.createDirectory(joinPath(this.basePath, path));
     } catch (e: any) {
       // 如果是405错误,则忽略
       if (e.message.includes("405")) {
-        return Promise.resolve();
+        return;
       }
-      return Promise.reject(e);
+      throw e;
     }
   }
 
@@ -82,10 +81,10 @@ export default class WebDAVFileSystem implements FileSystem {
         updatetime: new Date(item.lastmod).getTime(),
       });
     });
-    return Promise.resolve(ret);
+    return ret;
   }
 
-  getDirUrl(): Promise<string> {
-    return Promise.resolve(this.url + this.basePath);
+  async getDirUrl(): Promise<string> {
+    return this.url + this.basePath;
   }
 }

--- a/packages/filesystem/zip/rw.ts
+++ b/packages/filesystem/zip/rw.ts
@@ -25,8 +25,7 @@ export class ZipFileWriter implements FileWriter {
     this.path = path;
   }
 
-  write(content: string): Promise<void> {
+  async write(content: string): Promise<void> {
     this.zip.file(this.path, content);
-    return Promise.resolve();
   }
 }

--- a/packages/filesystem/zip/zip.ts
+++ b/packages/filesystem/zip/zip.ts
@@ -13,37 +13,36 @@ export default class ZipFileSystem implements FileSystem {
     this.basePath = basePath || "";
   }
 
-  verify(): Promise<void> {
-    return Promise.resolve();
+  async verify(): Promise<void> {
+    // do nothing
   }
 
-  open(info: File): Promise<FileReader> {
+  async open(info: File): Promise<FileReader> {
     const path = info.name;
     const file = this.zip.file(path);
     if (file) {
-      return Promise.resolve(new ZipFileReader(file));
+      return new ZipFileReader(file);
     }
-    return Promise.reject(new Error("File not found"));
+    throw new Error("File not found");
   }
 
-  openDir(path: string): Promise<FileSystem> {
-    return Promise.resolve(new ZipFileSystem(this.zip, path));
+  async openDir(path: string): Promise<FileSystem> {
+    return new ZipFileSystem(this.zip, path);
   }
 
-  create(path: string): Promise<FileWriter> {
-    return Promise.resolve(new ZipFileWriter(this.zip, path));
+  async create(path: string): Promise<FileWriter> {
+    return new ZipFileWriter(this.zip, path);
   }
 
-  createDir(): Promise<void> {
-    return Promise.resolve();
+  async createDir(): Promise<void> {
+    // do nothing
   }
 
-  delete(path: string): Promise<void> {
+  async delete(path: string): Promise<void> {
     this.zip.remove(path);
-    return Promise.resolve();
   }
 
-  list(): Promise<File[]> {
+  async list(): Promise<File[]> {
     const files: File[] = [];
     Object.keys(this.zip.files).forEach((key) => {
       files.push({
@@ -55,10 +54,10 @@ export default class ZipFileSystem implements FileSystem {
         updatetime: this.zip.files[key].date.getTime(),
       });
     });
-    return Promise.resolve(files);
+    return files;
   }
 
-  getDirUrl(): Promise<string> {
+  async getDirUrl(): Promise<string> {
     throw new Error("Method not implemented.");
   }
 }

--- a/src/app/cache.ts
+++ b/src/app/cache.ts
@@ -135,7 +135,7 @@ export default class Cache {
     return this.storage.get(key);
   }
 
-  public async getOrSet<T>(key: string, set: () => Promise<T>): Promise<T> {
+  public async getOrSet<T>(key: string, set: () => Promise<T> | T): Promise<T> {
     let ret = await this.get(key);
     if (!ret) {
       ret = await set();

--- a/src/app/migrate.ts
+++ b/src/app/migrate.ts
@@ -15,7 +15,7 @@ export function migrateToChromeStorage() {
       const scriptDAO = new ScriptDAO();
       const scriptCodeDAO = new ScriptCodeDAO();
       console.log("开始迁移脚本数据", scripts.length);
-      await Promise.all(
+      await Promise.all( // 不处理 Promise.reject ?
         scripts.map(async (script: ScriptAndCode) => {
           const {
             uuid,

--- a/src/app/repo/scripts.ts
+++ b/src/app/repo/scripts.ts
@@ -100,13 +100,12 @@ export class ScriptDAO extends Repo<Script> {
     return this.get(uuid);
   }
 
-  getAndCode(uuid: string): Promise<ScriptAndCode | undefined> {
-    return Promise.all([this.get(uuid), this.scriptCodeDAO.get(uuid)]).then(([script, code]) => {
-      if (!script || !code) {
-        return undefined;
-      }
-      return Object.assign(script, code);
-    });
+  async getAndCode(uuid: string): Promise<ScriptAndCode | undefined> {
+    const [script, code] = await Promise.all([this.get(uuid), this.scriptCodeDAO.get(uuid)]);
+    if (!script || !code) {
+      return undefined;
+    }
+    return Object.assign(script, code);
   }
 
   public findByName(name: string) {

--- a/src/app/service/content/gm_api.ts
+++ b/src/app/service/content/gm_api.ts
@@ -979,19 +979,18 @@ export default class GMApi {
 
   // GM_getResourceURL的异步版本，用来兼容GM.getResourceUrl
   @GMContext.API()
-  GMDotGetResourceUrl(name: string, isBlobUrl?: boolean): Promise<string | undefined> {
+  async GMDotGetResourceUrl(name: string, isBlobUrl?: boolean): Promise<string | undefined> {
     console.log("GMDotGetResourceUrl", name, isBlobUrl);
-    if (!this.scriptRes.resource) {
-      return Promise.resolve(undefined);
-    }
-    const r = this.scriptRes.resource[name];
-    if (r) {
-      if (isBlobUrl) {
-        return Promise.resolve(URL.createObjectURL(base64ToBlob(r.base64)));
+    if (this.scriptRes.resource) {
+      const r = this.scriptRes.resource[name];
+      if (r) {
+        if (isBlobUrl) {
+          return URL.createObjectURL(base64ToBlob(r.base64));
+        }
+        return r.base64;
       }
-      return Promise.resolve(r.base64);
     }
-    return Promise.resolve(undefined);
+    return undefined;
   }
 
   @GMContext.API()

--- a/src/app/service/offscreen/gm_api.ts
+++ b/src/app/service/offscreen/gm_api.ts
@@ -172,8 +172,8 @@ export default class GMApi {
     });
   }
 
-  openInTab({ url }: { url: string }) {
-    return Promise.resolve(window.open(url) !== undefined);
+  async openInTab({ url }: { url: string }) {
+    return window.open(url) !== undefined;
   }
 
   textarea: HTMLTextAreaElement = document.createElement("textarea");

--- a/src/app/service/offscreen/index.ts
+++ b/src/app/service/offscreen/index.ts
@@ -60,7 +60,7 @@ export class OffscreenManager {
     const vscodeConnect = new VSCodeConnect(this.windowServer.group("vscodeConnect"), this.extensionMessage);
     vscodeConnect.init();
 
-    this.windowServer.on("createObjectURL", (params: { data: Blob; persistence: boolean }) => {
+    this.windowServer.on("createObjectURL", async (params: { data: Blob; persistence: boolean }) => {
       const url = URL.createObjectURL(params.data);
       if (!params.persistence) {
         // 如果不是持久化的，则在1分钟后释放
@@ -68,7 +68,7 @@ export class OffscreenManager {
           URL.revokeObjectURL(url);
         }, 1000 * 60);
       }
-      return Promise.resolve(url);
+      return url;
     });
   }
 }

--- a/src/app/service/offscreen/vscode-connect.ts
+++ b/src/app/service/offscreen/vscode-connect.ts
@@ -59,7 +59,8 @@ export class VSCodeConnect {
         this.wsConnect = new WebSocket(url);
       } catch (e: any) {
         this.logger.debug("connect vscode faild", Logger.E(e));
-        return Promise.reject(e);
+        reject(e);
+        return;
       }
       let ok = false;
       this.wsConnect.addEventListener("open", () => {

--- a/src/app/service/sandbox/runtime.ts
+++ b/src/app/service/sandbox/runtime.ts
@@ -284,12 +284,12 @@ export class Runtime {
     const exec = this.execScripts.get(uuid);
     if (!exec) {
       proxyUpdateRunStatus(this.windowMessage, { uuid: uuid, runStatus: SCRIPT_RUN_STATUS_COMPLETE });
-      return Promise.resolve(false);
+      return false;
     }
     exec.stop();
     this.execScripts.delete(uuid);
     proxyUpdateRunStatus(this.windowMessage, { uuid: uuid, runStatus: SCRIPT_RUN_STATUS_COMPLETE });
-    return Promise.resolve(true);
+    return true;
   }
 
   async runScript(script: ScriptRunResouce) {

--- a/src/app/service/service_worker/popup.ts
+++ b/src/app/service/service_worker/popup.ts
@@ -354,7 +354,7 @@ export class PopupService {
       eventId: id.toString(),
       data: inputValue,
     });
-    return Promise.resolve(true);
+    return Promise.resolve(true); // 不需要异步
   }
 
   init() {
@@ -372,11 +372,11 @@ export class PopupService {
         script.forEach((script) => {
           // 处理GM_saveTab关闭事件, 由于需要用到tab相关的脚本数据，所以需要在这里处理
           // 避免先删除了数据获取不到
-          Cache.getInstance().tx(`GM_getTab:${script.uuid}`, (tabData: { [key: number]: any }) => {
+          Cache.getInstance().tx(`GM_getTab:${script.uuid}`, async (tabData: { [key: number]: any }) => {
             if (tabData) {
               delete tabData[tabId];
             }
-            return Promise.resolve(tabData);
+            return tabData;
           });
         });
         return undefined;

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -310,9 +310,7 @@ export class RuntimeService {
   }
 
   getAndGenMessageFlag() {
-    return Cache.getInstance().getOrSet("scriptInjectMessageFlag", () => {
-      return Promise.resolve(randomString(16));
-    });
+    return Cache.getInstance().getOrSet("scriptInjectMessageFlag", () => randomString(16));
   }
 
   deleteMessageFlag() {
@@ -387,10 +385,10 @@ export class RuntimeService {
     const isBlack = this.blackMatch.match(sender.getSender().url!);
     if (isBlack.length > 0) {
       // 如果在黑名单中, 则不加载脚本
-      return Promise.resolve({ flag: "", scripts: [] });
+      return { flag: "", scripts: [] };
     }
 
-    const [scriptFlag] = await Promise.all([this.getMessageFlag(), this.loadScriptMatchInfo()]);
+    const [scriptFlag, __] = await Promise.all([this.getMessageFlag(), this.loadScriptMatchInfo()]); // 只执行 loadScriptMatchInfo 但不获取结果
     const chromeSender = sender.getSender() as chrome.runtime.MessageSender;
 
     // 匹配当前页面的脚本
@@ -517,7 +515,7 @@ export class RuntimeService {
       scripts: enableScript,
     });
 
-    return Promise.resolve({ flag: scriptFlag, scripts: enableScript });
+    return { flag: scriptFlag, scripts: enableScript };
   }
 
   // 停止脚本

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -290,7 +290,7 @@ export class ScriptService {
         nextruntime: params.nextruntime,
       })) === false
     ) {
-      throw "update error";
+      throw new Error("update error");
     }
     this.mq.publish("scriptRunStatus", params);
     return true;

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -171,7 +171,7 @@ export class ScriptService {
       code: info.code,
       upsertBy: source,
     });
-    return Promise.resolve(prepareScript.script);
+    return prepareScript.script;
   }
 
   // 直接通过code静默安装脚本
@@ -182,7 +182,7 @@ export class ScriptService {
       code: param.code,
       upsertBy: param.upsertBy,
     });
-    return Promise.resolve(prepareScript.script);
+    return prepareScript.script;
   }
 
   // 获取安装信息
@@ -221,7 +221,7 @@ export class ScriptService {
           // 广播一下
           this.mq.publish("installScript", { script, update, upsertBy });
         });
-        return Promise.resolve({ update });
+        return { update };
       })
       .catch((e: any) => {
         logger.error("install error", Logger.E(e));
@@ -290,10 +290,10 @@ export class ScriptService {
         nextruntime: params.nextruntime,
       })) === false
     ) {
-      return Promise.reject("update error");
+      throw "update error";
     }
     this.mq.publish("scriptRunStatus", params);
-    return Promise.resolve(true);
+    return true;
   }
 
   getCode(uuid: string) {
@@ -323,7 +323,7 @@ export class ScriptService {
     ret.code = code.code;
     ret.code = compileScriptCode(ret);
 
-    return Promise.resolve(ret);
+    return ret;
   }
 
   async excludeUrl({ uuid, url, remove }: { uuid: string; url: string; remove: boolean }) {
@@ -404,11 +404,11 @@ export class ScriptService {
     // 检查更新
     const script = await this.scriptDAO.get(uuid);
     if (!script) {
-      return Promise.resolve(false);
+      return false;
     }
     await this.scriptDAO.update(uuid, { checktime: new Date().getTime() });
     if (!script.checkUpdateUrl) {
-      return Promise.resolve(false);
+      return false;
     }
     const logger = LoggerCore.logger({
       uuid: script.uuid,
@@ -419,12 +419,12 @@ export class ScriptService {
       const { metadata } = info;
       if (!metadata) {
         logger.error("parse metadata failed");
-        return Promise.resolve(false);
+        return false;
       }
       const newVersion = metadata.version && metadata.version[0];
       if (!newVersion) {
         logger.error("parse version failed", { version: metadata.version });
-        return Promise.resolve(false);
+        return false;
       }
       let oldVersion = script.metadata.version && script.metadata.version[0];
       if (!oldVersion) {
@@ -432,15 +432,15 @@ export class ScriptService {
       }
       // 对比版本大小
       if (ltever(newVersion, oldVersion, logger)) {
-        return Promise.resolve(false);
+        return false;
       }
       // 进行更新
       this.openUpdatePage(script, source);
     } catch (e) {
       logger.error("check update failed", Logger.E(e));
-      return Promise.resolve(false);
+        return false;
     }
-    return Promise.resolve(true);
+    return true;
   }
 
   // 打开更新窗口
@@ -521,9 +521,8 @@ export class ScriptService {
         })
         .then(() => {
           InfoNotification("检查更新", "所有脚本检查完成");
-          return Promise.resolve(true);
         });
-      return Promise.resolve(true);
+      return Promise.resolve(true); // 无视检查结果，立即回传true
     }
   }
 

--- a/src/app/service/service_worker/synchronize.ts
+++ b/src/app/service/service_worker/synchronize.ts
@@ -98,7 +98,7 @@ export class SynchronizeService {
           })
         );
       });
-      return Promise.all(rets);
+      return Promise.all(rets); // 不处理 Promise.reject ?
     }
     // 获取所有脚本
     const list = await this.scriptDAO.all();
@@ -150,7 +150,7 @@ export class SynchronizeService {
     ret.resources = this.resourceToBackdata(resources);
 
     ret.storage = storage;
-    return Promise.resolve(ret);
+    return ret;
   }
 
   resourceToBackdata(resource: { [key: string]: Resource }) {
@@ -191,7 +191,7 @@ export class SynchronizeService {
       ret.push(this.resource.importResource(uuid, item, "require-css"));
     });
     return Promise.all(ret).then(() => {
-      return Promise.resolve();
+      return;
     });
   }
 
@@ -259,7 +259,7 @@ export class SynchronizeService {
       saveAs: true,
       filename: `scriptcat-backup-${dayjs().format("YYYY-MM-DDTHH-mm-ss")}.zip`,
     });
-    return Promise.resolve();
+    return;
   }
 
   // 备份到云端
@@ -288,9 +288,9 @@ export class SynchronizeService {
       );
     } catch (e) {
       this.logger.error("backup to cloud error", Logger.E(e));
-      return Promise.reject(e);
+      throw e;
     }
-    return Promise.resolve();
+    return;
   }
 
   // 开始一次云同步
@@ -490,7 +490,7 @@ export class SynchronizeService {
     // 重新获取文件列表,保存文件摘要
     await this.updateFileDigest(fs);
     this.logger.info("sync complete");
-    return Promise.resolve();
+    return;
   }
 
   async updateFileDigest(fs: FileSystem) {
@@ -500,7 +500,7 @@ export class SynchronizeService {
       newFileDigestMap[file.name] = file.digest;
     });
     await this.storage.set("file_digest", newFileDigestMap);
-    return Promise.resolve();
+    return;
   }
 
   // 删除云端脚本数据
@@ -533,7 +533,7 @@ export class SynchronizeService {
     } catch (e) {
       logger.error("delete file error", Logger.E(e));
     }
-    return Promise.resolve();
+    return;
   }
 
   // 上传脚本
@@ -563,7 +563,7 @@ export class SynchronizeService {
       logger.error("push script error", Logger.E(e));
       throw e;
     }
-    return Promise.resolve();
+    return;
   }
 
   async pullScript(fs: FileSystem, file: SyncFiles, script?: Script) {
@@ -595,7 +595,7 @@ export class SynchronizeService {
     } catch (e) {
       logger.error("pull script error", Logger.E(e));
     }
-    return Promise.resolve();
+    return;
   }
 
   cloudSyncConfigChange(value: CloudSyncConfig) {

--- a/src/app/service/service_worker/value.ts
+++ b/src/app/service/service_worker/value.ts
@@ -57,7 +57,7 @@ export class ValueService {
     // 查询出脚本
     const script = await this.scriptDAO.get(uuid);
     if (!script) {
-      return Promise.reject(new Error("script not found"));
+      throw new Error("script not found");
     }
     // 查询老的值
     const storageName = getStorageName(script);
@@ -140,7 +140,7 @@ export class ValueService {
   async setValues(data: { uuid: string; values: { [key: string]: any } }, sender: ValueUpdateSender) {
     const script = await this.scriptDAO.get(data.uuid);
     if (!script) {
-      return Promise.reject(new Error("script not found"));
+      throw new Error("script not found");
     }
     const storageName = getStorageName(script);
     let oldValue: { [key: string]: any } = {};

--- a/src/pages/import/App.tsx
+++ b/src/pages/import/App.tsx
@@ -59,7 +59,7 @@ function App() {
               item.script = prepareScript;
             } catch (e: any) {
               item.error = e.toString();
-              return Promise.resolve(item);
+              return item;
             }
             if (!item.options) {
               item.options = {
@@ -86,7 +86,7 @@ function App() {
             item.script.script.status =
               item.enabled !== false && item.options.settings.enabled ? SCRIPT_STATUS_ENABLE : SCRIPT_STATUS_DISABLE;
             item.install = true;
-            return Promise.resolve(item);
+            return item;
           })
         );
         setScripts(result);
@@ -129,7 +129,6 @@ function App() {
                   setInstallNum((prev) => {
                     return [prev[0] + 1, prev[1]];
                   });
-                  return Promise.resolve();
                 });
                 await Promise.all(result);
                 setLoading(false);

--- a/src/pages/options/routes/script/ScriptEditor.tsx
+++ b/src/pages/options/routes/script/ScriptEditor.tsx
@@ -130,7 +130,7 @@ const emptyScript = async (template: string, hotKeys: any, target?: string) => {
   const prepareScript = await prepareScriptByCode(code, "", uuidv4());
   const { script } = prepareScript;
 
-  return Promise.resolve({
+  return ({
     script,
     code,
     active: true,

--- a/src/pages/store/utils.ts
+++ b/src/pages/store/utils.ts
@@ -29,11 +29,11 @@ const processScriptFavicon = async (script: Script) => {
         icons.map((icon) => {
           // 没有的话缓存到本地使用URL.createObjectURL
           if (!icon.icon) {
-            return Promise.resolve({
+            return {
               match: icon.match,
               website: icon.website,
               icon: "",
-            });
+            };
           }
           // 因为需要持久化URL.createObjectURL，所以需要通过调用到offscreen来创建
           return systemClient

--- a/src/pkg/backup/export.ts
+++ b/src/pkg/backup/export.ts
@@ -12,7 +12,7 @@ export default class BackupExport {
   }
 
   // 导出备份数据
-  export(data: BackupData): Promise<void> {
+  async export(data: BackupData): Promise<void> {
     // 写入脚本备份
     const results: Promise<void>[] = [];
     data.script.forEach((item) => {
@@ -21,7 +21,7 @@ export default class BackupExport {
     data.subscribe.forEach((item) => {
       results.push(this.writeSubscribe(item));
     });
-    return Promise.all(results).then(() => undefined);
+    await Promise.all(results);
   }
 
   async writeScript(script: ScriptBackupData) {
@@ -42,7 +42,7 @@ export default class BackupExport {
     await this.writeResource(name, script.requires, "requires");
     await this.writeResource(name, script.requiresCss, "requires.css");
 
-    return Promise.resolve();
+    return;
   }
 
   async writeResource(
@@ -70,6 +70,6 @@ export default class BackupExport {
     // 写入订阅options.json
     await (await this.fs.create(`${name}.user.sub.options.json`)).write(JSON.stringify(subscribe.options));
 
-    return Promise.resolve();
+    return;
   }
 }

--- a/src/pkg/utils/script.ts
+++ b/src/pkg/utils/script.ts
@@ -343,5 +343,5 @@ export async function prepareSubscribeByCode(
   if (old) {
     subscribe = copySubscribe(subscribe, old);
   }
-  return Promise.resolve({ subscribe, oldSubscribe: old });
+  return { subscribe, oldSubscribe: old };
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -22,9 +22,7 @@ export function initTestEnv() {
   // @ts-ignore
   global.Blob = function Blob(data, options) {
     const blob = new OldBlob(data, options);
-    blob.text = () => {
-      return Promise.resolve(data[0]);
-    };
+    blob.text = () => Promise.resolve(data[0]);
     blob.arrayBuffer = () => {
       return new Promise<ArrayBuffer>((resolve) => {
         const str = data[0];


### PR DESCRIPTION
不好意思，改动有点多

主要是我看到有很多写法都是用async/await, 但最后回传却是 Promise.resolve Promise.reject这样的双重Promise写法。
ScriptCat的写法大多都是同步处理，不用异步的 new Promise (...) 这种格式
那麼都改成 async/await 比较好。代码较短也易维护。
必要的地方才使用Promise.resolve Promise.reject吧

----

有几个地方好像原本的Logic有问题
维持了本来的Logic但加了註解

有空就看一下吧。

----

针对 Promise 处理，有几个位置明显有问题，或者是明显有更好写法的部份，也改动了
反正用Git比对一下新旧代码就看得出来吧
如果有些部份未能理解，也可以提出