### PR TITLE
addStyle 代碼修正

### DIFF
--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -421,7 +421,7 @@ export function proxyContext(global: any, context: any, thisContext?: { [key: st
 
 export function addStyle(css: string): HTMLElement {
   const dom = document.createElement("style");
-  dom.innerHTML = css;
+  dom.textContent = css;
   if (document.head) {
     return document.head.appendChild(dom);
   }


### PR DESCRIPTION
跟 script 一樣，style元素的內容setter 是textContent (Node值) 而非 innerHTML 。避免內容變形，加速。