### PR TITLE
[release/mv2] Pre-0.16.7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,17 +6,23 @@ on:
       - main
       - release/*
       - dev
+    paths-ignore:
+      - ".github/**"
+      - ".gitignore"
+      - "**.md"
+      - "LICENSE"
+  workflow_dispatch:
 
 jobs:
   build-deploy:
     runs-on: ubuntu-latest
     name: Build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Package with Node
@@ -30,7 +36,7 @@ jobs:
           npm run pack
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: all-artifacts
           path: |
@@ -38,7 +44,7 @@ jobs:
             dist/*.crx
 
       - name: Archive extension
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scriptcat
           path: |

--- a/.github/workflows/packageRelease.yml
+++ b/.github/workflows/packageRelease.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Package with Node

--- a/src/content.ts
+++ b/src/content.ts
@@ -17,10 +17,22 @@ const logger = new LoggerCore({
 
 const scriptFlag = randomString(8);
 
+const fixCoding = (text) => {
+    const toXChar = char => `\\x${char.charCodeAt(0).toString(16).padStart(2, '0')}`;
+    return text.replace(/['"][\x00-\x1F]+['"]/g, match => 
+        match.replace(/[\x00-\x1F]/g, toXChar)
+    ).replace(/\b[a-z]{4,8}:\s*['"]\[(.)-(.)\]['"]/g, (match, start, end) => 
+        match.replace(`${start}-${end}`, `${toXChar(start)}-${toXChar(end)}`)
+    );
+};
+
+const injectJs_ = fixCoding(injectJs);
+
 // 注入运行框架
 const temp = document.createElementNS("http://www.w3.org/1999/xhtml", "script");
 temp.setAttribute("type", "text/javascript");
-temp.innerHTML = `(function (ScriptFlag) {\n${injectJs}\n})('${scriptFlag}')`;
+temp.setAttribute("charset", "UTF-8");
+temp.textContent = `(function (ScriptFlag) {\n${injectJs_}\n})('${scriptFlag}')`;
 temp.className = "injected-js";
 document.documentElement.appendChild(temp);
 temp.remove();

--- a/src/content.ts
+++ b/src/content.ts
@@ -5,7 +5,7 @@ import MessageInternal from "./app/message/internal";
 import ContentRuntime from "./runtime/content/content";
 // @ts-ignore
 import injectJs from "../dist/inject.js";
-import { randomString } from "./pkg/utils/utils";
+import { randomString, fixCoding } from "./pkg/utils/utils";
 
 const internalMessage = new MessageInternal("content");
 
@@ -17,22 +17,13 @@ const logger = new LoggerCore({
 
 const scriptFlag = randomString(8);
 
-const fixCoding = (text) => {
-    const toXChar = char => `\\x${char.charCodeAt(0).toString(16).padStart(2, '0')}`;
-    return text.replace(/['"][\x00-\x1F]+['"]/g, match => 
-        match.replace(/[\x00-\x1F]/g, toXChar)
-    ).replace(/\b[a-z]{4,8}:\s*['"]\[(.)-(.)\]['"]/g, (match, start, end) => 
-        match.replace(`${start}-${end}`, `${toXChar(start)}-${toXChar(end)}`)
-    );
-};
-
-const injectJs_ = fixCoding(injectJs);
+const injectJs1 = fixCoding(injectJs);
 
 // 注入运行框架
 const temp = document.createElementNS("http://www.w3.org/1999/xhtml", "script");
 temp.setAttribute("type", "text/javascript");
 temp.setAttribute("charset", "UTF-8");
-temp.textContent = `(function (ScriptFlag) {\n${injectJs_}\n})('${scriptFlag}')`;
+temp.textContent = `(function (ScriptFlag) {\n${injectJs1}\n})('${scriptFlag}')`;
 temp.className = "injected-js";
 document.documentElement.appendChild(temp);
 temp.remove();

--- a/src/pkg/utils/utils.ts
+++ b/src/pkg/utils/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-control-regex */
 /* eslint-disable import/prefer-default-export */
 /* eslint-disable default-case */
 import LoggerCore from "@App/app/logger/core";
@@ -92,10 +93,7 @@ export function dealScript(source: string): string {
 }
 
 export function isFirefox() {
-  if (navigator.userAgent.indexOf("Firefox") >= 0) {
-    return true;
-  }
-  return false;
+  navigator.userAgent.includes("Firefox");
 }
 
 export function InfoNotification(title: string, msg: string) {
@@ -300,4 +298,16 @@ export function errorMsg(e: any): string {
     return JSON.stringify(e);
   }
   return "";
+}
+
+export function fixCoding(text: string): string {
+  const toXChar = (char: string) =>
+    `\\x${char.charCodeAt(0).toString(16).padStart(2, "0")}`;
+  return text
+    .replace(/['"][\x00-\x1F]+['"]/g, (match) =>
+      match.replace(/[\x00-\x1F]/g, toXChar)
+    )
+    .replace(/\b[a-z]{4,8}:\s*['"]\[(.)-(.)\]['"]/g, (match, start, end) =>
+      match.replace(`${start}-${end}`, `${toXChar(start)}-${toXChar(end)}`)
+    );
 }

--- a/src/pkg/utils/utils.ts
+++ b/src/pkg/utils/utils.ts
@@ -301,8 +301,12 @@ export function errorMsg(e: any): string {
 }
 
 export function fixCoding(text: string): string {
-  const toXChar = (char: string) =>
-    `\\x${char.charCodeAt(0).toString(16).padStart(2, "0")}`;
+  const toXChar = (char: string) => {
+    const c = char.charCodeAt(0).toString(16);
+    if (c.length <= 2) return `\\x${c.padStart(2, "0")}`;
+    return `\\u${c.padStart(4, "0")}`;
+  };
+
   return text
     .replace(/['"][\x00-\x1F]+['"]/g, (match) =>
       match.replace(/[\x00-\x1F]/g, toXChar)

--- a/src/runtime/background/runtime.ts
+++ b/src/runtime/background/runtime.ts
@@ -457,7 +457,8 @@ export default class Runtime extends Manager {
               code: `(function(){
                 let temp = document.createElementNS("http://www.w3.org/1999/xhtml", "script");
                     temp.setAttribute('type', 'text/javascript');
-                    temp.innerHTML = "${script.code}";
+                    temp.setAttribute('charset', 'UTF-8');
+                    temp.textContent = "${script.code}";
                     temp.className = "injected-js";
                     document.documentElement.appendChild(temp);
                     temp.remove();

--- a/src/runtime/content/content.ts
+++ b/src/runtime/content/content.ts
@@ -52,7 +52,7 @@ export default class ContentRuntime {
         el.setAttribute(key, attr[key]);
       });
       if (textContent) {
-        el.innerHTML = textContent;
+        el.textContent = textContent;
       }
       let parentNode;
       if (data.relatedTarget) {

--- a/src/runtime/content/utils.ts
+++ b/src/runtime/content/utils.ts
@@ -371,7 +371,7 @@ export function proxyContext(
 
 export function addStyle(css: string): HTMLElement {
   const dom = document.createElement("style");
-  dom.innerHTML = css;
+  dom.textContent = css;
   if (document.head) {
     return document.head.appendChild(dom);
   }


### PR DESCRIPTION
* 更新 Workflow Actions (v3 -> v4), 增加 `workflow_dispatch`. 與MV3一致
* script/style元素 `innerHTML` -> `textContent` ( 見 https://github.com/scriptscat/scriptcat/pull/463 ，https://github.com/scriptscat/scriptcat/pull/500 )
* 0.10.0 時加進了一堆代碼。其中一些依存包括了一堆非ASCII的依存垃圾代碼。

    ```
                const Jt = {
                        arab: "[٠-٩]",
                        arabext: "[۰-۹]",
                        bali: "[᭐-᭙]",
                        beng: "[০-৯]",
                        deva: "[०-९]",
                        fullwide: "[０-９]",
                        gujr: "[૦-૯]",
                        hanidec: "[〇|一|二|三|四|五|六|七|八|九]",
                        khmr: "[០-៩]",
                        knda: "[೦-೯]",
                        laoo: "[໐-໙]",
                        limb: "[᥆-᥏]",
                        mlym: "[൦-൯]",
                        mong: "[᠐-᠙]",
                        mymr: "[၀-၉]",
                        orya: "[୦-୯]",
                        tamldec: "[௦-௯]",
                        telu: "[౦-౯]",
                        thai: "[๐-๙]",
                        tibt: "[༠-༩]",
                        latn: "\\d",
                    },
    ```

       

    ```

            const Mo = "\ufeff",
                Co = "",
                Do = "",
                $o = "",
                Lo = (e) => !!e && "items" in e,
                Ro = (e) => !!e && ("scalar" === e.type || "single-quoted-scalar" === e.type || "double-quoted-scalar" === e.type || "block-scalar" === e.type);
            function Po(e) {

    ```

        0.16.7 打包工具未把非ASCII替換。

* 所有 `injected-js` 強制UTF-8編碼 (ScriptCat 打包編碼是UTF-8), 不依隨頁面代碼編碼。

* Close #352