### PR TITLE
GM注入优化

### DIFF
--- a/src/app/repo/scripts.ts
+++ b/src/app/repo/scripts.ts
@@ -79,7 +79,6 @@ export interface ScriptRunResource extends Script {
   value: { [key: string]: any };
   flag: string;
   resource: { [key: string]: Resource };
-  testMode?: boolean
 }
 
 export class ScriptDAO extends Repo<Script> {

--- a/src/app/repo/scripts.ts
+++ b/src/app/repo/scripts.ts
@@ -79,6 +79,7 @@ export interface ScriptRunResource extends Script {
   value: { [key: string]: any };
   flag: string;
   resource: { [key: string]: Resource };
+  testMode?: boolean
 }
 
 export class ScriptDAO extends Repo<Script> {

--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -6,7 +6,7 @@ import { GMContextApiGet } from "./gm_context";
 import { GM_Base } from "./gm_api";
 
 // 构建沙盒上下文
-export function createContext(scriptRes: ScriptRunResource, GMInfo: any, envPrefix: string, message: Message, grantSet: Set<string>): GM_Base {
+export function createContext(scriptRes: ScriptRunResource, GMInfo: any, envPrefix: string, message: Message, grantSet: Set<string>) {
   // 按照GMApi构建
   const valueChangeListener = new Map<number, { name: string; listener: GMTypes.ValueChangeListener }>();
   const EE: EventEmitter = new EventEmitter();
@@ -74,5 +74,5 @@ export function createContext(scriptRes: ScriptRunResource, GMInfo: any, envPref
   //   }
   // }
   context.unsafeWindow = window;
-  return <GM_Base>context;
+  return context;
 }

--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -1,38 +1,21 @@
 import { type ScriptRunResource } from "@App/app/repo/scripts";
 import { v4 as uuidv4 } from "uuid";
-import type { ApiValue } from "./types";
 import type { Message } from "@Packages/message/types";
 import EventEmitter from "eventemitter3";
 import { GMContextApiGet } from "./gm_context";
 import { GM_Base } from "./gm_api";
 
-// 设置api依赖
-function setDepend(context: { [key: string]: any }, apiVal: ApiValue) {
-  if (apiVal.param.depend) {
-    for (let i = 0; i < apiVal.param.depend.length; i += 1) {
-      const value = apiVal.param.depend[i];
-      const dependApi = GMContextApiGet(value);
-      if (!dependApi) {
-        return;
-      }
-      if (value.startsWith("GM.")) {
-        const [, t] = value.split(".");
-        (<{ [key: string]: any }>context.GM)[t] = dependApi.api.bind(context);
-      } else {
-        context[value] = dependApi.api.bind(context);
-      }
-      setDepend(context, dependApi);
-    }
-  }
-}
-
 // 构建沙盒上下文
-export function createContext(scriptRes: ScriptRunResource, GMInfo: any, envPrefix: string, message: Message): GM_Base {
+export function createContext(scriptRes: ScriptRunResource, GMInfo: any, envPrefix: string, message: Message, grantSet: Set<string>): GM_Base {
   // 按照GMApi构建
   const valueChangeListener = new Map<number, { name: string; listener: GMTypes.ValueChangeListener }>();
   const EE: EventEmitter = new EventEmitter();
-  const context: GM_Base & { [key: string]: any } = new GM_Base(envPrefix, message, scriptRes, valueChangeListener, EE);
-  Object.assign(context, {
+  const context = GM_Base.create({
+    prefix: envPrefix,
+    message,
+    scriptRes,
+    valueChangeListener,
+    EE,
     runFlag: uuidv4(),
     eventId: 10000,
     GM: { info: GMInfo },
@@ -40,73 +23,55 @@ export function createContext(scriptRes: ScriptRunResource, GMInfo: any, envPref
     window: {
       onurlchange: null,
     },
-  });
-  if (scriptRes.metadata.grant) {
-    const GM_cookie = function (action: string) {
-      return (
-        details: GMTypes.CookieDetails,
-        done: (cookie: GMTypes.Cookie[] | any, error: any | undefined) => void
-      ) => {
-        return context["GM_cookie"](action, details, done);
-      };
-    };
-    // 处理GM.与GM_，将GM_与GM.都复制一份
-    const grant: string[] = [];
-    scriptRes.metadata.grant.forEach((val) => {
-      if (val.startsWith("GM_")) {
-        const t = val.slice(3);
-        grant.push(`GM.${t}`);
-      } else if (val.startsWith("GM.")) {
-        grant.push(val);
-      }
-      grant.push(val);
-    });
-    // 去重
-    const uniqueGrant = new Set(grant);
-    uniqueGrant.forEach((val) => {
-      const api = GMContextApiGet(val);
-      if (!api) {
-        return;
-      }
-      if (/^(GM|window)\./.test(val)) {
-        const [n, t] = val.split(".");
-        if (t === "cookie") {
-          const createGMCookePromise = (action: string) => {
-            return (details: GMTypes.CookieDetails = {}) => {
-              return new Promise((resolve, reject) => {
-                const fn = GM_cookie(action);
-                fn(details, function (cookie, error) {
-                  if (error) {
-                    reject(error);
-                  } else {
-                    resolve(cookie);
-                  }
-                });
-              });
-            };
-          };
-          context[n][t] = {
-            list: createGMCookePromise("list"),
-            delete: createGMCookePromise("delete"),
-            set: createGMCookePromise("set"),
-          };
-          context["GM_cookie"] = api.api.bind(context);
-        } else {
-          (<{ [key: string]: any }>context[n])[t] = api.api.bind(context);
+    __methodInject__(grant: string): boolean {
+      const grantSet = this.grantSet || (this.grantSet = new Set());
+      const s = GMContextApiGet(grant);
+      if (!s) return false; // @grant 的定义未实作，略过 (返回 false 表示 @grant 不存在)
+      if (grantSet.has(grant)) return true; // 重覆的@grant，略过 (返回 true 表示 @grant 存在)
+      grantSet.add(grant);
+      for (const t of s) {
+        const fnKeyArray = t.fnKey.split('.');
+        const m = fnKeyArray.length - 1;
+        let g = context;
+        for (let i = 0; i < m; i++) {
+          const part = fnKeyArray[i];
+          g = g[part] || (g[part] = {});
         }
-      } else if (val === "GM_cookie") {
-        // 特殊处理GM_cookie.list之类
-        context[val] = api.api.bind(context);
-
-        context[val].list = GM_cookie("list");
-        context[val].delete = GM_cookie("delete");
-        context[val].set = GM_cookie("set");
-      } else {
-        context[val] = api.api.bind(context);
+        const finalPart = fnKeyArray[m];
+        if (g[finalPart]) continue;
+        g[finalPart] = t.api.bind(this);
+        const depend = t?.param?.depend;
+        if (depend) {
+          for (const grant of depend) {
+            this.__methodInject__(grant);
+          }
+        }
       }
-      setDepend(context, api);
-    });
+      return true;
+    }
+  });
+  for (const grant of grantSet) {
+    context.__methodInject__(grant);
   }
+  // if (scriptRes.metadata.grant) {
+  //   // 处理GM.与GM_，将GM_与GM.都复制一份
+  //   const grant: string[] = [];
+  //   scriptRes.metadata.grant.forEach((val) => {
+  //     // if (val.startsWith("GM_")) {
+  //     //   const t = val.slice(3);
+  //     //   grant.push(`GM.${t}`);
+  //     // } else if (val.startsWith("GM.")) {
+  //     //   grant.push(val);
+  //     // }
+  //     // grant.push(val);
+  //     grant.push(val);
+  //   });
+  //   // 去重
+  //   const uniqueGrant = new Set(grant);
+  //   for(const grant of uniqueGrant){
+  //     context.__methodInject__(grant);
+  //   }
+  // }
   context.unsafeWindow = window;
   return <GM_Base>context;
 }

--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -6,7 +6,13 @@ import { GMContextApiGet } from "./gm_context";
 import { GM_Base } from "./gm_api";
 
 // 构建沙盒上下文
-export function createContext(scriptRes: ScriptRunResource, GMInfo: any, envPrefix: string, message: Message, grantSet: Set<string>) {
+export function createContext(
+  scriptRes: ScriptRunResource,
+  GMInfo: any,
+  envPrefix: string,
+  message: Message,
+  scriptGrants: Set<string>
+) {
   // 按照GMApi构建
   const valueChangeListener = new Map<number, { name: string; listener: GMTypes.ValueChangeListener }>();
   const EE: EventEmitter = new EventEmitter();
@@ -23,7 +29,7 @@ export function createContext(scriptRes: ScriptRunResource, GMInfo: any, envPref
     window: {
       onurlchange: null,
     },
-    grantSet: new Set()
+    grantSet: new Set(),
   });
   const __methodInject__ = (grant: string): boolean => {
     const grantSet: Set<string> = context.grantSet;
@@ -32,7 +38,7 @@ export function createContext(scriptRes: ScriptRunResource, GMInfo: any, envPref
     if (grantSet.has(grant)) return true; // 重覆的@grant，略过 (返回 true 表示 @grant 存在)
     grantSet.add(grant);
     for (const t of s) {
-      const fnKeyArray = t.fnKey.split('.');
+      const fnKeyArray = t.fnKey.split(".");
       const m = fnKeyArray.length - 1;
       let g = context;
       for (let i = 0; i < m; i++) {
@@ -50,29 +56,10 @@ export function createContext(scriptRes: ScriptRunResource, GMInfo: any, envPref
       }
     }
     return true;
-  }
-  for (const grant of grantSet) {
+  };
+  for (const grant of scriptGrants) {
     __methodInject__(grant);
   }
-  // if (scriptRes.metadata.grant) {
-  //   // 处理GM.与GM_，将GM_与GM.都复制一份
-  //   const grant: string[] = [];
-  //   scriptRes.metadata.grant.forEach((val) => {
-  //     // if (val.startsWith("GM_")) {
-  //     //   const t = val.slice(3);
-  //     //   grant.push(`GM.${t}`);
-  //     // } else if (val.startsWith("GM.")) {
-  //     //   grant.push(val);
-  //     // }
-  //     // grant.push(val);
-  //     grant.push(val);
-  //   });
-  //   // 去重
-  //   const uniqueGrant = new Set(grant);
-  //   for(const grant of uniqueGrant){
-  //     context.__methodInject__(grant);
-  //   }
-  // }
   context.unsafeWindow = window;
   return context;
 }

--- a/src/app/service/content/exec_script.test.ts
+++ b/src/app/service/content/exec_script.test.ts
@@ -53,7 +53,7 @@ describe("GM_info", () => {
     const ret = await noneExec.exec();
     expect(ret.GM_info.version).toEqual(ExtVersion);
     expect(ret.GM_info.script.version).toEqual("1.0.0");
-    expect(ret._this).toEqual({});
+    expect(ret._this).toEqual(global);
   });
   it("sandbox", async () => {
     scriptRes2.code = "return {_this:this,GM_info};";

--- a/src/app/service/content/exec_script.test.ts
+++ b/src/app/service/content/exec_script.test.ts
@@ -18,7 +18,6 @@ const scriptRes = {
   code: "console.log('test')",
   sourceCode: "sourceCode",
   value: {},
-  testMode: true,
 } as unknown as ScriptRunResource;
 const envInfo: GMInfoEnv = {
   sandboxMode: "raw",
@@ -42,7 +41,6 @@ const scriptRes2 = {
   code: "console.log('test')",
   sourceCode: "sourceCode",
   value: {},
-  testMode: true,
 } as unknown as ScriptRunResource;
 
 // @ts-ignore

--- a/src/app/service/content/exec_script.test.ts
+++ b/src/app/service/content/exec_script.test.ts
@@ -63,7 +63,7 @@ describe("GM_info", () => {
     const ret = await sandboxExec.exec();
     expect(ret.GM_info.version).toEqual(ExtVersion);
     expect(ret.GM_info.script.version).toEqual("1.0.0");
-    expect(ret._this).not.toEqual({});
+    expect(ret._this).toEqual(sandboxExec.proxyContent);
   });
 });
 

--- a/src/app/service/content/exec_script.test.ts
+++ b/src/app/service/content/exec_script.test.ts
@@ -20,6 +20,7 @@ const scriptRes = {
   grantMap: {
     none: true,
   },
+  testMode: true
 } as unknown as ScriptRunResource;
 const envInfo: GMInfoEnv = {
   sandboxMode: "raw",
@@ -44,6 +45,7 @@ const scriptRes2 = {
   sourceCode: "sourceCode",
   value: {},
   grantMap: {},
+  testMode: true
 } as unknown as ScriptRunResource;
 
 // @ts-ignore

--- a/src/app/service/content/exec_script.test.ts
+++ b/src/app/service/content/exec_script.test.ts
@@ -32,7 +32,7 @@ const envInfo: GMInfoEnv = {
 };
 
 // @ts-ignore
-const noneExec = new ExecScript(scriptRes, undefined, undefined, undefined, envInfo, undefined);
+const noneExec = new ExecScript(scriptRes, undefined, undefined, undefined, envInfo);
 
 const scriptRes2 = {
   id: 0,
@@ -47,7 +47,7 @@ const scriptRes2 = {
 } as unknown as ScriptRunResource;
 
 // @ts-ignore
-const sandboxExec = new ExecScript(scriptRes2, undefined, undefined, undefined, envInfo, undefined);
+const sandboxExec = new ExecScript(scriptRes2, undefined, undefined, undefined, envInfo);
 
 describe("GM_info", () => {
   it("none", async () => {

--- a/src/app/service/content/exec_script.test.ts
+++ b/src/app/service/content/exec_script.test.ts
@@ -135,7 +135,15 @@ describe("this", () => {
     sandboxExec.scriptFunc = compileScript(compileScriptCode(scriptRes2));
     const ret = await sandboxExec.exec();
     expect(ret).toEqual(expect.any(Function));
-    // this.onload 不会影响 global.onload
+    // global.onload
+    expect(global.onload).toBeNull();
+  });
+  it("this.onload", async () => {
+    scriptRes2.code = `this.onload = () => "ok"; return this.onload;`;
+    sandboxExec.scriptFunc = compileScript(compileScriptCode(scriptRes2));
+    const ret = await sandboxExec.exec();
+    expect(ret).toEqual(expect.any(Function));
+    // global.onload
     expect(global.onload).toBeNull();
   });
   it("undefined variable", async () => {
@@ -155,5 +163,23 @@ describe("this", () => {
     } catch (e: any) {
       expect(e.message).toContain("testVar is not defined");
     }
+  });
+});
+
+describe("none this", () => {
+  it("onload", async () => {
+    scriptRes2.code = `onload = ()=>{};return onload;`;
+    noneExec.scriptFunc = compileScript(compileScriptCode(scriptRes2));
+    const ret = await noneExec.exec();
+    expect(ret).toEqual(expect.any(Function));
+    // global.onload
+    expect(global.onload).toEqual(expect.any(Function));
+    global.onload = null; // 清理全局变量
+  });
+  it("this.test", async () => {
+    scriptRes2.code = `this.test = "ok";return this.test;`;
+    noneExec.scriptFunc = compileScript(compileScriptCode(scriptRes2));
+    const ret = await noneExec.exec();
+    expect(ret).toEqual("ok");
   });
 });

--- a/src/app/service/content/exec_script.ts
+++ b/src/app/service/content/exec_script.ts
@@ -44,16 +44,13 @@ export default class ExecScript {
     } else {
       this.scriptFunc = code;
     }
-    const grantMap: { [key: string]: boolean } = {};
-    scriptRes.metadata.grant?.forEach((key) => {
-      grantMap[key] = true;
-    });
-    if (grantMap.none) {
+    const grantSet = new Set(scriptRes.metadata.grant || []);
+    if (grantSet.has('none')) {
       // 不注入任何GM api
       this.proxyContent = global;
     } else {
       // 构建脚本GM上下文
-      this.sandboxContent = createContext(scriptRes, this.GM_info, envPrefix, message);
+      this.sandboxContent = createContext(scriptRes, this.GM_info, envPrefix, message, grantSet);
       this.proxyContent = proxyContext(global, this.sandboxContent, thisContext);
     }
   }

--- a/src/app/service/content/exec_script.ts
+++ b/src/app/service/content/exec_script.ts
@@ -7,7 +7,7 @@ import type { Message } from "@Packages/message/types";
 import type { ScriptLoadInfo } from "../service_worker/types";
 import type { ValueUpdateData } from "./types";
 import { evaluateGMInfo } from "./gm_info";
-import { type GM_Base } from "./gm_api";
+import { type IGM_Base } from "./gm_api";
 
 // 执行脚本,控制脚本执行与停止
 export default class ExecScript {
@@ -19,7 +19,7 @@ export default class ExecScript {
 
   proxyContent: any;
 
-  sandboxContent?: GM_Base;
+  sandboxContent?: IGM_Base;
 
   GM_info: any;
 

--- a/src/app/service/content/exec_script.ts
+++ b/src/app/service/content/exec_script.ts
@@ -28,8 +28,8 @@ export default class ExecScript {
     envPrefix: "content" | "offscreen",
     message: Message,
     code: string | ScriptFunc,
-    envInfo: GMInfoEnv, 
-    globalInjection?: {[key:string]:any} // 主要是全域API. @grant none 时无效
+    envInfo: GMInfoEnv,
+    globalInjection?: { [key: string]: any } // 主要是全域API. @grant none 时无效
   ) {
     this.scriptRes = scriptRes;
     this.logger = LoggerCore.getInstance().logger({
@@ -45,7 +45,7 @@ export default class ExecScript {
       this.scriptFunc = code;
     }
     const grantSet = new Set(scriptRes.metadata.grant || []);
-    if (grantSet.has('none')) {
+    if (grantSet.has("none")) {
       // 不注入任何GM api
       this.proxyContent = global;
     } else {
@@ -69,7 +69,7 @@ export default class ExecScript {
 
   /**
    * @see {@link compileScriptCode}
-   * @returns 
+   * @returns
    */
   exec() {
     this.logger.debug("script start");

--- a/src/app/service/content/gm_api.ts
+++ b/src/app/service/content/gm_api.ts
@@ -255,8 +255,8 @@ export class GM_Base implements IGM_Base {
   // @GMContext.protected()
   // protected protect!: any;
 
-  @GMContext.protected()
-  public __methodInject__!: any;
+  // @GMContext.protected()
+  // public __methodInject__!: any;
 
   @GMContext.protected()
   public context!: any;

--- a/src/app/service/content/gm_api.ts
+++ b/src/app/service/content/gm_api.ts
@@ -267,23 +267,20 @@ export class GM_Base implements IGM_Base {
   @GMContext.protected()
   public eventId!: number;
 
-  @GMContext.protected()
-  public integrity!: any;
+  // @GMContext.protected()
+  // public integrity!: any;
 
   constructor(
-    options: any = null
+    options: any = null,
+    obj: any = null
   ) {
-
-    if(options?.integrity !== integrity) throw new TypeError("Illegal invocation");
-
+    if(obj !== integrity) throw new TypeError("Illegal invocation");
     Object.assign(this, options);
-
   }
 
   @GMContext.protected()
   static create(options: { [key:string]: any}){
-    options.integrity = integrity;
-    return (new GM_Base(options)) as GM_Base & { [key:string]: any };
+    return (new GM_Base(options, integrity)) as GM_Base & { [key:string]: any };
   }
 
   // 单次回调使用
@@ -371,13 +368,12 @@ export default class GMApi extends GM_Base {
     const valueChangeListener = new Map<number, { name: string; listener: GMTypes.ValueChangeListener }>();
     const EE: EventEmitter = new EventEmitter();
     super({
-      integrity,
       prefix,
       message,
       scriptRes,
       valueChangeListener,
       EE
-    });
+    }, integrity);
   }
 
   // 获取脚本的值,可以通过@storageName让多个脚本共享一个储存空间

--- a/src/app/service/content/gm_api.ts
+++ b/src/app/service/content/gm_api.ts
@@ -252,12 +252,6 @@ export class GM_Base implements IGM_Base {
   @GMContext.protected()
   protected EE!: EventEmitter;
 
-  // @GMContext.protected()
-  // protected protect!: any;
-
-  // @GMContext.protected()
-  // public __methodInject__!: any;
-
   @GMContext.protected()
   public context!: any;
 
@@ -266,9 +260,6 @@ export class GM_Base implements IGM_Base {
 
   @GMContext.protected()
   public eventId!: number;
-
-  // @GMContext.protected()
-  // public integrity!: any;
 
   constructor(
     options: any = null,

--- a/src/app/service/content/gm_api.ts
+++ b/src/app/service/content/gm_api.ts
@@ -19,18 +19,275 @@ export interface IGM_Base {
   emitEvent(event: string, eventId: string, data: any): void;
 }
 
+const integrity = {}; // 僅防止非法实例化
+
+const GM_cookie = (
+  a: IGM_Base,
+  action: string,
+  details: GMTypes.CookieDetails,
+  done: (cookie: GMTypes.Cookie[] | any, error: any | undefined) => void
+) => {
+  // 如果url和域名都没有，自动填充当前url
+  if (!details.url && !details.domain) {
+    details.url = window.location.href;
+  }
+  a.sendMessage("GM_cookie", [action, details])
+    .then((resp: any) => {
+      done && done(resp, undefined);
+    })
+    .catch((err) => {
+      done && done(undefined, err);
+    });
+}
+
+const GM_xmlhttpRequest = function (a: GMApi, details: GMTypes.XHRDetails) {
+
+    const u = new URL(details.url, window.location.href);
+    if (details.headers) {
+      Object.keys(details.headers).forEach((key) => {
+        if (key.toLowerCase() === "cookie") {
+          details.cookie = details.headers![key];
+          delete details.headers![key];
+        }
+      });
+    }
+
+    const param: GMSend.XHRDetails = {
+      method: details.method,
+      timeout: details.timeout,
+      url: u.href,
+      headers: details.headers,
+      cookie: details.cookie,
+      context: details.context,
+      responseType: details.responseType,
+      overrideMimeType: details.overrideMimeType,
+      anonymous: details.anonymous,
+      user: details.user,
+      password: details.password,
+      redirect: details.redirect,
+    };
+    if (!param.headers) {
+      param.headers = {};
+    }
+    if (details.nocache) {
+      param.headers["Cache-Control"] = "no-cache";
+    }
+    let connect: MessageConnect;
+    const handler = async () => {
+      // 处理数据
+      if (details.data instanceof FormData) {
+        // 处理FormData
+        param.dataType = "FormData";
+        const data: Array<GMSend.XHRFormData> = [];
+        const keys: { [key: string]: boolean } = {};
+        details.data.forEach((val, key) => {
+          keys[key] = true;
+        });
+        // 处理FormData中的数据
+        await Promise.all(
+          Object.keys(keys).map((key) => {
+            const values = (<FormData>details.data).getAll(key);
+            return Promise.all(
+              values.map(async (val) => {
+                if (val instanceof File) {
+                  const url = await a.CAT_createBlobUrl(val);
+                  data.push({
+                    key,
+                    type: "file",
+                    val: url,
+                    filename: val.name,
+                  });
+                } else {
+                  data.push({
+                    key,
+                    type: "text",
+                    val,
+                  });
+                }
+              })
+            );
+          })
+        );
+        param.data = data;
+      } else if (details.data instanceof Blob) {
+        // 处理blob
+        param.dataType = "Blob";
+        param.data = await a.CAT_createBlobUrl(details.data);
+      } else {
+        param.data = details.data;
+      }
+
+      // 处理返回数据
+      let readerStream: ReadableStream<Uint8Array> | undefined;
+      let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+      // 如果返回类型是arraybuffer或者blob的情况下,需要将返回的数据转化为blob
+      // 在background通过URL.createObjectURL转化为url,然后在content页读取url获取blob对象
+      const responseType = details.responseType?.toLocaleLowerCase();
+      const warpResponse = (old: (xhr: GMTypes.XHRResponse) => void) => {
+        if (responseType === "stream") {
+          readerStream = new ReadableStream<Uint8Array>({
+            start(ctrl) {
+              controller = ctrl;
+            },
+          });
+        }
+        return async (xhr: GMTypes.XHRResponse) => {
+          if (xhr.response) {
+            if (responseType === "document") {
+              xhr.response = await a.CAT_fetchDocument(<string>xhr.response);
+              xhr.responseXML = xhr.response;
+              xhr.responseType = "document";
+            } else {
+              const resp = await a.CAT_fetchBlob(<string>xhr.response);
+              if (responseType === "arraybuffer") {
+                xhr.response = await resp.arrayBuffer();
+              } else {
+                xhr.response = resp;
+              }
+            }
+          }
+          if (responseType === "stream") {
+            xhr.response = readerStream;
+          }
+          old(xhr);
+        };
+      };
+      if (
+        responseType === "arraybuffer" ||
+        responseType === "blob" ||
+        responseType === "document" ||
+        responseType === "stream"
+      ) {
+        if (details.onload) {
+          details.onload = warpResponse(details.onload);
+        }
+        if (details.onreadystatechange) {
+          details.onreadystatechange = warpResponse(details.onreadystatechange);
+        }
+        if (details.onloadend) {
+          details.onloadend = warpResponse(details.onloadend);
+        }
+        // document类型读取blob,然后在content页转化为document对象
+        if (responseType === "document") {
+          param.responseType = "blob";
+        }
+        if (responseType === "stream") {
+          if (details.onloadstart) {
+            details.onloadstart = warpResponse(details.onloadstart);
+          }
+        }
+      }
+
+      // 发送信息
+      a.connect("GM_xmlhttpRequest", [param]).then((con) => {
+        connect = con;
+        con.onMessage((data: { action: string; data: any }) => {
+          // 处理返回
+          switch (data.action) {
+            case "onload":
+              details.onload?.(data.data);
+              break;
+            case "onloadend":
+              details.onloadend?.(data.data);
+              break;
+            case "onloadstart":
+              details.onloadstart?.(data.data);
+              break;
+            case "onprogress":
+              details.onprogress?.(data.data);
+              break;
+            case "onreadystatechange":
+              details.onreadystatechange && details.onreadystatechange(data.data);
+              break;
+            case "ontimeout":
+              details.ontimeout?.();
+              break;
+            case "onerror":
+              details.onerror?.("");
+              break;
+            case "onabort":
+              details.onabort?.();
+              break;
+            case "onstream":
+              controller?.enqueue(new Uint8Array(data.data));
+              break;
+            default:
+              LoggerCore.logger().warn("GM_xmlhttpRequest resp is error", {
+                data,
+              });
+              break;
+          }
+        });
+      });
+    };
+    // 由于需要同步返回一个abort，但是一些操作是异步的，所以需要在这里处理
+    handler();
+    return {
+      abort: () => {
+        if (connect) {
+          connect.disconnect();
+        }
+      },
+    };
+}
+
+// GM_Base 定义内部用变量和函数。均使用@protected
 export class GM_Base implements IGM_Base {
-  runFlag!: string;
+
+  @GMContext.protected()
+  protected runFlag!: string;
+
+  @GMContext.protected()
+  protected prefix!: string;
+
+  @GMContext.protected()
+  protected message!: Message;
+
+  @GMContext.protected()
+  protected scriptRes!: ScriptRunResource;
+
+  @GMContext.protected()
+  protected valueChangeListener!: Map<number, { name: string; listener: GMTypes.ValueChangeListener }>;
+
+  @GMContext.protected()
+  protected EE!: EventEmitter;
+
+  // @GMContext.protected()
+  // protected protect!: any;
+
+  @GMContext.protected()
+  public __methodInject__!: any;
+
+  @GMContext.protected()
+  public context!: any;
+
+  @GMContext.protected()
+  public grantSet!: any;
+
+  @GMContext.protected()
+  public eventId!: number;
+
+  @GMContext.protected()
+  public integrity!: any;
 
   constructor(
-    public prefix: string,
-    public message: Message,
-    public scriptRes: ScriptRunResource,
-    public valueChangeListener: Map<number, { name: string; listener: GMTypes.ValueChangeListener }>,
-    public EE: EventEmitter
-  ) {}
+    options: any = null
+  ) {
+
+    if(options?.integrity !== integrity) throw new TypeError("Illegal invocation");
+
+    Object.assign(this, options);
+
+  }
+
+  @GMContext.protected()
+  static create(options: { [key:string]: any}){
+    options.integrity = integrity;
+    return (new GM_Base(options)) as GM_Base & { [key:string]: any };
+  }
 
   // 单次回调使用
+  @GMContext.protected()
   public sendMessage(api: string, params: any[]) {
     return sendMessage(this.message, this.prefix + "/runtime/gmApi", {
       uuid: this.scriptRes.uuid,
@@ -41,6 +298,7 @@ export class GM_Base implements IGM_Base {
   }
 
   // 长连接使用,connect只用于接受消息,不发送消息
+  @GMContext.protected()
   public connect(api: string, params: any[]) {
     return connect(this.message, this.prefix + "/runtime/gmApi", {
       uuid: this.scriptRes.uuid,
@@ -50,6 +308,7 @@ export class GM_Base implements IGM_Base {
     } as MessageRequest);
   }
 
+  @GMContext.protected()
   public valueUpdate(data: ValueUpdateData) {
     if (data.uuid === this.scriptRes.uuid || data.storageName === getStorageName(this.scriptRes)) {
       // 触发,并更新值
@@ -68,11 +327,35 @@ export class GM_Base implements IGM_Base {
     }
   }
 
+  @GMContext.protected()
   emitEvent(event: string, eventId: string, data: any) {
     this.EE.emit(event + ":" + eventId, data);
   }
 }
 
+const GM_getValue = (a: GMApi, key: string, defaultValue?: any) => {
+  const ret = a.scriptRes.value[key];
+  if (ret !== undefined) {
+    return ret;
+  }
+  return defaultValue;
+}
+
+const GM_setValue = (a: GMApi, key: string, value: any) => {
+  // 对object的value进行一次转化
+  if (typeof value === "object") {
+    value = JSON.parse(JSON.stringify(value));
+  }
+  if (value === undefined) {
+    delete a.scriptRes.value[key];
+    a.sendMessage("GM_setValue", [key]);
+  } else {
+    a.scriptRes.value[key] = value;
+    a.sendMessage("GM_setValue", [key, value]);
+  }
+}
+
+// GMApi 定义 外部用API函数。不使用@protected
 export default class GMApi extends GM_Base {
   /**
    * <tag, notificationId>
@@ -84,84 +367,78 @@ export default class GMApi extends GM_Base {
     public message: Message,
     public scriptRes: ScriptRunResource
   ) {
+    // testing only
     const valueChangeListener = new Map<number, { name: string; listener: GMTypes.ValueChangeListener }>();
     const EE: EventEmitter = new EventEmitter();
-    super(prefix, message, scriptRes, valueChangeListener, EE);
+    super({
+      integrity,
+      prefix,
+      message,
+      scriptRes,
+      valueChangeListener,
+      EE
+    });
   }
 
   // 获取脚本的值,可以通过@storageName让多个脚本共享一个储存空间
   @GMContext.API()
-  public GM_getValue(key: string, defaultValue?: any) {
-    const ret = this.scriptRes.value[key];
-    if (ret !== undefined) {
-      return ret;
-    }
-    return defaultValue;
+  public ['GM_getValue'](key: string, defaultValue?: any) {
+    return GM_getValue(this, key, defaultValue);
   }
 
-  @GMContext.API({ depend: ["GM_getValue"] })
-  public GMDotGetValue(key: string, defaultValue?: any): Promise<any> {
+  @GMContext.API()
+  public ['GM.getValue'](key: string, defaultValue?: any): Promise<any> {
     // 兼容GM.getValue
     return new Promise((resolve) => {
-      const ret = this.GM_getValue(key, defaultValue);
+      const ret = GM_getValue(this, key, defaultValue);
       resolve(ret);
     });
   }
 
   @GMContext.API()
-  public GM_setValue(key: string, value: any) {
-    // 对object的value进行一次转化
-    if (typeof value === "object") {
-      value = JSON.parse(JSON.stringify(value));
-    }
-    if (value === undefined) {
-      delete this.scriptRes.value[key];
-      this.sendMessage("GM_setValue", [key]);
-    } else {
-      this.scriptRes.value[key] = value;
-      this.sendMessage("GM_setValue", [key, value]);
-    }
+  public ['GM_setValue'](key: string, value: any) {
+    GM_setValue(this, key, value);
   }
 
-  @GMContext.API({ depend: ["GM_setValue"] })
-  public GMDotSetValue(key: string, value: any): Promise<void> {
+  @GMContext.API()
+  public ['GM.setValue'](key: string, value: any): Promise<void> {
     // Asynchronous wrapper for GM_setValue to support GM.setValue
     return new Promise((resolve) => {
-      this.GM_setValue(key, value);
-      resolve();
-    });
-  }
-
-  @GMContext.API({ depend: ["GM_setValue"] })
-  public GM_deleteValue(name: string): void {
-    this.GM_setValue(name, undefined);
-  }
-
-  @GMContext.API({ depend: ["GM_deleteValue"] })
-  public GMDotDeleteValue(name: string): Promise<void> {
-    // Asynchronous wrapper for GM_deleteValue to support GM.deleteValue
-    return new Promise((resolve) => {
-      this.GM_deleteValue(name);
+      GM_setValue(this, key, value);
       resolve();
     });
   }
 
   @GMContext.API()
-  public GM_listValues(): string[] {
+  public ['GM_deleteValue'](name: string): void {
+    GM_setValue(this, name, undefined);
+  }
+
+  @GMContext.API()
+  public ['GM.deleteValue'](name: string): Promise<void> {
+    // Asynchronous wrapper for GM_deleteValue to support GM.deleteValue
+    return new Promise((resolve) => {
+      GM_setValue(this, name, undefined);
+      resolve();
+    });
+  }
+
+  @GMContext.API()
+  public ['GM_listValues'](): string[] {
     return Object.keys(this.scriptRes.value);
   }
 
-  @GMContext.API({ depend: ["GM_listValues"] })
-  public GMDotListValues(): Promise<string[]> {
+  @GMContext.API()
+  public ['GM.listValues'](): Promise<string[]> {
     // Asynchronous wrapper for GM_listValues to support GM.listValues
     return new Promise((resolve) => {
-      const ret = this.GM_listValues();
+      const ret = Object.keys(this.scriptRes.value);
       resolve(ret);
     });
   }
 
-  @GMContext.API({ depend: ["GM_setValue"] })
-  public GM_setValues(values: { [key: string]: any }) {
+  @GMContext.API()
+  public ['GM_setValues'](values: { [key: string]: any }) {
     if (values == null) {
       throw new Error("GM_setValues: values must not be null or undefined");
     }
@@ -170,12 +447,12 @@ export default class GMApi extends GM_Base {
     }
     Object.keys(values).forEach((key) => {
       const value = values[key];
-      return this.GM_setValue(key, value);
+      GM_setValue(this, key, value);
     });
   }
 
-  @GMContext.API({ depend: ["GM_getValue"] })
-  public GM_getValues(keysOrDefaults: { [key: string]: any } | string[] | null | undefined) {
+  @GMContext.API()
+  public ['GM_getValues'](keysOrDefaults: { [key: string]: any } | string[] | null | undefined) {
     if (keysOrDefaults == null) {
       // Returns all values
       return this.scriptRes.value;
@@ -195,7 +472,7 @@ export default class GMApi extends GM_Base {
       // Handle object with default values (e.g., { foo: 1, bar: 2, baz: 3 })
       Object.keys(keysOrDefaults).forEach((key) => {
         const defaultValue = keysOrDefaults[key];
-        result[key] = this.GM_getValue(key, defaultValue);
+        result[key] = GM_getValue(this, key, defaultValue);
       });
     }
     return result;
@@ -203,7 +480,7 @@ export default class GMApi extends GM_Base {
 
   // Asynchronous wrapper for GM.getValues
   @GMContext.API({ depend: ["GM_getValues"] })
-  public GMDotGetValues(
+  public ['GM.getValues'](
     keysOrDefaults: { [key: string]: any } | string[] | null | undefined
   ): Promise<{ [key: string]: any }> {
     return new Promise((resolve) => {
@@ -212,20 +489,20 @@ export default class GMApi extends GM_Base {
     });
   }
 
-  @GMContext.API({ depend: ["GM_deleteValue"] })
-  public GM_deleteValues(keys: string[]) {
+  @GMContext.API()
+  public ['GM_deleteValues'](keys: string[]) {
     if (!Array.isArray(keys)) {
       console.warn(" GM_deleteValues: keys must be string[]");
       return;
     }
     keys.forEach((key) => {
-      this.GM_deleteValue(key);
+      GM_setValue(this, key, undefined);
     });
   }
 
   // Asynchronous wrapper for GM.deleteValues
   @GMContext.API({ depend: ["GM_deleteValues"] })
-  public GMDotDeleteValues(keys: string[]): Promise<void> {
+  public ['GM.deleteValues'](keys: string[]): Promise<void> {
     return new Promise((resolve) => {
       this.GM_deleteValues(keys);
       resolve();
@@ -277,23 +554,78 @@ export default class GMApi extends GM_Base {
     return (<CustomEventMessage>this.message).getAndDelRelatedTarget(data.relatedTarget) as Document;
   }
 
+
+  @GMContext.API({ follow: 'GM.cookie' })
+  ['GM.cookie.set'](
+    details: GMTypes.CookieDetails
+  ) {
+    return new Promise((resolve, reject) => {
+      GM_cookie(this, "set", details, (cookie, error) => {
+        error ? reject(error) : resolve(cookie);
+      });
+    });
+  }
+
+
+
+  @GMContext.API({ follow: 'GM.cookie' })
+  ['GM.cookie.list'](
+    details: GMTypes.CookieDetails
+  ) {
+    return new Promise((resolve, reject) => {
+      GM_cookie(this, "list", details, (cookie, error) => {
+        error ? reject(error) : resolve(cookie);
+      });
+    });
+  }
+
+
+  @GMContext.API({ follow: 'GM.cookie' })
+  ['GM.cookie.delete'](
+    details: GMTypes.CookieDetails
+  ) {
+    return new Promise((resolve, reject) => {
+      GM_cookie(this, "delete", details, (cookie, error) => {
+        error ? reject(error) : resolve(cookie);
+      });
+    });
+  }
+
+
+  @GMContext.API({ follow: 'GM_cookie' })
+  ['GM_cookie.set'](
+    details: GMTypes.CookieDetails,
+    done: (cookie: GMTypes.Cookie[] | any, error: any | undefined) => void
+  ) {
+    GM_cookie(this, "set", details, done);
+  }
+
+
+  @GMContext.API({ follow: 'GM_cookie' })
+  ['GM_cookie.list'](
+    details: GMTypes.CookieDetails,
+    done: (cookie: GMTypes.Cookie[] | any, error: any | undefined) => void
+  ) {
+    GM_cookie(this, "list", details, done);
+  }
+
+
+  @GMContext.API({ follow: 'GM_cookie' })
+  ['GM_cookie.delete'](
+    details: GMTypes.CookieDetails,
+    done: (cookie: GMTypes.Cookie[] | any, error: any | undefined) => void
+  ) {
+    GM_cookie(this, "delete", details, done);
+  }
+
+
   @GMContext.API()
   GM_cookie(
     action: string,
     details: GMTypes.CookieDetails,
     done: (cookie: GMTypes.Cookie[] | any, error: any | undefined) => void
   ) {
-    // 如果url和域名都没有，自动填充当前url
-    if (!details.url && !details.domain) {
-      details.url = window.location.href;
-    }
-    this.sendMessage("GM_cookie", [action, details])
-      .then((resp: any) => {
-        done && done(resp, undefined);
-      })
-      .catch((err) => {
-        done && done(undefined, err);
-      });
+      GM_cookie(this, action, details, done);
   }
 
   @GMContext.API()
@@ -464,193 +796,25 @@ export default class GMApi extends GM_Base {
     depend: ["CAT_fetchBlob", "CAT_createBlobUrl", "CAT_fetchDocument"],
   })
   public GM_xmlhttpRequest(details: GMTypes.XHRDetails) {
-    const u = new URL(details.url, window.location.href);
-    if (details.headers) {
-      Object.keys(details.headers).forEach((key) => {
-        if (key.toLowerCase() === "cookie") {
-          details.cookie = details.headers![key];
-          delete details.headers![key];
-        }
-      });
-    }
-
-    const param: GMSend.XHRDetails = {
-      method: details.method,
-      timeout: details.timeout,
-      url: u.href,
-      headers: details.headers,
-      cookie: details.cookie,
-      context: details.context,
-      responseType: details.responseType,
-      overrideMimeType: details.overrideMimeType,
-      anonymous: details.anonymous,
-      user: details.user,
-      password: details.password,
-      redirect: details.redirect,
-    };
-    if (!param.headers) {
-      param.headers = {};
-    }
-    if (details.nocache) {
-      param.headers["Cache-Control"] = "no-cache";
-    }
-    let connect: MessageConnect;
-    const handler = async () => {
-      // 处理数据
-      if (details.data instanceof FormData) {
-        // 处理FormData
-        param.dataType = "FormData";
-        const data: Array<GMSend.XHRFormData> = [];
-        const keys: { [key: string]: boolean } = {};
-        details.data.forEach((val, key) => {
-          keys[key] = true;
-        });
-        // 处理FormData中的数据
-        await Promise.all(
-          Object.keys(keys).map((key) => {
-            const values = (<FormData>details.data).getAll(key);
-            return Promise.all(
-              values.map(async (val) => {
-                if (val instanceof File) {
-                  const url = await this.CAT_createBlobUrl(val);
-                  data.push({
-                    key,
-                    type: "file",
-                    val: url,
-                    filename: val.name,
-                  });
-                } else {
-                  data.push({
-                    key,
-                    type: "text",
-                    val,
-                  });
-                }
-              })
-            );
-          })
-        );
-        param.data = data;
-      } else if (details.data instanceof Blob) {
-        // 处理blob
-        param.dataType = "Blob";
-        param.data = await this.CAT_createBlobUrl(details.data);
-      } else {
-        param.data = details.data;
-      }
-
-      // 处理返回数据
-      let readerStream: ReadableStream<Uint8Array> | undefined;
-      let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
-      // 如果返回类型是arraybuffer或者blob的情况下,需要将返回的数据转化为blob
-      // 在background通过URL.createObjectURL转化为url,然后在content页读取url获取blob对象
-      const responseType = details.responseType?.toLocaleLowerCase();
-      const warpResponse = (old: (xhr: GMTypes.XHRResponse) => void) => {
-        if (responseType === "stream") {
-          readerStream = new ReadableStream<Uint8Array>({
-            start(ctrl) {
-              controller = ctrl;
-            },
-          });
-        }
-        return async (xhr: GMTypes.XHRResponse) => {
-          if (xhr.response) {
-            if (responseType === "document") {
-              xhr.response = await this.CAT_fetchDocument(<string>xhr.response);
-              xhr.responseXML = xhr.response;
-              xhr.responseType = "document";
-            } else {
-              const resp = await this.CAT_fetchBlob(<string>xhr.response);
-              if (responseType === "arraybuffer") {
-                xhr.response = await resp.arrayBuffer();
-              } else {
-                xhr.response = resp;
-              }
-            }
-          }
-          if (responseType === "stream") {
-            xhr.response = readerStream;
-          }
-          old(xhr);
-        };
-      };
-      if (
-        responseType === "arraybuffer" ||
-        responseType === "blob" ||
-        responseType === "document" ||
-        responseType === "stream"
-      ) {
-        if (details.onload) {
-          details.onload = warpResponse(details.onload);
-        }
-        if (details.onreadystatechange) {
-          details.onreadystatechange = warpResponse(details.onreadystatechange);
-        }
-        if (details.onloadend) {
-          details.onloadend = warpResponse(details.onloadend);
-        }
-        // document类型读取blob,然后在content页转化为document对象
-        if (responseType === "document") {
-          param.responseType = "blob";
-        }
-        if (responseType === "stream") {
-          if (details.onloadstart) {
-            details.onloadstart = warpResponse(details.onloadstart);
-          }
-        }
-      }
-
-      // 发送信息
-      this.connect("GM_xmlhttpRequest", [param]).then((con) => {
-        connect = con;
-        con.onMessage((data: { action: string; data: any }) => {
-          // 处理返回
-          switch (data.action) {
-            case "onload":
-              details.onload?.(data.data);
-              break;
-            case "onloadend":
-              details.onloadend?.(data.data);
-              break;
-            case "onloadstart":
-              details.onloadstart?.(data.data);
-              break;
-            case "onprogress":
-              details.onprogress?.(data.data);
-              break;
-            case "onreadystatechange":
-              details.onreadystatechange && details.onreadystatechange(data.data);
-              break;
-            case "ontimeout":
-              details.ontimeout?.();
-              break;
-            case "onerror":
-              details.onerror?.("");
-              break;
-            case "onabort":
-              details.onabort?.();
-              break;
-            case "onstream":
-              controller?.enqueue(new Uint8Array(data.data));
-              break;
-            default:
-              LoggerCore.logger().warn("GM_xmlhttpRequest resp is error", {
-                data,
-              });
-              break;
-          }
-        });
-      });
-    };
-    // 由于需要同步返回一个abort，但是一些操作是异步的，所以需要在这里处理
-    handler();
-    return {
-      abort: () => {
-        if (connect) {
-          connect.disconnect();
-        }
-      },
-    };
+    return GM_xmlhttpRequest(this, details)
+  }
+  @GMContext.API({
+    depend: ["CAT_fetchBlob", "CAT_createBlobUrl", "CAT_fetchDocument"],
+  })
+  public GM_xmlHttpRequest(details: GMTypes.XHRDetails) {
+    return GM_xmlhttpRequest(this, details)
+  }
+  @GMContext.API({
+    depend: ["CAT_fetchBlob", "CAT_createBlobUrl", "CAT_fetchDocument"],
+  })
+  public ['GM.xmlhttpRequest'](details: GMTypes.XHRDetails) {
+    return GM_xmlhttpRequest(this, details)
+  }
+  @GMContext.API({
+    depend: ["CAT_fetchBlob", "CAT_createBlobUrl", "CAT_fetchDocument"],
+  })
+  public ['GM.xmlHttpRequest'](details: GMTypes.XHRDetails) {
+    return GM_xmlhttpRequest(this, details)
   }
 
   @GMContext.API()
@@ -950,7 +1114,7 @@ export default class GMApi extends GM_Base {
   }
 
   @GMContext.API({ depend: ["GM_getResourceText"] })
-  public GMDotGetResourceText(name: string): Promise<string | undefined> {
+  public ['GM.getResourceText'](name: string): Promise<string | undefined> {
     // Asynchronous wrapper for GM_getResourceText to support GM.getResourceText
     return new Promise((resolve) => {
       const ret = this.GM_getResourceText(name);
@@ -975,7 +1139,7 @@ export default class GMApi extends GM_Base {
 
   // GM_getResourceURL的异步版本，用来兼容GM.getResourceUrl
   @GMContext.API({ depend: ["GM_getResourceURL"] })
-  public GMDotGetResourceUrl(name: string, isBlobUrl?: boolean): Promise<string | undefined> {
+  public ['GM.getResourceUrl'](name: string, isBlobUrl?: boolean): Promise<string | undefined> {
     // Asynchronous wrapper for GM_getResourceURL to support GM.getResourceURL
     return new Promise((resolve) => {
       const ret = this.GM_getResourceURL(name, isBlobUrl);
@@ -984,12 +1148,12 @@ export default class GMApi extends GM_Base {
   }
 
   @GMContext.API()
-  windowDotClose() {
+  ['window.close']() {
     return this.sendMessage("windowDotClose", []);
   }
 
   @GMContext.API()
-  windowDotFocus() {
+  ['window.focus']() {
     return this.sendMessage("windowDotFocus", []);
   }
 }

--- a/src/app/service/content/gm_api.ts
+++ b/src/app/service/content/gm_api.ts
@@ -11,7 +11,15 @@ import type { MessageRequest } from "../service_worker/types";
 import { connect, sendMessage } from "@Packages/message/client";
 import { getStorageName } from "@App/pkg/utils/utils";
 
-export class GM_Base {
+// 内部函数呼叫定义
+export interface IGM_Base {
+  sendMessage(api: string, params: any[]): Promise<any>;
+  connect(api: string, params: any[]): Promise<any>;
+  valueUpdate(data: ValueUpdateData): void;
+  emitEvent(event: string, eventId: string, data: any): void;
+}
+
+export class GM_Base implements IGM_Base {
   runFlag!: string;
 
   constructor(

--- a/src/app/service/content/gm_context.ts
+++ b/src/app/service/content/gm_context.ts
@@ -1,37 +1,37 @@
 import type { ApiParam, ApiValue } from "./types";
 
-const apis: Map<string, ApiValue> = new Map();
+const apis: Map<string, ApiValue[]> = new Map();
 
-export function GMContextApiGet(name: string): ApiValue | undefined {
+export function GMContextApiGet(name: string): ApiValue[] | undefined {
+  // 回傳 Api 列表
   return apis.get(name);
 }
 
-export function GMContextApiSet(name: string, api: any, param: ApiParam): void {
-  apis.set(name, {api, param});
+export function GMContextApiSet(grant: string, fnKey: string, api: any, param: ApiParam): void {
+  // 一个 @grant 可以扩充多个 API 函数
+  let m: ApiValue[] | undefined = apis.get(grant);
+  if (!m) apis.set(grant, m = []);
+  m.push({ fnKey, api, param });
 }
 
+export const protect: { [key: string]: any } = {};
+
 export default class GMContext {
+
+  public static protected(value: any = undefined) {
+    return (target: any, propertyName: string) => {
+      // keyword是与createContext时同步的,避免访问到context的内部变量
+      // 暂时只用於禁止存取（value = undefined)。日后有需要可扩展成假值
+      protect[propertyName] = value;
+    };
+  }
 
   public static API(param: ApiParam = {}) {
     return (target: any, propertyName: string, descriptor: PropertyDescriptor) => {
       const key = propertyName;
-      if (/^(GM|window)Dot/.test(key)) {
-        const key = propertyName.replace(/^(GM|window)Dot(.)/, (_, a, b) => `${a}.${b.toLowerCase()}`);
-        GMContextApiSet(key, descriptor.value, param);
-        return;
-      }
-      GMContextApiSet(key, descriptor.value, param);
-      // 兼容GM.*
-      let dot = key.replace("_", ".");
-      if (dot !== key) {
-        // 特殊处理GM.*一些大小写不一致的情况
-        switch (dot) {
-          case "GM.xmlhttpRequest":
-            dot = "GM.xmlHttpRequest";
-            break;
-        }
-        GMContextApiSet(dot, descriptor.value, param);
-      }
+      let { follow } = param;
+      if (!follow) follow = key; // follow 是实际 @grant 的权限
+      GMContextApiSet(follow, key, descriptor.value, param);
     };
   }
 }

--- a/src/app/service/content/types.ts
+++ b/src/app/service/content/types.ts
@@ -1,6 +1,6 @@
 // types
 
-export type ScriptFunc = (context: any, GM_info: any) => any;
+export type ScriptFunc = (context: { [key: string]: any }, scriptName: string) => any;
 
 // exec_script.ts
 

--- a/src/app/service/content/types.ts
+++ b/src/app/service/content/types.ts
@@ -1,6 +1,6 @@
 // types
 
-export type ScriptFunc = (context: { [key: string]: any }, scriptName: string) => any;
+export type ScriptFunc = (named: { [key: string]: any } | undefined, scriptName: string) => any;
 
 // exec_script.ts
 

--- a/src/app/service/content/types.ts
+++ b/src/app/service/content/types.ts
@@ -21,10 +21,12 @@ export type ValueUpdateData = {
 // gm_api.ts
 
 export interface ApiParam {
+  follow?: string;
   depend?: string[];
 }
 
 export interface ApiValue {
+  fnKey: string;
   api: any;
   param: ApiParam;
 }

--- a/src/app/service/content/utils.test.ts
+++ b/src/app/service/content/utils.test.ts
@@ -62,7 +62,7 @@ describe("window", () => {
 });
 
 describe("兼容问题", () => {
-  const _this = proxyContext({}, {});
+  const _this = proxyContext<{ [key: string]: any }>({}, {});
   // https://github.com/xcanwin/KeepChatGPT 环境隔离得不够干净导致的
   it("Uncaught TypeError: Illegal invocation #189", () => {
     return new Promise((resolve) => {
@@ -77,7 +77,7 @@ describe("兼容问题", () => {
 });
 
 describe("Symbol", () => {
-  const _this = proxyContext({}, {});
+  const _this = proxyContext<{ [key: string]: any } & any>({}, {});
   // 允许往global写入Symbol属性,影响内容: https://bbs.tampermonkey.net.cn/thread-5509-1-1.html
   it("Symbol", () => {
     const s = Symbol("test");
@@ -92,7 +92,7 @@ describe("Symbol", () => {
 
 // Object.hasOwnProperty穿透 https://github.com/scriptscat/scriptcat/issues/272
 describe("Object", () => {
-  const _this = proxyContext({}, {});
+  const _this = proxyContext<{ [key: string]: any }>({}, {});
   it("hasOwnProperty", () => {
     expect(Object.prototype.hasOwnProperty.call(_this, "test1")).toEqual(false);
     _this.test1 = "ok";

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -1,7 +1,18 @@
 import type { ScriptRunResource } from "@App/app/repo/scripts";
 
-import { has } from "@App/pkg/utils/lodash";
 import type { ScriptFunc } from "./types";
+
+// undefined 和 null 以外，使用 hasOwnProperty 检查
+// 不使用 != 避免类型转换比较
+const has = (object: any, key: any) => {
+  switch (object) {
+    case undefined:
+    case null:
+      return false;
+    default:
+      return Object.prototype.hasOwnProperty.call(object, key);
+  }
+}
 
 // 构建脚本运行代码
 export function compileScriptCode(scriptRes: ScriptRunResource, scriptCode?: string): string {
@@ -210,9 +221,9 @@ export function proxyContext(global: any, context: any, thisContext?: { [key: st
           return true;
         case "top":
         case "parent":
-          if (global[name] === global.self) {
-            return true;
-          }
+          // if (global[name] === global.self) {
+          //   return true;
+          // }
           return true;
         default:
           break;
@@ -266,13 +277,14 @@ export function proxyContext(global: any, context: any, thisContext?: { [key: st
         }
         // 只处理onxxxx的事件
         if (has(global, name) && name.startsWith("on")) {
+          const eventName = name.slice(2);
           if (val === undefined) {
-            global.removeEventListener(name.slice(2), thisContext[name]);
+            global.removeEventListener(eventName, thisContext[name]);
           } else {
             if (thisContext[name]) {
-              global.removeEventListener(name.slice(2), thisContext[name]);
+              global.removeEventListener(eventName, thisContext[name]);
             }
-            global.addEventListener(name.slice(2), val);
+            global.addEventListener(eventName, val);
           }
           thisContext[name] = val;
           return true;

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -60,6 +60,16 @@ export function compileScriptCode(scriptRes: ScriptRunResource, scriptCode?: str
 // } catch (e) {
 //   arguments[2](e);
 // }`;
+
+  if (scriptRes.testMode) {
+    // 测试时需要回传值
+    return `with(arguments[0]){
+${preCode}
+return (function(){
+${code}
+})();
+}`;
+  }
   return `with(arguments[0]){
 ${preCode}
 [((async function(){

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -1,6 +1,7 @@
 import type { ScriptRunResource } from "@App/app/repo/scripts";
 
 import type { ScriptFunc } from "./types";
+import { protect } from "./gm_context";
 
 // undefined 和 null 以外，使用 hasOwnProperty 检查
 // 不使用 != 避免类型转换比较
@@ -136,16 +137,6 @@ export function proxyContext(global: any, context: any, thisContext?: { [key: st
   thisContext.eval = global.eval;
   thisContext.define = undefined;
   warpObject(thisContext, special, global, context);
-  // keyword是与createContext时同步的,避免访问到context的内部变量
-  const contextKeyword: { [key: string]: any } = {
-    message: 1,
-    valueChangeListener: 1,
-    connect: 1,
-    runFlag: 1,
-    valueUpdate: 1,
-    sendMessage: 1,
-    scriptRes: 1,
-  };
   // @ts-ignore
   const proxy = new Proxy(context, {
     defineProperty(_, name, desc) {
@@ -180,7 +171,7 @@ export function proxyContext(global: any, context: any, thisContext?: { [key: st
         }
         if (typeof name === "string") {
           if (has(context, name)) {
-            if (has(contextKeyword, name)) {
+            if (has(protect, name)) {
               return undefined;
             }
             return context[name];
@@ -237,7 +228,7 @@ export function proxyContext(global: any, context: any, thisContext?: { [key: st
             return true;
           }
           if (has(context, name)) {
-            if (has(contextKeyword, name)) {
+            if (has(protect, name)) {
               return false;
             }
             return true;

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -72,10 +72,9 @@ export function compileScript(code: string): ScriptFunc {
  */
 export function compileInjectScript(
   script: ScriptRunResource,
-  scriptCode?: string,
+  scriptCode: string,
   autoDeleteMountFunction: boolean = false
 ): string {
-  scriptCode = scriptCode ?? script.code;
   const autoDeleteMountCode = autoDeleteMountFunction ? `try{delete window['${script.flag}']}catch(e){}` : "";
   return `window['${script.flag}'] = function(){${autoDeleteMountCode}${scriptCode}}`;
 }

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -46,9 +46,9 @@ export function compileScriptCode(scriptRes: ScriptRunResource, scriptCode?: str
   return `try {
   with(this){
     ${preCode}
-    return (async function({GM,GM_info}){
+    return (async({GM,GM_info})=>{
     ${code}
-    }).call(this,arguments[0]||{GM,GM_info});
+    })(arguments[0]||{GM,GM_info});
   }
 } catch (e) {
   if (e.message && e.stack) {

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -48,7 +48,7 @@ export function compileScriptCode(scriptRes: ScriptRunResource, scriptCode?: str
     ${preCode}
     return (async function({GM,GM_info}){
     ${code}
-    })(arguments[0]||{GM,GM_info});
+    }).call(this,arguments[0]||{GM,GM_info});
   }
 } catch (e) {
   if (e.message && e.stack) {

--- a/src/app/service/service_worker/client.ts
+++ b/src/app/service/service_worker/client.ts
@@ -110,7 +110,7 @@ export class ScriptClient extends Client {
             return json;
           });
         const { code, data, msg } = scriptInfo;
-        if (code != 0) {
+        if (code !== 0) {
           // 无脚本访问权限
           return { success: false, msg };
         } else {

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -711,7 +711,7 @@ export class RuntimeService {
       return undefined;
     }
 
-    scriptRes.code = compileInjectScript(scriptRes);
+    scriptRes.code = compileInjectScript(scriptRes, scriptRes.code);
 
     const patternMatches = dealPatternMatches(matches);
     const scriptMatchInfo: ScriptMatchInfo = Object.assign(

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -458,7 +458,7 @@ export class RuntimeService {
                 return resourceUri;
               }
             })
-            .filter((it) => it != null)
+            .filter((it) => it !== undefined)
         );
       }
       return uriList.some((uri) => {
@@ -497,7 +497,7 @@ export class RuntimeService {
             }
           })
         )
-      ).filter((it) => it != null);
+      ).filter((it) => it !== undefined);
       // 批量更新
       if (scriptRegisterInfoList.length) {
         try {

--- a/src/pkg/utils/lodash.ts
+++ b/src/pkg/utils/lodash.ts
@@ -1,6 +1,0 @@
-// 因为这个包出过好几次问题, 从原仓库单独剥离出来使用
-// copyright: https://github.com/lodash/lodash
-
-export function has(object: any, key: any) {
-  return object != null && Object.prototype.hasOwnProperty.call(object, key);
-}


### PR DESCRIPTION
(首先不好意思，没有及时提交，~跟最新的commit会有衝突~）

-----

之前我在改动时发现了以下问题

在脚本裡可以直接存取变量 `EE` （修改后也知道了是手动打这些。手动加漏了吧）
研究 GM API 的行为时，发现depend 会导致脚本裡出现其他API
（例如我们只需要 GM.getValues, 但会连同 GM_getValue 都给了出来）

於是重构了几个相关部份

为了容易看，我把他们分开了5个commit

----

[重构 GM Api 内部代码处理](https://github.com/scriptscat/scriptcat/commit/09cfdf4be4643ba34ca1e7dfaecf194a865daebf)
+
[__methodInject__ 处理内部化](https://github.com/scriptscat/scriptcat/commit/a74e34b489260d13947e05bcf4e8eb6d856a4cba)


这个是弃用以往的做法，会在GMContext那裡直接写好API，而不是各处加一堆特别处理（像cookie)
现在定明，GM.cookie.set 裡面做什麼，当@grant 了什麼权限才会有这个之类

这样除了清楚，方便日后修改外，还减少了一堆 nested function 的效能下降隐藏问题

现在我们用TypeScript，用ESM，通用的我们可以直接抽出来，不用grant来Grant去
我不是全改了。只是常用修改了一下。

当然还保留了 depend 的做法。使用方法不变。见 __methodInject__

针对 `EE` 那些漏掉的问题
现在会在context出现的都要写在 GM_Base, 然后加一个 `@protected`
这样的话，就会自动生成一个 不要外漏的清单

----

[优化注入代码](https://github.com/scriptscat/scriptcat/commit/67d072c651dc69961c895e96db23992789133fb4)

这个改动了Context那个部份

在產生sandbox context 时，直接按protect清单，把context裡的GM或CAT API东西抄到 exposedObject (旧称thisContext)

（终极目标是减少proxy的处理。Proxy用在with上面有效能问题。）

另外，本来是用有名字的变量 `context` 来做Injection. 实际上我们用arguments就好了
arguments只在顶层scope有效。跑code 那裡就不能存取


error 那个我拿走了
因为现在async 设计，async裡的出错也不会被抓到
如果真的发生了问题，瀏览器本身会报错 （有sourceURL能追踪）
所以不用特别加报错处理吧

要注入的东西在生成sandbox就注入
之后的proxy 不要搞这麼多判断

我看不懂之前 ExecScript `.apply`时要把 this 都绑定的理由。现在是改成绑定null. 实际使用也没差别

之前绑定了GM_info. 但这个会在context 给出，应该不用绑定吧
跟TM那些一样。用了 `@grant none`, `GM_info`跟`GM` 也不会有

----


这些就是提交的改动

看不懂再提出。

或者需要修改的地方 （我只使用一般TM腳本，沒使用什麼後台腳本。TM腳本有測試過沒問題）