### PR TITLE
💄 调整 UI

### DIFF
--- a/src/pages/components/layout/Sider.tsx
+++ b/src/pages/components/layout/Sider.tsx
@@ -101,7 +101,7 @@ const Sider: React.FC = () => {
                 key="/external_links"
                 title={
                   <>
-                    <RiLinkM /> {t("external_links")}
+                    <RiLinkM /> <span className="grow">{t("external_links")}</span>
                   </>
                 }
               >

--- a/src/pages/components/layout/index.css
+++ b/src/pages/components/layout/index.css
@@ -9,3 +9,13 @@
 .action-tools>.arco-btn {
     padding: 0 8px;
 }
+
+.arco-dropdown-menu-item,
+.arco-dropdown-menu-item a {
+    display: flex;
+    align-items: center;
+}
+
+:is(.arco-dropdown-menu-pop-header, .arco-dropdown-menu-item, .arco-dropdown-menu-item a) > svg {
+    margin-right: .5em;
+}

--- a/src/pages/import/App.tsx
+++ b/src/pages/import/App.tsx
@@ -57,7 +57,7 @@ const ScriptListItem = React.memo(
                 : t("no_operation"))}
           </span>
         </Space>
-        <div className="flex flex-col justify-between" style={{ minWidth: "80px", textAlign: "center" }}>
+        <div className="flex flex-col justify-center" style={{ minWidth: "80px", textAlign: "center" }}>
           <span className="text-sm color-gray-5">{t("enable_script")}</span>
           <div className="text-center">
             <Switch

--- a/src/pages/popup/App.tsx
+++ b/src/pages/popup/App.tsx
@@ -4,11 +4,11 @@ import {
   IconBook,
   IconBug,
   IconGithub,
-  IconHome,
   IconMoreVertical,
   IconNotification,
   IconPlus,
   IconSearch,
+  IconSettings,
   IconSync,
 } from "@arco-design/web-react/icon";
 import React, { useEffect, useMemo, useState } from "react";
@@ -135,6 +135,7 @@ function App() {
             <div className="flex flex-row items-center">
               <Switch
                 size="small"
+                className="mr-1"
                 checked={isEnableScript}
                 onChange={(val) => {
                   setIsEnableScript(val);
@@ -143,7 +144,7 @@ function App() {
               />
               <Button
                 type="text"
-                icon={<IconHome />}
+                icon={<IconSettings />}
                 iconOnly
                 onClick={() => {
                   // 用a链接的方式,vivaldi竟然会直接崩溃


### PR DESCRIPTION
由于都是细微的调整，所以没有分成多个 PR。

- 把 Popup 中的 `IconHome` 图标替换成 `IconSettings`，和 Violentmonkey、Tampermonkey 保持一致，也和设置界面的 URL（/src/options.html）保持语义上的一致，避免用户误以为是项目主页（<https://docs.scriptcat.org/>）。
- 为 Popup 中的脚本总开关设置 `margin-right`，避免右侧按钮在 `hover` 状态下的 `background` 和开关相连。
- 导入界面的`开启脚本`标签和对应的开关过于分散，反而使前一个 `ScriptListItem` 的开关和后一个 `ScriptListItem` 的标签更加接近，造成视觉上的困惑。
- 修复了“侧边栏 - 帮助中心 - 外部链接”图标和文本间隔过大的问题，并使“帮助中心”下所有菜单项的图标和文本在竖直方向上对齐。
