### PR TITLE
重构MainWorld沙盒proxyContext（效能优化，保持TM沙盒行为）

### DIFF
--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -9,8 +9,8 @@ import { createGMBase } from "./gm_api";
 export function createContext(
   scriptRes: ScriptRunResource,
   GMInfo: any,
-  envPrefix: string,
-  message: Message,
+  envPrefix: string | undefined,
+  message: Message | undefined,
   scriptGrants: Set<string>
 ) {
   // 按照GMApi构建
@@ -35,7 +35,7 @@ export function createContext(
   const __methodInject__ = (grant: string): boolean => {
     const grantSet: Set<string> = context.grantSet;
     const s = GMContextApiGet(grant);
-    if (!s) return false; // @grant 的定义未实作，略过 (返回 false 表示 @grant 不存在)
+    if (!s) return false; // @grant 的定义未实装，略过 (返回 false 表示 @grant 不存在)
     if (grantSet.has(grant)) return true; // 重覆的@grant，略过 (返回 true 表示 @grant 存在)
     grantSet.add(grant);
     for (const {fnKey, api, param} of s) {

--- a/src/app/service/content/exec_script.test.ts
+++ b/src/app/service/content/exec_script.test.ts
@@ -79,6 +79,10 @@ describe("unsafeWindow", () => {
     sandboxExec.scriptFunc = compileScript(compileScriptCode(scriptRes2));
     const ret = await sandboxExec.exec();
     expect(ret).toEqual(global);
+    scriptRes2.code = `return window`;
+    sandboxExec.scriptFunc = compileScript(compileScriptCode(scriptRes2));
+    const ret3 = await sandboxExec.exec();
+    expect(ret3).not.toEqual(global);
   });
 
   it("sandbox", async () => {
@@ -95,6 +99,21 @@ describe("unsafeWindow", () => {
     const ret2 = await sandboxExec.exec();
     expect(ret2).toEqual(undefined);
   });
+
+
+  it("sandbox NodeFilter", async () => {
+    const nodeFilter = global.NodeFilter;
+    expect(nodeFilter).toEqual(expect.any(Function));
+    scriptRes2.code = `return unsafeWindow.NodeFilter`;
+    sandboxExec.scriptFunc = compileScript(compileScriptCode(scriptRes2));
+    const ret = await sandboxExec.exec();
+    expect(ret).toEqual(nodeFilter);
+    scriptRes2.code = "return window.NodeFilter";
+    sandboxExec.scriptFunc = compileScript(compileScriptCode(scriptRes2));
+    const ret2 = await sandboxExec.exec();
+    expect(ret2).toEqual(nodeFilter);
+  });
+
 });
 
 describe("sandbox", () => {

--- a/src/app/service/content/exec_script.ts
+++ b/src/app/service/content/exec_script.ts
@@ -17,7 +17,7 @@ export default class ExecScript {
 
   logger: Logger;
 
-  proxyContext: typeof globalThis;
+  // proxyContext: typeof globalThis;
 
   sandboxContext?: IGM_Base & { [key: string]: any };
 
@@ -47,7 +47,6 @@ export default class ExecScript {
     const grantSet = new Set(scriptRes.metadata.grant || []);
     if (grantSet.has("none")) {
       // 不注入任何GM api
-      this.proxyContext = global;
       // ScriptCat行为：GM.info 和 GM_info 同时注入
       // 不改变Context情况下，以 named 传多於一个全域变量
       this.named = {GM: {info: GM_info}, GM_info};
@@ -57,7 +56,6 @@ export default class ExecScript {
       if (globalInjection) {
         Object.assign(this.sandboxContext, globalInjection);
       }
-      this.proxyContext = createProxyContext(global, this.sandboxContext);
     }
   }
 
@@ -76,7 +74,8 @@ export default class ExecScript {
    */
   exec() {
     this.logger.debug("script start");
-    const context = this.proxyContext;
+    const sandboxContext = this.sandboxContext;
+    const context = sandboxContext ? createProxyContext(global, sandboxContext) : global; // this.$ 只能执行一次
     return this.scriptFunc.call(context, this.named, this.scriptRes.name);
   }
 

--- a/src/app/service/content/exec_script.ts
+++ b/src/app/service/content/exec_script.ts
@@ -25,8 +25,8 @@ export default class ExecScript {
 
   constructor(
     scriptRes: ScriptLoadInfo,
-    envPrefix: "content" | "offscreen",
-    message: Message,
+    envPrefix: "content" | "offscreen" | undefined,
+    message: Message | undefined,
     code: string | ScriptFunc,
     envInfo: GMInfoEnv,
     globalInjection?: { [key: string]: any } // 主要是全域API. @grant none 时无效

--- a/src/app/service/content/utils.test.ts
+++ b/src/app/service/content/utils.test.ts
@@ -23,12 +23,25 @@ describe("proxy context", () => {
     expect(global["md5"]).toEqual(undefined);
   });
 
-  it("set window null", () => {
-    _this["onload"] = "ok";
-    expect(_this["onload"]).toEqual("ok");
-    expect(global["onload"]).toEqual(null);
-    _this["onload"] = undefined;
-    expect(_this["onload"]).toEqual(undefined);
+  it("set window.onload null", () => {
+    // null確認
+    _this["onload"] = null;
+    global["onload"] = null;
+    expect(_this["onload"]).toBeNull();
+    expect(global["onload"]).toBeNull();
+    // _this.onload
+    _this["onload"] = function thisOnLoad() { };
+    expect(_this["onload"]?.name).toEqual("thisOnLoad");
+    expect(global["onload"]).toBeNull();
+    // global.onload
+    _this["onload"] = null;
+    global["onload"] = function globalOnLoad() { };
+    expect(_this["onload"]).toBeNull();
+    expect(global["onload"]?.name).toEqual("globalOnLoad");
+    global["onload"] = null;
+    // 還原確認
+    expect(_this["onload"]).toBeNull();
+    expect(global["onload"]).toBeNull();
   });
 
   it("update", () => {
@@ -57,7 +70,7 @@ describe("proxy context", () => {
 // 只允许访问onxxxxx
 describe("window", () => {
   const _this = createProxyContext({ onanimationstart: null }, {});
-  it("window", () => {
+  it("onxxxxx", () => {
     expect(_this.onanimationstart).toBeNull();
   });
 });

--- a/src/app/service/content/utils.test.ts
+++ b/src/app/service/content/utils.test.ts
@@ -69,14 +69,14 @@ describe("proxy context", () => {
 
 // 只允许访问onxxxxx
 describe("window", () => {
-  const _this = createProxyContext({ onanimationstart: null }, {});
+  const _this = createProxyContext<{ [key: string]: any} & any>({ onanimationstart: null }, {});
   it("onxxxxx", () => {
     expect(_this.onanimationstart).toBeNull();
   });
 });
 
 describe("兼容问题", () => {
-  const _this = createProxyContext<{ [key: string]: any }>({}, {});
+  const _this = createProxyContext<{ [key: string]: any} & any>({}, {});
   // https://github.com/xcanwin/KeepChatGPT 环境隔离得不够干净导致的
   it("Uncaught TypeError: Illegal invocation #189", () => {
     return new Promise((resolve) => {
@@ -106,7 +106,7 @@ describe("Symbol", () => {
 
 // Object.hasOwnProperty穿透 https://github.com/scriptscat/scriptcat/issues/272
 describe("Object", () => {
-  const _this = createProxyContext<{ [key: string]: any }>({}, {});
+  const _this = createProxyContext<{ [key: string]: any} & any>({}, {});
   it("hasOwnProperty", () => {
     expect(Object.prototype.hasOwnProperty.call(_this, "test1")).toEqual(false);
     _this.test1 = "ok";

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -104,7 +104,8 @@ export const unscopables: { [key: string]: boolean } = {
   // "await": true,
   // "define": true,
   // "module": true,
-  // "exports": true
+  // "exports": true,
+  [Symbol.unscopables]: true,
 };
 
 // 在 CacheSet 加入的propKeys将会在myCopy实装阶段时设置

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -43,12 +43,13 @@ export function compileScriptCode(scriptRes: ScriptRunResource, scriptCode?: str
   // arguments = [named: Object, scriptName: string]
   // @grant none 时，不让 preCode 中的外部代码存取 GM 跟 GM_info，以arguments[0]存取 GM 跟 GM_info
   // 使用sandboxContext时，arguments[0]为undefined
+  // 在userScript API中，由於执行不是在物件导向裡呼叫，使用arrow function的话会把this改变。须使用 .call(this) [ 或 .bind(this)() ]
   return `try {
   with(this){
-    ${preCode}
-    return (async({GM,GM_info})=>{
-    ${code}
-    })(arguments[0]||{GM,GM_info});
+${preCode}
+    return (async function({GM,GM_info}){
+${code}
+    }).call(this,arguments[0]||{GM,GM_info});
   }
 } catch (e) {
   if (e.message && e.stack) {

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -272,9 +272,9 @@ export function createProxyContext<const Context extends GMWorldContext>(global:
 
       // return new Proxy(<Context>myCopy, {
       //   get(target, prop, receiver) {
-      //     // 由於Context全拦截，我們沒有方法判斷這個get是 typeof xxx 還是 xxx
-      //     // (不拦截的話會觸發全域變量存取讀寫)
-      //     // 因此總是傳回 undefined 而不報錯
+      //     // 由於Context全拦截，我们没有方法判断这个get是 typeof xxx 还是 xxx
+      //     // (不拦截的话会触发全域变量存取读写)
+      //     // 因此总是传回 undefined 而不报错
       //     if(Reflect.has(target, prop)){
       //       return Reflect.get(target, prop, receiver);
       //     }

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -258,37 +258,39 @@ export function createProxyContext<const Context extends GMWorldContext>(global:
     configurable: true,
     get() {
       delete (<any>this).$;
-      return new Proxy(<Context>myCopy, {
-        get(target, prop, receiver) {
-          // 由於Context全拦截，我們沒有方法判斷這個get是 typeof xxx 還是 xxx
-          // (不拦截的話會觸發全域變量存取讀寫)
-          // 因此總是傳回 undefined 而不報錯
-          if(Reflect.has(target, prop)){
-            return Reflect.get(target, prop, receiver);
-          }
-          // throw new ReferenceError(`${String(prop)} is not defined.`);
-          return undefined;
-        },
-        has(_target, _key) {
-          // 全拦截，避免 userscript 改变 global window 变量 （包括删除及生成）
-          // 强制针对所有"属性"为[[HasProperty]]，即 `* in $` 总是 true
-          return true;
-        },
-        set(target, key, value, receiver) {
-          // if (Reflect.has(target, key)) {
-            // Allow updating existing properties in the context
-            return Reflect.set(target, key, value, receiver);
-          // }
-          // Prevent creating new properties
-          // throw new ReferenceError(`Cannot create variable ${String(key)} in sandbox`);
-        },
-        deleteProperty(target, key) {
-          if (Reflect.has(target, key)) {
-            return Reflect.deleteProperty(target, key);
-          }
-          return false;
-        }
-      });
+      return myCopy;
+
+      // return new Proxy(<Context>myCopy, {
+      //   get(target, prop, receiver) {
+      //     // 由於Context全拦截，我們沒有方法判斷這個get是 typeof xxx 還是 xxx
+      //     // (不拦截的話會觸發全域變量存取讀寫)
+      //     // 因此總是傳回 undefined 而不報錯
+      //     if(Reflect.has(target, prop)){
+      //       return Reflect.get(target, prop, receiver);
+      //     }
+      //     // throw new ReferenceError(`${String(prop)} is not defined.`);
+      //     return undefined;
+      //   },
+      //   has(_target, _key) {
+      //     // 全拦截，避免 userscript 改变 global window 变量 （包括删除及生成）
+      //     // 强制针对所有"属性"为[[HasProperty]]，即 `* in $` 总是 true
+      //     return true;
+      //   },
+      //   set(target, key, value, receiver) {
+      //     // if (Reflect.has(target, key)) {
+      //       // Allow updating existing properties in the context
+      //       return Reflect.set(target, key, value, receiver);
+      //     // }
+      //     // Prevent creating new properties
+      //     // throw new ReferenceError(`Cannot create variable ${String(key)} in sandbox`);
+      //   },
+      //   deleteProperty(target, key) {
+      //     if (Reflect.has(target, key)) {
+      //       return Reflect.deleteProperty(target, key);
+      //     }
+      //     return false;
+      //   }
+      // });
     }
   }
 

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -52,20 +52,19 @@ export class RuntimeService {
 
   async initUserAgentData() {
     // @ts-ignore
-    if (navigator.userAgentData) {
-      // @ts-ignore
+    const userAgentData = navigator.userAgentData;
+    if (userAgentData) {
       this.userAgentData = {
-        // @ts-ignore
-        brands: navigator.userAgentData.brands,
-        // @ts-ignore
-        mobile: navigator.userAgentData.mobile,
-        // @ts-ignore
-        platform: navigator.userAgentData.platform,
+        brands: userAgentData.brands,
+        mobile: userAgentData.mobile,
+        platform: userAgentData.platform,
       };
       // 处理architecture和bitness
-      const platformInfo = await chrome.runtime.getPlatformInfo();
-      this.userAgentData.architecture = platformInfo.nacl_arch;
-      this.userAgentData.bitness = platformInfo.arch.includes("64") ? "64" : "32";
+      if (chrome?.runtime?.getPlatformInfo) {
+        const platformInfo = await chrome.runtime.getPlatformInfo();
+        this.userAgentData.architecture = platformInfo.nacl_arch;
+        this.userAgentData.bitness = platformInfo.arch.includes("64") ? "64" : "32";
+      }
     }
   }
 

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -1,3 +1,41 @@
 import chromeMock from "@Packages/chrome-extension-mock";
 
 chromeMock.init();
+
+const isPrimitive = (x: any) => x !== Object(x);
+
+if (!("onanimationstart" in global)) {
+    // Define or mock the global handler
+    let val: any = null;
+    Object.defineProperty(global, "onanimationstart", {
+        configurable: true,
+        enumerable: true,
+        set(newVal) {
+            if (isPrimitive(newVal)) newVal = null;
+            val = newVal;
+        },
+        get() {
+            return val;
+        }
+    });
+}
+
+//@ts-ignore
+delete global.onload;
+
+if (!("onload" in global)) {
+    // Define or mock the global handler
+    let val: any = null;
+    Object.defineProperty(global, "onload", {
+        configurable: true,
+        enumerable: true,
+        set(newVal) {
+            if (isPrimitive(newVal)) newVal = null;
+            val = newVal;
+        },
+        get() {
+            return val;
+        }
+    });
+}
+


### PR DESCRIPTION
这个沙盒是重新写的
因为我们用 `with(...)` ， 旧写法会有效能问题（Proxy has 裡面是动态判断，所有变数名都要经过这个， 因为动态，所以V8引擎等无法优化存取）

-----

### 新沙盒原理

新沙盒是这样的:

1. 先读取 window 所有属性, 包括继承来的 （例如addEventListener)
2. 由於本来就要把初始值都保存一遍，所以这个loop不会比旧写法慢很多。（OwnPropertyDescriptors佔总属性 98%）
3. 如果是值属性，判断是否需要bind ( setTimeout, requestAnimationFrame 等要bind. DocumentFragement, NodeFilter, Audio等不用）。由於值属性在descriptor 就能得到，所以直接保存 （旧写法的writables相约，但有改进 - 加入 名字大小寫 判断）
4. 如果是读写属性，则把getter setter 绑定在window上。 （即 `window.location`, `window.document` )
5. 如果是 onxxxxx 属性，使用自订方式处理 （与旧写法相约，但有改进 - 加入 isPrimitive 判断） 
6. 其他自订的东西，例如context裡的，都会复製到沙盒物件

因为，初始化时，所有行为已经定义好所有属性。不用动态处理。( with 拦截时，JS引擎能使用cache优化）
初始化行为是同步的。快慢也不会对脚本行为做成影响。

----
### 继承属性 -> 自属性（此跟旧写法 writables 一致）

这个沙盒是Window类的实例，加入以上的OwnPropertyDescriptor. 
由於window属性98%以上都是在 window 物件实例定义，只有极少数 (addEventListener等) 是由上层继承而来。
只有这极少数属性 （addEventListener等）会从继承属性变成自属性 （此跟旧写法 writables 一致）

---

### 非全拦截Context（此跟TM 一致）

* 因为非全拦截Context，所以跟TM一样可以在非strict mode 生成及删除页面的全域变数

---

之前为了做 全拦截Context 写了 this.$ 这个东西
取消了全拦截，但保留了 this.$ 这个写法

----

## 其他修订

单元测试有修订还有增加。以往的测试都有保留下来并通过。保证相容旧版本。