### PR TITLE
调整 service_worker init

### DIFF
--- a/packages/message/window_message.ts
+++ b/packages/message/window_message.ts
@@ -170,15 +170,15 @@ export class ServiceWorkerMessageSend implements MessageSend {
 
   async init() {
     if (!this.target && self.clients) {
-      const list = await self.clients.matchAll({ includeUncontrolled: true, type: "window" });
-      // 找到offscreen.html窗口
-      this.target = list.find((client) => client.url == chrome.runtime.getURL("src/offscreen.html")) as PostMessage;
       if (!this.listened) {
         this.listened = true;
         self.addEventListener("message", (e) => {
           this.messageHandle(e.data);
         });
       }
+      const list = await self.clients.matchAll({ includeUncontrolled: true, type: "window" });
+      // 找到offscreen.html窗口
+      this.target = list.find((client) => client.url == chrome.runtime.getURL("src/offscreen.html")) as PostMessage;
     }
   }
 


### PR DESCRIPTION
<img width="987" height="551" alt="Screenshot 2025-07-14 at 21 24 58" src="https://github.com/user-attachments/assets/7f8cf10b-e49a-4c13-899b-19ed19fc3889" />

原因是 service_worker 的 init 中
先做了 `await self.clients.matchAll({ includeUncontrolled: true, type: "window" });` 再做 `self.addEventListener("message"`

因此要改次序