### PR TITLE
修改 messageFlag 格式避免与其他页面代码衝突

### DIFF
--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -10,7 +10,7 @@ import { subscribeScriptDelete, subscribeScriptEnable, subscribeScriptInstall, s
 import { type ScriptService } from "./script";
 import { runScript, stopScript } from "../offscreen/client";
 import { getRunAt } from "./utils";
-import { isUserScriptsAvailable, randomString } from "@App/pkg/utils/utils";
+import { isUserScriptsAvailable, randomMessageFlag } from "@App/pkg/utils/utils";
 import Cache from "@App/app/cache";
 import { dealPatternMatches, UrlMatch } from "@App/pkg/utils/match";
 import { ExtensionContentMessageSend } from "@Packages/message/extension_message";
@@ -309,7 +309,7 @@ export class RuntimeService {
   }
 
   getAndGenMessageFlag() {
-    return Cache.getInstance().getOrSet("scriptInjectMessageFlag", () => randomString(16));
+    return Cache.getInstance().getOrSet("scriptInjectMessageFlag", () => randomMessageFlag());
   }
 
   deleteMessageFlag() {

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -5,7 +5,7 @@ import Logger from "@App/app/logger/logger";
 import LoggerCore from "@App/app/logger/core";
 import Cache from "@App/app/cache";
 import CacheKey from "@App/app/cache_key";
-import { checkSilenceUpdate, InfoNotification, openInCurrentTab, randomString } from "@App/pkg/utils/utils";
+import { checkSilenceUpdate, InfoNotification, openInCurrentTab, randomMessageFlag } from "@App/pkg/utils/utils";
 import { ltever } from "@App/pkg/utils/semver";
 import type { Script, SCRIPT_RUN_STATUS, ScriptDAO, ScriptRunResource } from "@App/app/repo/scripts";
 import { SCRIPT_STATUS_DISABLE, SCRIPT_STATUS_ENABLE, ScriptCodeDAO } from "@App/app/repo/scripts";
@@ -315,7 +315,7 @@ export class ScriptService {
 
     ret.resource = await this.resourceService.getScriptResources(ret, true);
 
-    ret.flag = randomString(16);
+    ret.flag = randomMessageFlag();
     const code = await this.getCode(ret.uuid);
     if (!code) {
       throw new Error("code is null");

--- a/src/pkg/utils/utils.ts
+++ b/src/pkg/utils/utils.ts
@@ -1,13 +1,23 @@
 import type { Metadata, Script } from "@App/app/repo/scripts";
 
-export function randomString(e = 32): string {
-  const t = "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz";
-  const a = t.length;
-  const n = new Array(e);
-  for (let i = 0; i < e; i++) {
-    n[i] = t[(Math.random() * a) | 0];
-  }
-  return n.join("");
+// export function randomString(e = 32): string {
+//   const t = "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz";
+//   const a = t.length;
+//   const n = new Array(e);
+//   for (let i = 0; i < e; i++) {
+//     n[i] = t[(Math.random() * a) | 0];
+//   }
+//   return n.join("");
+// }
+
+function randNum(a: number, b: number) {
+  return Math.floor(Math.random() * (b - a + 1)) + a;
+}
+
+export function randomMessageFlag(): string {
+  // parseInt('a0000000', 36) = 783641640960;
+  // parseInt('zzzzzzzz', 36) = 2821109907455;
+  return `-${Date.now().toString(36)}.${randNum(8e11, 2e12).toString(36)}`;
 }
 
 export function dealSymbol(source: string): string {


### PR DESCRIPTION
現在使用

```ts
export function randomString(e = 32): string {
  const t = "ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz";
  const a = t.length;
  const n = new Array(e);
  for (let i = 0; i < e; i++) {
    n[i] = t[(Math.random() * a) | 0];
  }
  return n.join("");
}
```

用`randomString(16)`
這個雖然達到 41^16  (6.376 * 10^25) 個組合，但鍵都是英文字，而且執行時要運用new Array loop 等方式，效率低



```ts
function randNum(a: number, b: number) {
  return Math.floor(Math.random() * (b - a + 1)) + a;
}

export function randomMessageFlag(): string {
  // parseInt('a0000000', 36) = 783641640960;
  // parseInt('zzzzzzzz', 36) = 2821109907455;
  return `-${Date.now().toString(36)}.${randNum(8e11, 2e12).toString(36)}`;
}
```
新寫法是利用 `.toString(36)` 直接轉換，效率高
採用 "-xxxxxxxx.xxxxxxxx" 格式，不容易引起衝突（例如頁面本身也使用 XXXXXXXXXXXXXXXX 這種鍵）
而且沙盒內的全域變數生成/刪除也不能改 "-" 開首的

`Date.now()` 是递增特性。後面的 `randNum(8e11, 2e12)`能產生一個不易重覆的8位字串 (1.2 x 10^12 組合）。 

* 後面的可以改成 randNum(2e14, 9e15) ->  8.8 * 10^15 組合



