### PR TITLE
未支持`window.onurlchange`

### DIFF
--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -28,7 +28,7 @@ export const createContext = (
     GM: { info: GMInfo },
     GM_info: GMInfo,
     window: {
-      onurlchange: null,
+      // onurlchange: null,
     },
     grantSet: new Set(),
   });


### PR DESCRIPTION
由於ScriptCat未支持，不应预计为 `null`

----

要支持这个TM特有的功能，为了效率，要考虑
```
chrome.tabs.onUpdated
chrome.webNavigation onHistoryStateUpdated
chrome.webNavigation onCompleted
chrome.webNavigation onReferenceFragmentUpdated
```
来做一个库去实现

详细： https://github.com/scriptscat/scriptcat/issues/535

----

因为需要后台特别处理，不建议预计。跟TM 一样 `@grant window.onurlchange` 就好