### PR TITLE
优化脚本安装页面

### DIFF
--- a/src/app/service/service_worker/client.ts
+++ b/src/app/service/service_worker/client.ts
@@ -15,6 +15,7 @@ import { type ResourceBackup } from "@App/pkg/backup/struct";
 import { type VSCodeConnect } from "../offscreen/vscode-connect";
 import type { GMInfoEnv } from "../content/types";
 import { type SystemService } from "./system";
+import { type ScriptInfo } from "@App/pkg/utils/scriptInstall";
 
 export class ServiceWorkerClient extends Client {
   constructor(msg: MessageSend) {
@@ -38,7 +39,7 @@ export class ScriptClient extends Client {
 
   // 获取安装信息
   getInstallInfo(uuid: string) {
-    return this.do("getInstallInfo", uuid);
+    return this.do<[boolean, ScriptInfo]>("getInstallInfo", uuid);
   }
 
   install(script: Script, code: string, upsertBy: InstallSource = "user"): Promise<{ update: boolean }> {

--- a/src/app/service/service_worker/subscribe.ts
+++ b/src/app/service/service_worker/subscribe.ts
@@ -7,12 +7,11 @@ import { type SystemConfig } from "@App/pkg/config/config";
 import { type MessageQueue } from "@Packages/message/message_queue";
 import { type Group } from "@Packages/message/server";
 import { type ScriptService } from "./script";
-import type { InstallSource } from "./types";
+import { createScriptInfo, type InstallSource } from "@App/pkg/utils/scriptInstall";
 import { type TInstallSubscribe } from "../queue";
 import { checkSilenceUpdate, InfoNotification } from "@App/pkg/utils/utils";
 import { ltever } from "@App/pkg/utils/semver";
-import type { ScriptInfo } from "@App/pkg/utils/script";
-import { fetchScriptInfo, prepareSubscribeByCode } from "@App/pkg/utils/script";
+import { fetchScriptBody, parseMetadata, prepareSubscribeByCode } from "@App/pkg/utils/script";
 import { cacheInstance } from "@App/app/cache";
 import { CACHE_KEY_SCRIPT_INFO } from "@App/app/cache_key";
 
@@ -171,8 +170,10 @@ export class SubscribeService {
     });
     await this.subscribeDAO.update(url, { checktime: Date.now() });
     try {
-      const info = await fetchScriptInfo(subscribe.url, source, false, subscribe.url);
-      const { metadata } = info;
+      const code = await fetchScriptBody(subscribe.url);
+      const metadata = parseMetadata(code);
+      const url = subscribe.url;
+      const uuid = subscribe.url; // 使用 url 作為 uuid?
       if (!metadata) {
         logger.error("parse metadata failed");
         return false;
@@ -191,7 +192,15 @@ export class SubscribeService {
         return false;
       }
       // 进行更新
-      this.openUpdatePage(info);
+      if (true === (await this.trySilenceUpdate(code, url))) {
+        // slience update
+      } else {
+        const si = [false, createScriptInfo(uuid, code, url, source, metadata)];
+        await cacheInstance.set(`${CACHE_KEY_SCRIPT_INFO}${uuid}`, si);
+        chrome.tabs.create({
+          url: `/src/install.html?uuid=${uuid}`,
+        });
+      }
       return true;
     } catch (e) {
       logger.error("check update failed", Logger.E(e));
@@ -199,31 +208,26 @@ export class SubscribeService {
     }
   }
 
-  async openUpdatePage(info: ScriptInfo) {
+  async trySilenceUpdate(code: string, url: string) {
     const logger = this.logger.with({
-      url: info.url,
+      url,
     });
     // 是否静默更新
     const silenceUpdate = await this.systemConfig.getSilenceUpdateScript();
     if (silenceUpdate) {
       try {
-        const newSubscribe = await prepareSubscribeByCode(info.code, info.url);
+        const newSubscribe = await prepareSubscribeByCode(code, url);
         if (checkSilenceUpdate(newSubscribe.oldSubscribe!.metadata, newSubscribe.subscribe.metadata)) {
           logger.info("silence update subscribe");
           this.install({
             subscribe: newSubscribe.subscribe,
           });
-          return;
+          return true;
         }
       } catch (e) {
         logger.error("prepare script failed", Logger.E(e));
       }
     }
-    const cacheKey = `${CACHE_KEY_SCRIPT_INFO}${info.uuid}`;
-    cacheInstance.set(cacheKey, info);
-    chrome.tabs.create({
-      url: `/src/install.html?uuid=${info.uuid}`,
-    });
   }
 
   async checkSubscribeUpdate() {

--- a/src/app/service/service_worker/subscribe.ts
+++ b/src/app/service/service_worker/subscribe.ts
@@ -13,6 +13,7 @@ import { checkSilenceUpdate, InfoNotification } from "@App/pkg/utils/utils";
 import { ltever } from "@App/pkg/utils/semver";
 import { fetchScriptBody, parseMetadata, prepareSubscribeByCode } from "@App/pkg/utils/script";
 import { cacheInstance } from "@App/app/cache";
+import { v4 as uuidv4 } from "uuid";
 import { CACHE_KEY_SCRIPT_INFO } from "@App/app/cache_key";
 
 export class SubscribeService {
@@ -173,7 +174,7 @@ export class SubscribeService {
       const code = await fetchScriptBody(subscribe.url);
       const metadata = parseMetadata(code);
       const url = subscribe.url;
-      const uuid = subscribe.url; // 使用 url 作為 uuid?
+      const uuid = uuidv4();
       if (!metadata) {
         logger.error("parse metadata failed");
         return false;

--- a/src/pages/install/App.tsx
+++ b/src/pages/install/App.tsx
@@ -326,7 +326,7 @@ function App() {
         if (shouldClose) {
           setTimeout(() => {
             closeWindow();
-          }, 100);
+          }, 500);
         }
       } catch (e) {
         const errorMessage = scriptInfo?.userSubscribe ? t("subscribe_failed") : t("install_failed");

--- a/src/pages/install/App.tsx
+++ b/src/pages/install/App.tsx
@@ -21,10 +21,16 @@ import { SCRIPT_STATUS_DISABLE, SCRIPT_STATUS_ENABLE } from "@App/app/repo/scrip
 import type { Subscribe } from "@App/app/repo/subscribe";
 import { i18nDescription, i18nName } from "@App/locales/locales";
 import { useTranslation } from "react-i18next";
-import type { ScriptInfo } from "@App/pkg/utils/script";
-import { prepareScriptByCode, prepareSubscribeByCode, scriptInfoByCode } from "@App/pkg/utils/script";
+import { createScriptInfo, type ScriptInfo } from "@App/pkg/utils/scriptInstall";
+import { parseMetadata, prepareScriptByCode, prepareSubscribeByCode } from "@App/pkg/utils/script";
 import { nextTime } from "@App/pkg/utils/cron";
 import { scriptClient, subscribeClient } from "../store/features/script";
+import { type FTInfo, startFileTrack, unmountFileTrack } from "@App/pkg/utils/file-tracker";
+import { cleanupOldHandles, loadHandle, saveHandle } from "@App/pkg/utils/filehandle-db";
+import { dayFormat } from "@App/pkg/utils/day_format";
+import { intervalExecution, timeoutExecution } from "@App/pkg/utils/timer";
+
+type ScriptOrSubscribe = Script | Subscribe;
 
 // Types
 interface PermissionItem {
@@ -39,99 +45,138 @@ const closeWindow = () => {
   window.close();
 };
 
-// Custom hooks
-const useScriptInstall = () => {
+const cIdKey = `(cid_${Math.random()})`;
+
+function App() {
+  const [enable, setEnable] = useState<boolean>(false);
+  const [btnText, setBtnText] = useState<string>("");
+  const [scriptCode, setScriptCode] = useState<string>("");
   const [scriptInfo, setScriptInfo] = useState<ScriptInfo>();
-  const [upsertScript, setUpsertScript] = useState<Script | Subscribe>();
-  const [code, setCode] = useState<string>("");
+  const [upsertScript, setUpsertScript] = useState<ScriptOrSubscribe>();
   const [diffCode, setDiffCode] = useState<string>();
-  const [oldScript, setOldScript] = useState<Script | Subscribe>();
+  const [oldScriptVersion, setOldScriptVersion] = useState<string | null>(null);
   const [isUpdate, setIsUpdate] = useState<boolean>(false);
-  const [localFile, setLocalFile] = useState<File | null>(null);
   const [localFileHandle, setLocalFileHandle] = useState<FileSystemFileHandle | null>(null);
   const { t } = useTranslation();
 
-  useEffect(() => {
-    const handle = async () => {
-      try {
-        const url = new URL(window.location.href);
-        const uuid = url.searchParams.get("uuid");
-        let info: ScriptInfo | undefined;
-        if (!uuid) {
-          // 检查是不是本地文件安装
-          const local = url.searchParams.get("local") === "true";
-          if (!local || !window.localFile) {
-            return;
-          }
-          // 处理本地文件的安装流程
-          // 处理成info对象
-          const file = window.localFile;
-          setLocalFile(file);
-          setLocalFileHandle(window.localFileHandle!);
-          const code = await file.text();
-          info = scriptInfoByCode(code, "file:///*from-local*/" + file.name, "user", false, uuidv4());
-        } else {
-          info = await scriptClient.getInstallInfo(uuid);
-          if (!info) {
-            throw new Error("fetch script info failed");
-          }
-        }
-
-        let prepare:
-          | { script: Script; oldScript?: Script; oldScriptCode?: string }
-          | { subscribe: Subscribe; oldSubscribe?: Subscribe };
-        let action: Script | Subscribe;
-
-        if (info.userSubscribe) {
-          prepare = await prepareSubscribeByCode(info.code, info.url);
-          action = prepare.subscribe;
-          setOldScript(prepare.oldSubscribe);
-          setCode(prepare.subscribe.code);
-          setDiffCode(prepare.oldSubscribe?.code);
-          if (prepare.oldSubscribe) {
-            setIsUpdate(true);
-          }
-        } else {
-          if (info.update) {
-            prepare = await prepareScriptByCode(info.code, info.url, info.uuid);
-          } else {
-            prepare = await prepareScriptByCode(info.code, info.url);
-          }
-          action = prepare.script;
-          setOldScript(prepare.oldScript);
-          setCode(info.code);
-          setDiffCode(prepare.oldScriptCode);
-          if (prepare.oldScript) {
-            setIsUpdate(true);
-          }
-        }
-
-        setScriptInfo(info);
-        setUpsertScript(action);
-      } catch (e: any) {
-        Message.error(t("script_info_load_failed") + " " + e.message);
-      }
-    };
-    handle();
-  }, [t]);
-
-  return {
-    scriptInfo,
-    upsertScript,
-    setUpsertScript,
-    code,
-    diffCode,
-    oldScript,
-    isUpdate,
-    localFile,
-    localFileHandle,
+  const installOrUpdateScript = async (newScript: Script, code: string) => {
+    await scriptClient.install(newScript, code);
+    const metadata = newScript.metadata;
+    setScriptInfo((prev) => (prev ? { ...prev, code, metadata } : prev));
+    setOldScriptVersion(metadata!.version![0]);
+    setUpsertScript(newScript);
+    setDiffCode(code);
   };
-};
 
-const usePermissions = (scriptInfo: ScriptInfo | undefined, metadata: SCMetadata) => {
-  const { t } = useTranslation();
+  const getUpdatedNewScript = async (uuid: string, code: string) => {
+    const oldScript = await scriptClient.info(uuid);
+    if (!oldScript || oldScript.uuid !== uuid) {
+      throw new Error("uuid is mismatched");
+    }
+    const { script } = await prepareScriptByCode(code, oldScript.origin || "", uuid);
+    script.origin = oldScript.origin || script.origin || "";
+    if (!script.name) {
+      throw new Error(t("script_name_cannot_be_set_to_empty"));
+    }
+    return script;
+  };
 
-  return useMemo(() => {
+  const initAsync = async () => {
+    try {
+      const locationUrl = new URL(window.location.href);
+      const uuid = locationUrl.searchParams.get("uuid");
+      let info: ScriptInfo | undefined;
+      let isKnownUpdate: boolean = false;
+      if (uuid) {
+        const cachedInfo = await scriptClient.getInstallInfo(uuid);
+        if (cachedInfo?.[0]) isKnownUpdate = true;
+        info = cachedInfo?.[1] || undefined;
+        if (!info) {
+          throw new Error("fetch script info failed");
+        }
+      } else {
+        // 检查是不是本地文件安装
+        const fid = locationUrl.searchParams.get("file");
+        if (!fid) {
+          throw new Error("url param - local file id is not found");
+        }
+        const fileHandle = await loadHandle(fid);
+        if (!fileHandle) {
+          throw new Error("invalid file access - fileHandle is null");
+        }
+        const file = await fileHandle.getFile();
+        if (!file) {
+          throw new Error("invalid file access - file is null");
+        }
+        // 处理本地文件的安装流程
+        // 处理成info对象
+        setLocalFileHandle((prev) => {
+          if (prev instanceof FileSystemFileHandle) unmountFileTrack(prev);
+          return fileHandle!;
+        });
+
+        // 刷新 timestamp, 使 10s~15s 后不会被立即清掉
+        // 每五分鐘刷新一次db记录的timestamp，使开啟中的安装页面的fileHandle不会被刷掉
+        intervalExecution(`${cIdKey}liveFileHandle`, () => saveHandle(fid, fileHandle), 5 * 60 * 1000, true);
+
+        const code = await file.text();
+        const metadata = parseMetadata(code);
+        if (!metadata) {
+          throw new Error("parse script info failed");
+        }
+        info = createScriptInfo(uuidv4(), code, `file:///*from-local*/${file.name}`, "user", metadata);
+      }
+
+      let prepare:
+        | { script: Script; oldScript?: Script; oldScriptCode?: string }
+        | { subscribe: Subscribe; oldSubscribe?: Subscribe };
+      let action: Script | Subscribe;
+
+      const { code, url } = info;
+      let oldVersion: string | undefined = undefined;
+      let diffCode: string | undefined = undefined;
+      if (info.userSubscribe) {
+        prepare = await prepareSubscribeByCode(code, url);
+        action = prepare.subscribe;
+        if (prepare.oldSubscribe) {
+          oldVersion = prepare.oldSubscribe!.metadata!.version![0] || "";
+        }
+        diffCode = prepare.oldSubscribe?.code;
+      } else {
+        const knownUUID = isKnownUpdate ? info.uuid : undefined;
+        prepare = await prepareScriptByCode(code, url, knownUUID);
+        action = prepare.script;
+        if (prepare.oldScript) {
+          oldVersion = prepare.oldScript!.metadata!.version![0] || "";
+        }
+        diffCode = prepare.oldScriptCode;
+      }
+      setScriptCode(code);
+      setDiffCode(diffCode);
+      setOldScriptVersion(typeof oldVersion === "string" ? oldVersion : null);
+      setIsUpdate(typeof oldVersion === "string");
+      setScriptInfo(info);
+      setUpsertScript(action);
+    } catch (e: any) {
+      Message.error(t("script_info_load_failed") + " " + e.message);
+    } finally {
+      // fileHandle 保留处理方式（暂定）：
+      // fileHandle 会保留一段足够时间，避免用户重新刷画面，重啟瀏览器等操作后，安装页变得空白一片。
+      // 处理会在所有Tab都载入后（不包含睡眠Tab）进行，因此延迟 10s~15s 让处理有足够时间。
+      // 安装页面关掉后15分鐘为不保留状态，会在安装画面再次打开时（其他脚本安装），进行清除。
+      const delay = Math.floor(5000 * Math.random()) + 10000; // 使用乱数时间避免瀏览器重啟时大量Tabs同时执行DB清除
+      timeoutExecution(`${cIdKey}cleanupFileHandle`, cleanupOldHandles, delay);
+    }
+  };
+
+  useEffect(() => {
+    initAsync();
+  }, []);
+
+  const [watchFile, setWatchFile] = useState(false);
+  const metadataLive = useMemo(() => (scriptInfo?.metadata || {}) as SCMetadata, [scriptInfo]);
+
+  const permissions = useMemo(() => {
     const permissions: Permission = [];
 
     if (!scriptInfo) return permissions;
@@ -140,39 +185,35 @@ const usePermissions = (scriptInfo: ScriptInfo | undefined, metadata: SCMetadata
       permissions.push({
         label: t("subscribe_install_label"),
         color: "#ff0000",
-        value: metadata.scripturl!,
+        value: metadataLive.scripturl!,
       });
     }
 
-    if (metadata.match) {
-      permissions.push({ label: t("script_runs_in"), value: metadata.match });
+    if (metadataLive.match) {
+      permissions.push({ label: t("script_runs_in"), value: metadataLive.match });
     }
 
-    if (metadata.connect) {
+    if (metadataLive.connect) {
       permissions.push({
         label: t("script_has_full_access_to"),
         color: "#F9925A",
-        value: metadata.connect,
+        value: metadataLive.connect,
       });
     }
 
-    if (metadata.require) {
-      permissions.push({ label: t("script_requires"), value: metadata.require });
+    if (metadataLive.require) {
+      permissions.push({ label: t("script_requires"), value: metadataLive.require });
     }
 
     return permissions;
-  }, [scriptInfo, metadata, t]);
-};
+  }, [scriptInfo, metadataLive]);
 
-const useScriptDescription = (scriptInfo: ScriptInfo | undefined, metadata: SCMetadata) => {
-  const { t } = useTranslation();
-
-  return useMemo(() => {
+  const description = useMemo(() => {
     const description: JSX.Element[] = [];
 
     if (!scriptInfo) return description;
 
-    const isCookie = metadata.grant?.some((val) => val === "GM_cookie");
+    const isCookie = metadataLive.grant?.some((val) => val === "GM_cookie");
     if (isCookie) {
       description.push(
         <Typography.Text type="error" key="cookie">
@@ -181,80 +222,55 @@ const useScriptDescription = (scriptInfo: ScriptInfo | undefined, metadata: SCMe
       );
     }
 
-    if (metadata.crontab) {
+    if (metadataLive.crontab) {
       description.push(<Typography.Text key="crontab">{t("scheduled_script_description_title")}</Typography.Text>);
       description.push(
         <Typography.Text key="cronta-nexttime">
           {t("scheduled_script_description_description", {
-            expression: metadata.crontab[0],
-            time: nextTime(metadata.crontab[0]),
+            expression: metadataLive.crontab[0],
+            time: nextTime(metadataLive.crontab[0]),
           })}
         </Typography.Text>
       );
-    } else if (metadata.background) {
+    } else if (metadataLive.background) {
       description.push(<Typography.Text key="background">{t("background_script_description")}</Typography.Text>);
     }
 
     return description;
-  }, [scriptInfo, metadata, t]);
-};
+  }, [scriptInfo, metadataLive]);
 
-const useAntiFeatures = () => {
-  const { t } = useTranslation();
-
-  return useMemo(() => {
-    const antifeatures: { [key: string]: { color: string; title: string; description: string } } = {
-      "referral-link": {
-        color: "purple",
-        title: t("antifeature_referral_link_title"),
-        description: t("antifeature_referral_link_description"),
-      },
-      ads: {
-        color: "orange",
-        title: t("antifeature_ads_title"),
-        description: t("antifeature_ads_description"),
-      },
-      payment: {
-        color: "magenta",
-        title: t("antifeature_payment_title"),
-        description: t("antifeature_payment_description"),
-      },
-      miner: {
-        color: "orangered",
-        title: t("antifeature_miner_title"),
-        description: t("antifeature_miner_description"),
-      },
-      membership: {
-        color: "blue",
-        title: t("antifeature_membership_title"),
-        description: t("antifeature_membership_description"),
-      },
-      tracking: {
-        color: "pinkpurple",
-        title: t("antifeature_tracking_title"),
-        description: t("antifeature_tracking_description"),
-      },
-    };
-
-    return antifeatures;
-  }, [t]);
-};
-
-function App() {
-  const [enable, setEnable] = useState<boolean>(false);
-  const [btnText, setBtnText] = useState<string>("");
-  const [scriptCode, setScriptCode] = useState<string>("");
-  const { t } = useTranslation();
-
-  const { scriptInfo, upsertScript, setUpsertScript, code, diffCode, oldScript, isUpdate, localFile, localFileHandle } =
-    useScriptInstall();
-
-  const [watchFile, setWatchFile] = useState(false);
-
-  const metadata = scriptInfo?.metadata || ({} as SCMetadata);
-  const permissions = usePermissions(scriptInfo, metadata);
-  const description = useScriptDescription(scriptInfo, metadata);
-  const antifeatures = useAntiFeatures();
+  const antifeatures: { [key: string]: { color: string; title: string; description: string } } = {
+    "referral-link": {
+      color: "purple",
+      title: t("antifeature_referral_link_title"),
+      description: t("antifeature_referral_link_description"),
+    },
+    ads: {
+      color: "orange",
+      title: t("antifeature_ads_title"),
+      description: t("antifeature_ads_description"),
+    },
+    payment: {
+      color: "magenta",
+      title: t("antifeature_payment_title"),
+      description: t("antifeature_payment_description"),
+    },
+    miner: {
+      color: "orangered",
+      title: t("antifeature_miner_title"),
+      description: t("antifeature_miner_description"),
+    },
+    membership: {
+      color: "blue",
+      title: t("antifeature_membership_title"),
+      description: t("antifeature_membership_description"),
+    },
+    tracking: {
+      color: "pinkpurple",
+      title: t("antifeature_tracking_title"),
+      description: t("antifeature_tracking_description"),
+    },
+  };
 
   // 更新按钮文案和页面标题
   useEffect(() => {
@@ -263,11 +279,10 @@ function App() {
     } else {
       setBtnText(isUpdate ? t("update_script")! : t("install_script"));
     }
-    setScriptCode(code || "");
     if (upsertScript) {
       document.title = `${!isUpdate ? t("install_script") : t("update_script")} - ${i18nName(upsertScript)} - ScriptCat`;
     }
-  }, [isUpdate, scriptInfo, upsertScript, t]);
+  }, [isUpdate, scriptInfo, upsertScript]);
 
   // 设置脚本状态
   useEffect(() => {
@@ -297,7 +312,8 @@ function App() {
             (upsertScript as Script).checkUpdate = false;
           }
 
-          await scriptClient.install(upsertScript as Script, code);
+          // 故意只安装或执行，不改变显示内容
+          await scriptClient.install(upsertScript as Script, scriptCode);
           if (isUpdate) {
             Message.success(t("install.update_success")!);
             setBtnText(t("install.update_success")!);
@@ -310,14 +326,14 @@ function App() {
         if (shouldClose) {
           setTimeout(() => {
             closeWindow();
-          }, 500);
+          }, 100);
         }
       } catch (e) {
         const errorMessage = scriptInfo?.userSubscribe ? t("subscribe_failed") : t("install_failed");
         Message.error(`${errorMessage}: ${e}`);
       }
     },
-    [upsertScript, scriptInfo, code, isUpdate, t]
+    [upsertScript, scriptInfo, scriptCode, isUpdate]
   );
 
   const handleStatusChange = useCallback(
@@ -345,27 +361,84 @@ function App() {
     [scriptInfo]
   );
 
-  useEffect(() => {
-    if (!watchFile) {
-      return;
+  const fileWatchMessageId = `id_${Math.random()}`;
+
+  async function onWatchFileCodeChanged(this: FTInfo, code: string, hideInfo: boolean = false) {
+    if (this.uuid !== scriptInfo?.uuid) return;
+    if (this.fileName !== localFileHandle?.name) return;
+    setScriptCode(code);
+    const uuid = (upsertScript as Script)?.uuid;
+    if (!uuid) {
+      throw new Error("uuid is undefined");
     }
-    if (!upsertScript) {
-      return;
-    }
-    // @ts-ignore
-    const observer = new FileSystemObserver(async (records) => {
-      // 调用安装
-      const code = await (await records[0].root.getFile()).text();
-      setScriptCode(code);
-      scriptClient.install(upsertScript as Script, code).catch((e) => {
-        Message.error(t("install_failed") + ": " + e);
+    try {
+      const newScript = await getUpdatedNewScript(uuid, code);
+      await installOrUpdateScript(newScript, code);
+    } catch (e) {
+      Message.error({
+        id: fileWatchMessageId,
+        content: t("install_failed") + ": " + e,
       });
-    });
-    observer.observe(localFileHandle);
-    return () => {
-      observer.disconnect();
-    };
-  }, [watchFile]);
+      return;
+    }
+    if (!hideInfo) {
+      Message.info({
+        id: fileWatchMessageId,
+        content: `${t("last_updated")}: ${dayFormat()}`,
+        duration: 3000,
+        closable: true,
+        showIcon: true,
+      });
+    }
+  }
+
+  const memoWatchFile = useMemo(() => {
+    return `${watchFile}.${scriptInfo?.uuid}.${localFileHandle?.name}`;
+  }, [watchFile, scriptInfo, localFileHandle]);
+
+  const setupWatchFile = async (uuid: string, fileName: string, handle: FileSystemFileHandle) => {
+    try {
+      // 如没有安装纪录，将进行安装。
+      // 如已经安装，在FileSystemObserver检查更改前，先进行更新。
+      const code = `${scriptCode}`;
+      await installOrUpdateScript(upsertScript as Script, code);
+      // setScriptCode(`${code}`);
+      setDiffCode(`${code}`);
+      const ftInfo: FTInfo = {
+        uuid,
+        fileName,
+        setCode: onWatchFileCodeChanged,
+      };
+      // 进行监听
+      startFileTrack(handle, ftInfo);
+      // 先取最新代码
+      const file = await handle.getFile();
+      const currentCode = await file.text();
+      // 如不一致，先更新
+      if (currentCode !== code) {
+        ftInfo.setCode(currentCode, true);
+      }
+    } catch (e: any) {
+      Message.error(`${e.message}`);
+      console.warn(e);
+    }
+  };
+
+  useEffect(() => {
+    if (!watchFile || !localFileHandle) {
+      return;
+    }
+    // 去除React特性
+    const [handle] = [localFileHandle];
+    unmountFileTrack(handle); // 避免重覆追踪
+    const uuid = scriptInfo?.uuid;
+    const fileName = handle?.name;
+    if (!uuid || !fileName) {
+      return;
+    }
+    setupWatchFile(uuid, fileName, handle);
+    return () => (unmountFileTrack(handle), void 0);
+  }, [memoWatchFile]);
 
   return (
     <div id="install-app-container">
@@ -392,7 +465,7 @@ function App() {
             </div>
             <div>
               <Typography.Text bold>
-                {t("author")}: {metadata.author}
+                {t("author")}: {metadataLive.author}
               </Typography.Text>
             </div>
             <div>
@@ -412,7 +485,7 @@ function App() {
             <div className="text-end">
               <Space>
                 <Button.Group>
-                  <Button type="primary" size="small" onClick={() => handleInstall()}>
+                  <Button type="primary" size="small" onClick={() => handleInstall()} disabled={watchFile}>
                     {btnText}
                   </Button>
                   <Dropdown
@@ -429,17 +502,18 @@ function App() {
                       </Menu>
                     }
                     position="bottom"
+                    disabled={watchFile}
                   >
-                    <Button type="primary" size="small" icon={<IconDown />} />
+                    <Button type="primary" size="small" icon={<IconDown />} disabled={watchFile} />
                   </Dropdown>
                 </Button.Group>
-                {localFile && (
+                {localFileHandle && (
                   <Popover content={t("watch_file_description")}>
                     <Button
                       type="secondary"
                       size="small"
                       onClick={() => {
-                        setWatchFile(!watchFile);
+                        setWatchFile((prev) => !prev);
                       }}
                     >
                       {watchFile ? t("stop_watch_file") : t("watch_file")}
@@ -479,34 +553,34 @@ function App() {
           <Space direction="vertical">
             <div>
               <Space>
-                {oldScript && (
-                  <Tooltip content={`${t("current_version")}: v${oldScript.metadata.version![0]}`}>
-                    <Tag bordered>{oldScript.metadata.version![0]}</Tag>
+                {oldScriptVersion && (
+                  <Tooltip content={`${t("current_version")}: v${oldScriptVersion}`}>
+                    <Tag bordered>{oldScriptVersion}</Tag>
                   </Tooltip>
                 )}
-                {metadata.version && (
-                  <Tooltip color="red" content={`${t("update_version")}: v${metadata.version[0]}`}>
+                {metadataLive.version && metadataLive.version[0] !== oldScriptVersion && (
+                  <Tooltip color="red" content={`${t("update_version")}: v${metadataLive.version[0]}`}>
                     <Tag bordered color="red">
-                      {metadata.version[0]}
+                      {metadataLive.version[0]}
                     </Tag>
                   </Tooltip>
                 )}
-                {(metadata.background || metadata.crontab) && (
+                {(metadataLive.background || metadataLive.crontab) && (
                   <Tooltip color="green" content={t("background_script_tag")}>
                     <Tag bordered color="green">
                       {t("background_script")}
                     </Tag>
                   </Tooltip>
                 )}
-                {metadata.crontab && (
+                {metadataLive.crontab && (
                   <Tooltip color="green" content={t("scheduled_script_tag")}>
                     <Tag bordered color="green">
                       {t("scheduled_script")}
                     </Tag>
                   </Tooltip>
                 )}
-                {metadata.antifeature &&
-                  metadata.antifeature.map((antifeature) => {
+                {metadataLive.antifeature &&
+                  metadataLive.antifeature.map((antifeature) => {
                     const item = antifeature.split(" ")[0];
                     return (
                       antifeatures[item] && (

--- a/src/pages/install/App.tsx
+++ b/src/pages/install/App.tsx
@@ -437,7 +437,9 @@ function App() {
       return;
     }
     setupWatchFile(uuid, fileName, handle);
-    return () => (unmountFileTrack(handle), void 0);
+    return () => {
+      unmountFileTrack(handle);
+    };
   }, [memoWatchFile]);
 
   return (

--- a/src/pages/install/main.tsx
+++ b/src/pages/install/main.tsx
@@ -20,19 +20,6 @@ const loggerCore = new LoggerCore({
 
 loggerCore.logger().debug("install page start");
 
-// 接收FileSystemType
-window.addEventListener(
-  "message",
-  (event) => {
-    if (event.data && event.data.type === "file") {
-      // 将FileSystemType存储到全局变量中
-      window.localFile = event.data.file;
-      window.localFileHandle = event.data.fileHandle;
-    }
-  },
-  false
-);
-
 const Root = (
   <Provider store={store}>
     <MainLayout className="!flex-col !px-4 box-border install-main-layout">

--- a/src/pkg/backup/struct.ts
+++ b/src/pkg/backup/struct.ts
@@ -65,11 +65,6 @@ export type ScriptOptionsFile = {
   meta: ScriptMeta;
 };
 
-export type ScriptInfo = {
-  name: string;
-  code: string;
-};
-
 export type ScriptBackupData = {
   code: string;
   options?: ScriptOptionsFile;

--- a/src/pkg/utils/file-tracker.ts
+++ b/src/pkg/utils/file-tracker.ts
@@ -1,0 +1,55 @@
+const handleRecords = new Set<[FileSystemFileHandle, FTInfo, FileSystemObserverInstance]>();
+
+export type FTInfo = {
+  uuid: string;
+  fileName: string;
+  setCode(code: string, hideInfo?: boolean): void;
+  lastModified?: number;
+};
+
+const callback = async (records: FileSystemChangeRecord[], observer: FileSystemObserverInstance) => {
+  for (const record of records) {
+    const { root, type } = record;
+    if (!(root instanceof FileSystemFileHandle) || type !== "modified") continue;
+    for (const [fileHandle, ftInfo, fileObserver] of handleRecords) {
+      if (fileObserver !== observer) continue;
+      try {
+        const isSame = await root.isSameEntry(fileHandle);
+        if (!isSame) continue;
+        // 调用安装
+        const file = await root.getFile();
+        // 避免重覆更新
+        if (ftInfo.lastModified === file.lastModified) continue;
+        ftInfo.lastModified = file.lastModified;
+        const code = await file.text();
+        if (code && typeof code === "string") {
+          ftInfo.setCode(code, false);
+        }
+      } catch (e) {
+        console.warn(e);
+      }
+    }
+  }
+};
+
+export const startFileTrack = (fileHandle: FileSystemFileHandle, ftInfo: FTInfo) => {
+  const fileObserver = new FileSystemObserver(callback);
+  handleRecords.add([fileHandle, ftInfo, fileObserver]);
+  fileObserver!.observe(fileHandle);
+};
+
+export const unmountFileTrack = async (fileHandle: FileSystemFileHandle) => {
+  try {
+    for (const entry of handleRecords) {
+      const [fileHandleEntry, _ftInfo, fileObserver] = entry;
+      if (await fileHandle.isSameEntry(fileHandleEntry)) {
+        handleRecords.delete(entry);
+        fileObserver.disconnect();
+        return true;
+      }
+    }
+  } catch (e) {
+    console.warn(e);
+  }
+  return false;
+};

--- a/src/pkg/utils/file-tracker.ts
+++ b/src/pkg/utils/file-tracker.ts
@@ -35,7 +35,7 @@ const callback = async (records: FileSystemChangeRecord[], observer: FileSystemO
 export const startFileTrack = (fileHandle: FileSystemFileHandle, ftInfo: FTInfo) => {
   const fileObserver = new FileSystemObserver(callback);
   handleRecords.add([fileHandle, ftInfo, fileObserver]);
-  fileObserver!.observe(fileHandle);
+  fileObserver.observe(fileHandle);
 };
 
 export const unmountFileTrack = async (fileHandle: FileSystemFileHandle) => {

--- a/src/pkg/utils/filehandle-db.ts
+++ b/src/pkg/utils/filehandle-db.ts
@@ -1,0 +1,44 @@
+import Dexie from "dexie";
+const dbName = "filehandle-temp-dexie";
+
+// Define the Dexie database class
+class FileHandleDB extends Dexie {
+  handles: Dexie.Table<{ handle: FileSystemFileHandle; timestamp: number }, string>;
+
+  constructor() {
+    super(dbName);
+    this.version(1).stores({
+      handles: "", // No key path, keys are provided explicitly as strings
+    });
+    this.handles = this.table("handles");
+  }
+}
+
+// Instantiate the database
+const db = new FileHandleDB();
+
+// Save a file handle with a timestamp
+export async function saveHandle(key: string, handle: FileSystemFileHandle): Promise<void> {
+  await db.handles.put({ handle, timestamp: Date.now() }, key);
+}
+
+// Load a file handle by key
+export async function loadHandle(key: string): Promise<FileSystemFileHandle> {
+  const result = await db.handles.get(key);
+  if (result?.handle instanceof FileSystemFileHandle) {
+    return result.handle;
+  } else {
+    throw new Error("Handle not found or invalid");
+  }
+}
+
+// Delete a file handle by key
+export async function deleteHandle(key: string): Promise<void> {
+  await db.handles.delete(key);
+}
+
+// 清除超过 15 分钟未使用的FileHandle
+export async function cleanupOldHandles(maxAgeMs = 15 * 60 * 1000): Promise<void> {
+  const now = Date.now();
+  await db.handles.filter((entry) => now - entry.timestamp > maxAgeMs).delete();
+}

--- a/src/pkg/utils/script.ts
+++ b/src/pkg/utils/script.ts
@@ -80,8 +80,9 @@ export async function prepareScriptByCode(
   origin: string,
   uuid?: string,
   override: boolean = false,
-  dao: ScriptDAO = new ScriptDAO()
+  dao?: ScriptDAO
 ): Promise<{ script: Script; oldScript?: Script; oldScriptCode?: string }> {
+  dao = dao ?? new ScriptDAO();
   const metadata = parseMetadata(code);
   if (metadata == null) {
     throw new Error("MetaData信息错误");

--- a/src/pkg/utils/scriptInstall.ts
+++ b/src/pkg/utils/scriptInstall.ts
@@ -1,0 +1,25 @@
+import type { InstallSource } from "@App/app/service/service_worker/types";
+import type { SCMetadata } from "@App/app/repo/metadata";
+
+export { InstallSource };
+
+export type ScriptInfo = {
+  url: string;
+  code: string;
+  uuid: string;
+  userSubscribe: boolean;
+  metadata: SCMetadata;
+  source: InstallSource;
+};
+
+// 供 getInstallInfo 使用
+export function createScriptInfo(
+  uuid: string,
+  code: string,
+  url: string,
+  source: InstallSource,
+  metadata: SCMetadata
+): ScriptInfo {
+  const userSubscribe = metadata.usersubscribe !== undefined;
+  return { uuid, code, url, source, metadata, userSubscribe } as ScriptInfo;
+}

--- a/src/types/main.d.ts
+++ b/src/types/main.d.ts
@@ -7,9 +7,21 @@ declare const sandbox: Window;
 
 declare const self: ServiceWorkerGlobalScope;
 
-declare interface Window {
-  localFile: File | undefined;
-  localFileHandle: FileSystemFileHandle | undefined;
+type FileSystemEventCallback = (records: any[], observer: FileSystemObserverInstance) => void;
+
+declare const FileSystemObserver: {
+  new (callback: FileSystemEventCallback): FileSystemObserverInstance;
+};
+
+interface FileSystemChangeRecord {
+  root: FileSystemFileHandle | FileSystemDirectoryHandle | FileSystemSyncAccessHandle;
+  type: string;
+  changedHandle: FileSystemFileHandle;
+}
+
+interface FileSystemObserverInstance {
+  disconnect(): void;
+  observe(handle: FileSystemFileHandle | FileSystemDirectoryHandle | FileSystemSyncAccessHandle): Promise<void>;
 }
 
 declare const MessageFlag: string;


### PR DESCRIPTION
好像没办法再拆PR
暂时没有其他PR了

1） 把 `fetchScriptInfo` 拆开成 `fetchScriptBody`，避免重覆进行 `parseMetadata`
2）ScriptInfo只用来做过渡用途。裡面的 update 拆了出来 - 因为实际看是不是更新，是检查 `prepareScriptByCode` 裡面有没有 `oldScript`
3）本地文件的fileHandle跟网络文件不一样。如果是F5等方式重载页面，会重新建立ScriptInfo。没有重载页面的话，代码是保持不变的。除非按了Watch File Change
4）按了Watch File 的话，会自动检查ScriptInfo的代码是否最新本地档案内容。安装并更新至最新本地档案内容后，用observer检查本地档案内容的更改。（假设情况：拉了档案后，改了一下，按Watch File. 此时会自动以最新本地档案内容安装，否则后面的observer运作会有矛盾）
5）页面的metadata 都是动态的。当Watch File的代码改变，页面的资讯也会一起改变。
6）因为Watch File时会自动安装成最新档案内容，不会有Diff （在安装页面有提醒 observer 检查到内容变更并更新）

