### PR TITLE
兼容性调整（pack.js 兼容性 及 API兼容性）

### DIFF
--- a/packages/message/extension_message.ts
+++ b/packages/message/extension_message.ts
@@ -93,7 +93,7 @@ export class ExtensionMessage extends ExtensionMessageSend implements Message {
   onMessage(
     callback: (data: TMessageCommAction, sendResponse: (data: any) => void, sender: MessageSender) => boolean | void
   ): void {
-    chrome.runtime.onMessage?.addListener((msg: TMessage, sender, sendResponse) => {
+    chrome.runtime.onMessage.addListener((msg: TMessage, sender, sendResponse) => {
       const lastError = chrome.runtime.lastError;
       if (lastError) {
         console.error("chrome.runtime.lastError in chrome.runtime.onMessage:", lastError);

--- a/packages/message/extension_message.ts
+++ b/packages/message/extension_message.ts
@@ -78,13 +78,13 @@ export class ExtensionMessage extends ExtensionMessageSend implements Message {
           // do nothing
         }
       };
-      // Firefox 需要先得到 userScripts 權限才能進行 onUserScriptConnect 的監聽
+      // Firefox 需要先得到 userScripts 权限才能进行 onUserScriptConnect 的监听
       this.tryEnableUserScriptConnectionListener = () => {
         if (typeof chrome.runtime.onUserScriptConnect?.addListener === "function") {
           addUserScriptConnectionListener && addUserScriptConnectionListener();
         }
       };
-      // Chrome 在初始化時就能監聽
+      // Chrome 在初始化时就能监听
       this.tryEnableUserScriptConnectionListener();
     }
   }
@@ -100,11 +100,18 @@ export class ExtensionMessage extends ExtensionMessageSend implements Message {
         // 消息API发生错误因此不继续执行
         return false;
       }
-      if ((msg as any)?.type === "userScripts.PERMISSION_GRANTED") {
-        console.log("userScripts.PERMISSION_GRANTED");
-        this.tryEnableUserScriptConnectionListener();
-        this.tryEnableUserScriptMessageListener();
-        sendResponse(1);
+      if ((msg as any)?.type === "userScripts.LISTEN_CONNECTIONS") {
+        console.log("userScripts.LISTEN_CONNECTIONS");
+        if (
+          typeof chrome.runtime.onUserScriptConnect?.addListener === "function" &&
+          typeof chrome.runtime.onUserScriptMessage?.addListener === "function"
+        ) {
+          this.tryEnableUserScriptConnectionListener();
+          this.tryEnableUserScriptMessageListener();
+          sendResponse(true);
+        } else {
+          sendResponse(false);
+        }
         return false;
       }
       if (typeof msg.action !== "string") return;
@@ -131,13 +138,13 @@ export class ExtensionMessage extends ExtensionMessageSend implements Message {
           // do nothing
         }
       };
-      // Firefox 需要先得到 userScripts 權限才能進行 onUserScriptMessage 的監聽
+      // Firefox 需要先得到 userScripts 权限才能进行 onUserScriptMessage 的监听
       this.tryEnableUserScriptMessageListener = () => {
         if (typeof chrome.runtime.onUserScriptMessage?.addListener === "function") {
           addUserScriptMessageListener && addUserScriptMessageListener();
         }
       };
-      // Chrome 在初始化時就能監聽
+      // Chrome 在初始化时就能监听
       this.tryEnableUserScriptMessageListener();
     }
   }

--- a/packages/message/extension_message.ts
+++ b/packages/message/extension_message.ts
@@ -30,7 +30,14 @@ export class ExtensionMessageSend implements MessageSend {
 }
 
 export class ExtensionMessage extends ExtensionMessageSend implements Message {
-  constructor(private onUserScript = false) {
+  tryEnableUserScriptConnectionListener = (..._args: any) => {
+    // empty function
+  };
+  tryEnableUserScriptMessageListener = (..._args: any) => {
+    // empty function
+  };
+
+  constructor(private backgroundPrimary = false) {
     super();
   }
 
@@ -49,20 +56,36 @@ export class ExtensionMessage extends ExtensionMessageSend implements Message {
       port!.onMessage.addListener(handler);
     });
 
-    if (this.onUserScript) {
-      // 监听用户脚本的连接
-      chrome.runtime.onUserScriptConnect.addListener((port: chrome.runtime.Port | null) => {
-        const lastError = chrome.runtime.lastError;
-        if (lastError) {
-          console.error("chrome.runtime.lastError in chrome.runtime.onUserScriptConnect:", lastError);
+    if (this.backgroundPrimary) {
+      let addUserScriptConnectionListener: (() => void) | null = () => {
+        try {
+          // 监听用户脚本的连接
+          chrome.runtime.onUserScriptConnect.addListener((port: chrome.runtime.Port | null) => {
+            const lastError = chrome.runtime.lastError;
+            if (lastError) {
+              console.error("chrome.runtime.lastError in chrome.runtime.onUserScriptConnect:", lastError);
+            }
+            const handler = (msg: TMessage) => {
+              port!.onMessage.removeListener(handler);
+              callback(msg, new ExtensionMessageConnect(port!));
+              port = null;
+            };
+            port!.onMessage.addListener(handler);
+          });
+          addUserScriptConnectionListener = null;
+          console.log("addUserScriptConnectionListener() is executed.");
+        } catch {
+          // do nothing
         }
-        const handler = (msg: TMessage) => {
-          port!.onMessage.removeListener(handler);
-          callback(msg, new ExtensionMessageConnect(port!));
-          port = null;
-        };
-        port!.onMessage.addListener(handler);
-      });
+      };
+      // Firefox 需要先得到 userScripts 權限才能進行 onUserScriptConnect 的監聽
+      this.tryEnableUserScriptConnectionListener = () => {
+        if (typeof chrome.runtime.onUserScriptConnect?.addListener === "function") {
+          addUserScriptConnectionListener && addUserScriptConnectionListener();
+        }
+      };
+      // Chrome 在初始化時就能監聽
+      this.tryEnableUserScriptConnectionListener();
     }
   }
 
@@ -72,26 +95,50 @@ export class ExtensionMessage extends ExtensionMessageSend implements Message {
   ): void {
     chrome.runtime.onMessage?.addListener((msg: TMessage, sender, sendResponse) => {
       const lastError = chrome.runtime.lastError;
-      if (typeof msg.action !== "string") return;
       if (lastError) {
         console.error("chrome.runtime.lastError in chrome.runtime.onMessage:", lastError);
         // 消息API发生错误因此不继续执行
         return false;
       }
+      if ((msg as any)?.type === "userScripts.PERMISSION_GRANTED") {
+        console.log("userScripts.PERMISSION_GRANTED");
+        this.tryEnableUserScriptConnectionListener();
+        this.tryEnableUserScriptMessageListener();
+        sendResponse(1);
+        return false;
+      }
+      if (typeof msg.action !== "string") return;
       return callback(msg, sendResponse, sender);
     });
-    if (this.onUserScript) {
-      // 监听用户脚本的消息
-      chrome.runtime.onUserScriptMessage?.addListener((msg: TMessage, sender, sendResponse) => {
-        const lastError = chrome.runtime.lastError;
-        if (typeof msg.action !== "string") return;
-        if (lastError) {
-          console.error("chrome.runtime.lastError in chrome.runtime.onUserScriptMessage:", lastError);
-          // 消息API发生错误因此不继续执行
-          return false;
+
+    if (this.backgroundPrimary) {
+      let addUserScriptMessageListener: (() => void) | null = () => {
+        try {
+          // 监听用户脚本的消息
+          chrome.runtime.onUserScriptMessage.addListener((msg: TMessage, sender, sendResponse) => {
+            const lastError = chrome.runtime.lastError;
+            if (typeof msg.action !== "string") return;
+            if (lastError) {
+              console.error("chrome.runtime.lastError in chrome.runtime.onUserScriptMessage:", lastError);
+              // 消息API发生错误因此不继续执行
+              return false;
+            }
+            return callback(msg, sendResponse, sender);
+          });
+          addUserScriptMessageListener = null;
+          console.log("addUserScriptMessageListener() is executed.");
+        } catch {
+          // do nothing
         }
-        return callback(msg, sendResponse, sender);
-      });
+      };
+      // Firefox 需要先得到 userScripts 權限才能進行 onUserScriptMessage 的監聽
+      this.tryEnableUserScriptMessageListener = () => {
+        if (typeof chrome.runtime.onUserScriptMessage?.addListener === "function") {
+          addUserScriptMessageListener && addUserScriptMessageListener();
+        }
+      };
+      // Chrome 在初始化時就能監聽
+      this.tryEnableUserScriptMessageListener();
     }
   }
 }

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -43,9 +43,9 @@ export class RuntimeService {
 
   logger: Logger;
 
-  // 当前扩充是否在开发者模式打开时执行
+  // 当前扩充是否允许执行 UserScripts API (例如是否已打开开发者模式，或已给予 userScripts 权限)
   // 在未初始化前，预设 false。一般情况初始化值会很快被替换
-  isEnableDeveloperMode = false;
+  boolUserScriptsAvailable = false;
 
   // 当前扩充是否开啟了啟用脚本
   // 在未初始化前，预设 true。一般情况初始化值会很快被替换
@@ -236,22 +236,80 @@ export class RuntimeService {
       });
     });
 
+    const onUserScriptAPIGrantAdded = async () => {
+      this.boolUserScriptsAvailable = true;
+      const res = await new Promise((resolve) => {
+        chrome.runtime.sendMessage({ type: "userScripts.PERMISSION_GRANTED" }, (resp) => {
+          const lastError = chrome.runtime.lastError;
+          if (lastError) {
+            console.error("chrome.runtime.lastError in chrome.runtime.sendMessage:", lastError.message);
+          }
+          resolve(resp);
+        });
+      });
+      if (res === 1) {
+        console.log("onUserScriptAPIGrantAdded() is executed.");
+        // 先取消当前注册 （如有）。
+        // 只是安全起见用。一般情况应该没有注册。
+        await this.unregisterUserscripts();
+        // 如果初始化时开啟了啟用脚本，则注册脚本
+        if (this.isLoadScripts) {
+          await this.registerUserscripts();
+        }
+      }
+    };
+
+    const onUserScriptAPIGrantRemoved = async () => {
+      this.boolUserScriptsAvailable = false;
+      console.log("onUserScriptAPIGrantRemoved() is executed.");
+      // 取消当前注册 （如有）
+      await this.unregisterUserscripts();
+    };
+
+    chrome.permissions.onAdded.addListener((permissions: chrome.permissions.Permissions) => {
+      const lastError = chrome.runtime.lastError;
+      if (lastError) {
+        console.error("chrome.runtime.lastError in chrome.permissions.onAdded:", lastError);
+        return;
+      }
+      if (permissions.permissions?.includes("userScripts")) {
+        // Firefox 或其他瀏览器或需要手动啟动 optional_permission
+        // 啟动后注册脚本，不需重啟扩充
+        onUserScriptAPIGrantAdded();
+      }
+      console.log("chrome.permissions.onAdded", [...(permissions.permissions || [])]);
+    });
+
+    chrome.permissions.onRemoved.addListener((permissions: chrome.permissions.Permissions) => {
+      const lastError = chrome.runtime.lastError;
+      if (lastError) {
+        console.error("chrome.runtime.lastError in chrome.permissions.onRemoved:", lastError);
+        return;
+      }
+      if (permissions.permissions?.includes("userScripts")) {
+        // 虽然在目前设计中未有使用 permissions.remove
+        // 仅保留作为未来之用
+        onUserScriptAPIGrantRemoved();
+      }
+      console.log("chrome.permissions.onRemoved", [...(permissions.permissions || [])]);
+    });
+
     // ======== 以下初始化是异步处理，因此扩充载入时可能会优先跑其他同步初始化 ========
 
     // 取得初始值
-    const [isEnableDeveloperMode, isLoadScripts, strBlacklist] = await Promise.all([
+    const [boolUserScriptsAvailable, isLoadScripts, strBlacklist] = await Promise.all([
       isUserScriptsAvailable(),
       this.systemConfig.getEnableScript(),
       this.systemConfig.getBlacklist(),
     ]);
 
     // 保存初始值
-    this.isEnableDeveloperMode = isEnableDeveloperMode;
+    this.boolUserScriptsAvailable = boolUserScriptsAvailable;
     this.isLoadScripts = isLoadScripts;
     this.blacklist = obtainBlackList(strBlacklist);
 
     // 检查是否开启了开发者模式
-    if (!this.isEnableDeveloperMode) {
+    if (!this.boolUserScriptsAvailable) {
       // 未开启加上警告引导
       this.showNoDeveloperModeWarning();
     }
@@ -262,7 +320,7 @@ export class RuntimeService {
     await this.initUserAgentData();
 
     // 如果初始化时开啟了啟用脚本，则注册脚本
-    if (this.isLoadScripts) {
+    if (boolUserScriptsAvailable && this.isLoadScripts) {
       await this.registerUserscripts();
     }
   }
@@ -282,8 +340,7 @@ export class RuntimeService {
 
   // 取消脚本注册
   async unregisterUserscripts() {
-    await chrome.userScripts.unregister();
-    return this.deleteMessageFlag();
+    await Promise.allSettled([chrome.userScripts.unregister(), this.deleteMessageFlag()]);
   }
 
   async registerUserscripts() {
@@ -326,7 +383,7 @@ export class RuntimeService {
       });
 
       // 如果脚本开启, 则注册脚本
-      if (this.isEnableDeveloperMode && this.isLoadScripts) {
+      if (this.boolUserScriptsAvailable && this.isLoadScripts) {
         // 批量注册
         // 先删除所有脚本
         await chrome.userScripts.unregister();
@@ -840,7 +897,7 @@ export class RuntimeService {
     const { registerScript } = resp;
 
     // 如果脚本开启, 则注册脚本
-    if (this.isEnableDeveloperMode && this.isLoadScripts && script.status === SCRIPT_STATUS_ENABLE) {
+    if (this.boolUserScriptsAvailable && this.isLoadScripts && script.status === SCRIPT_STATUS_ENABLE) {
       const res = await chrome.userScripts.getScripts({ ids: [uuid] });
       const logger = LoggerCore.logger({
         name,
@@ -868,7 +925,7 @@ export class RuntimeService {
 
   async unregistryPageScript(uuid: string) {
     const cacheKey = `${CACHE_KEY_REGISTRY_SCRIPT}${uuid}`;
-    if (!this.isEnableDeveloperMode || !this.isLoadScripts || !(await cacheInstance.get(cacheKey))) {
+    if (!this.boolUserScriptsAvailable || !this.isLoadScripts || !(await cacheInstance.get(cacheKey))) {
       return;
     }
     // 删除缓存

--- a/src/app/service/service_worker/utils.ts
+++ b/src/app/service/service_worker/utils.ts
@@ -160,3 +160,31 @@ export function msgResponse<T>(errType: number, t: Error | any, params?: T): TMs
   const { name, message } = t;
   return { ok: false, err: { name, message, errType, ...t, ...params } };
 }
+
+export async function notificationsUpdate(
+  notificationId: string,
+  options: chrome.notifications.NotificationOptions
+): Promise<
+  | {
+      ok: true;
+      res: boolean | null;
+    }
+  | ({
+      ok: false;
+    } & {
+      browserNoSupport?: true;
+      apiError?: Error;
+    })
+> {
+  // No Support in Firefox
+  if (typeof chrome.notifications?.update !== "function") {
+    return { ok: false, browserNoSupport: true };
+  }
+  try {
+    // chrome > 116 return Promise<boolean>
+    const wasUpdated: any = await chrome.notifications.update(notificationId, options);
+    return { ok: true, res: typeof wasUpdated === "boolean" ? wasUpdated : null };
+  } catch (e: any) {
+    return { ok: false, apiError: e as Error };
+  }
+}

--- a/src/content.ts
+++ b/src/content.ts
@@ -6,7 +6,7 @@ import { RuntimeClient } from "./app/service/service_worker/client";
 import { Server } from "@Packages/message/server";
 import ContentRuntime from "./app/service/content/content";
 
-if (typeof chrome?.runtime?.onMessage !== "function") {
+if (typeof chrome?.runtime?.onMessage?.addListener !== "function") {
   // ScriptCat 未支持 Firefox MV3
   console.error("Firefox MV3 UserScripts is not yet supported by ScriptCat");
 } else {

--- a/src/content.ts
+++ b/src/content.ts
@@ -6,7 +6,7 @@ import { RuntimeClient } from "./app/service/service_worker/client";
 import { Server } from "@Packages/message/server";
 import ContentRuntime from "./app/service/content/content";
 
-if (typeof chrome?.runtime?.onMessage !== "undefined") {
+if (typeof chrome?.runtime?.onMessage !== "function") {
   // ScriptCat 未支持 Firefox MV3
   console.error("Firefox MV3 UserScripts is not yet supported by ScriptCat");
 } else {

--- a/src/pages/popup/App.tsx
+++ b/src/pages/popup/App.tsx
@@ -245,24 +245,38 @@ function App() {
       {showRequestButton && (
         <Button
           onClick={() => {
-            chrome.permissions.request({ permissions: ["userScripts"] }, function (granted) {
-              const lastError = chrome.runtime.lastError;
-              if (lastError) {
-                granted = false;
-                console.error("chrome.runtime.lastError in chrome.permissions.request:", lastError.message);
+            const updateOnPermissionGranted = async (granted: boolean) => {
+              if (granted) {
+                granted = await new Promise((resolve) => {
+                  chrome.runtime.sendMessage({ type: "userScripts.LISTEN_CONNECTIONS" }, (resp) => {
+                    const lastError = chrome.runtime.lastError;
+                    if (lastError) {
+                      resp = false;
+                      console.error("chrome.runtime.lastError in chrome.permissions.request:", lastError.message);
+                    }
+                    resolve(resp === true);
+                  });
+                });
               }
               if (granted) {
                 console.log("Permission granted");
                 setPermissionReqResult("✅");
-                // 需要进行UserScript API相关的通讯初始化
-                // 或是使用 用 chrome.permissions.onAdded.addListener
-                // 及 chrome.permissions.onRemoved.addListener
-                // 来实现
+                // UserScripts API相关的初始化：
+                // userScripts.LISTEN_CONNECTIONS 進行 Server 通讯初始化
+                // onUserScriptAPIGrantAdded 進行 腳本注冊
                 updateIsUserScriptsAvailableState();
               } else {
                 console.log("Permission denied");
                 setPermissionReqResult("❎");
               }
+            };
+            chrome.permissions.request({ permissions: ["userScripts"] }, (granted) => {
+              const lastError = chrome.runtime.lastError;
+              if (lastError) {
+                granted = false;
+                console.error("chrome.runtime.lastError in chrome.permissions.request:", lastError.message);
+              }
+              updateOnPermissionGranted(granted);
             });
           }}
         >

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -51,7 +51,7 @@ async function setupOffscreenDocument() {
             console.log("setupOffscreenDocument() calling is invalid.");
             return;
           }
-          creating = true; // chrome.offscreen.createDocument 只執行一次
+          creating = true; // chrome.offscreen.createDocument 只执行一次
         });
       creating = promise;
     }


### PR DESCRIPTION
## pack.js 兼容性
1. 修正 manifest 代码问题 `{ ...manifest, background: { ...manifest.background } }`
2. strict_min_version 至 [FireFox 136.0](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts#browser_compatibility)
3. 跟MV2 打包一样 加 firefoxManifest.browser_specific_settings.gecko.id
4. 跟MV2 打包一样 加 beta时红猫logo
5. 加入 PACK_FIREFOX = false，让其他人 fork 这个分支时，能改代码啟用 firefox 打包 （官方main branch 不啟用）


## API兼容性
1. 增强 `chrome.notifications.update` 的兼容性
2. isEnableDeveloperMode -> boolUserScriptsAvailable (现在Chrome新版本跟Firefox都不是判断 Developer Mode)
3. 在以 optional permission 取得UserScripts API权限的瀏览器，`chrome.runtime.onUserScriptConnect.addListener` 和 `chrome.runtime.onUserScriptMessage.addListener` 会在 optional permission 取得后才执行
4. 取得 permission 后取消 `showNoDeveloperModeWarning`

## 修正以前错误的commit
1. c5ac3e34176b10ab5f52e705da3d0764aae5519d 中使用了 `chrome.runtime.onMessage?.addListener`。现改回 `chrome.runtime.onMessage.addListener`

## 其他
1. 改善注册脚本流程
2. 针对没有 runtime.onMessage 的情况，因为 extSend 无法正确设置，改为显示错误且不继续执行。
3. [Firefox MV3 没有expose onMessage](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/WorldProperties#messaging), 日后需改用其他方式来实现对Firefox MV3的支持