### PR TITLE
兼容性调整（offscreen）及代码优化

### DIFF
--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -14,7 +14,7 @@ migrate();
 
 const OFFSCREEN_DOCUMENT_PATH = "src/offscreen.html";
 
-let creating: Promise<void> | null;
+let creating: Promise<void> | null | boolean = null;
 
 async function hasDocument() {
   const offscreenUrl = chrome.runtime.getURL(OFFSCREEN_DOCUMENT_PATH);
@@ -26,26 +26,36 @@ async function hasDocument() {
 }
 
 async function setupOffscreenDocument() {
+  if (typeof chrome.offscreen?.createDocument !== "function") {
+    // Firefox does not support offscreen
+    console.error("Your browser does not support chrome.offscreen.createDocument");
+    return;
+  }
   //if we do not have a document, we are already setup and can skip
   if (!(await hasDocument())) {
     // create offscreen document
-    if (creating) {
-      await creating;
-    } else {
-      creating = chrome.offscreen.createDocument({
-        url: OFFSCREEN_DOCUMENT_PATH,
-        reasons: [
-          chrome.offscreen.Reason.BLOBS,
-          chrome.offscreen.Reason.CLIPBOARD,
-          chrome.offscreen.Reason.DOM_SCRAPING,
-          chrome.offscreen.Reason.LOCAL_STORAGE,
-        ],
-        justification: "offscreen page",
-      });
-
-      await creating;
-      creating = null;
+    if (!creating) {
+      const promise = chrome.offscreen
+        .createDocument({
+          url: OFFSCREEN_DOCUMENT_PATH,
+          reasons: [
+            chrome.offscreen.Reason.BLOBS,
+            chrome.offscreen.Reason.CLIPBOARD,
+            chrome.offscreen.Reason.DOM_SCRAPING,
+            chrome.offscreen.Reason.LOCAL_STORAGE,
+          ],
+          justification: "offscreen page",
+        })
+        .then(() => {
+          if (creating !== promise) {
+            console.log("setupOffscreenDocument() calling is invalid.");
+            return;
+          }
+          creating = true; // chrome.offscreen.createDocument 只执行一次
+        });
+      creating = promise;
     }
+    await creating;
   }
 }
 
@@ -75,23 +85,23 @@ const apiActions: {
   },
 };
 
-chrome.runtime.onMessage.addListener((req, sender, sendReseponse) => {
+chrome.runtime.onMessage.addListener((req, sender, sendResponse) => {
   const f = apiActions[req.message ?? ""];
   if (f) {
     let res;
     try {
       res = f(req, sender);
     } catch (e: any) {
-      sendReseponse(msgResponse(1, e));
+      sendResponse(msgResponse(1, e));
       return false;
     }
     if (typeof res?.then === "function") {
-      res.then(sendReseponse).catch((e: Error) => {
-        sendReseponse(msgResponse(1, e));
+      res.then(sendResponse).catch((e: Error) => {
+        sendResponse(msgResponse(1, e));
       });
       return true;
     } else {
-      sendReseponse(msgResponse(0, res));
+      sendResponse(msgResponse(0, res));
       return false;
     }
   }


### PR DESCRIPTION
我明白 offscreen 是对ScriptCat是很重要的一部份
但现在即使Firefox不支持 offscreen, 也只是一部份的API不能用
因此日后即使都不支持，可以文档或者什麼方式去提醒用户

当然现在不需要。因为ScriptCat没有正式支持Firefox
只是从测试角度来看，还应该是可以在Firefox测试看看

----
所以加这个就可以了吧
```js
  if (typeof chrome.offscreen?.createDocument !== "function") {
    // Firefox does not support offscreen
    console.error("Your browser does not support chrome.offscreen.createDocument");
    return;
  }
```
---