### PR TITLE
兼容性调整：没有 `chrome.runtime.onMessage`的话 `content.js` 要报错

### DIFF
--- a/packages/message/extension_message.ts
+++ b/packages/message/extension_message.ts
@@ -70,7 +70,7 @@ export class ExtensionMessage extends ExtensionMessageSend implements Message {
   onMessage(
     callback: (data: TMessageCommAction, sendResponse: (data: any) => void, sender: MessageSender) => boolean | void
   ): void {
-    chrome.runtime.onMessage?.addListener((msg: TMessage, sender, sendResponse) => {
+    chrome.runtime.onMessage.addListener((msg: TMessage, sender, sendResponse) => {
       const lastError = chrome.runtime.lastError;
       if (typeof msg.action !== "string") return;
       if (lastError) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -6,26 +6,31 @@ import { RuntimeClient } from "./app/service/service_worker/client";
 import { Server } from "@Packages/message/server";
 import ContentRuntime from "./app/service/content/content";
 
-// 建立与service_worker页面的连接
-const send = new ExtensionMessageSend();
+if (typeof chrome?.runtime?.onMessage?.addListener !== "function") {
+  // ScriptCat 未支持 Firefox MV3
+  console.error("Firefox MV3 UserScripts is not yet supported by ScriptCat");
+} else {
+  // 建立与service_worker页面的连接
+  const send = new ExtensionMessageSend();
 
-// 初始化日志组件
-const loggerCore = new LoggerCore({
-  writer: new MessageWriter(send),
-  labels: { env: "content" },
-});
+  // 初始化日志组件
+  const loggerCore = new LoggerCore({
+    writer: new MessageWriter(send),
+    labels: { env: "content" },
+  });
 
-const client = new RuntimeClient(send);
-client.pageLoad().then((data) => {
-  loggerCore.logger().debug("content start");
-  const extMsg = new ExtensionMessage();
-  const msg = new CustomEventMessage(data.flag, true);
-  const server = new Server("content", msg);
-  // Opera中没有chrome.runtime.onConnect，并且content也不需要chrome.runtime.onConnect
-  // 所以不需要处理连接，设置为false
-  const extServer = new Server("content", extMsg, false);
-  // 初始化运行环境
-  const runtime = new ContentRuntime(extServer, server, send, msg);
-  runtime.init();
-  runtime.start(data.scripts, data.envInfo);
-});
+  const client = new RuntimeClient(send);
+  client.pageLoad().then((data) => {
+    loggerCore.logger().debug("content start");
+    const extMsg = new ExtensionMessage();
+    const msg = new CustomEventMessage(data.flag, true);
+    const server = new Server("content", msg);
+    // Opera中没有chrome.runtime.onConnect，并且content也不需要chrome.runtime.onConnect
+    // 所以不需要处理连接，设置为false
+    const extServer = new Server("content", extMsg, false);
+    // 初始化运行环境
+    const runtime = new ContentRuntime(extServer, server, send, msg);
+    runtime.init();
+    runtime.start(data.scripts, data.envInfo);
+  });
+}


### PR DESCRIPTION
`content.js` 裡要用 `chrome.runtime.onMessage` 来实现 `const extMsg = new ExtensionMessage();`
这影响 `extServer` 跟 `runtime` 
（ 把 `content.js` 改用传统的 `content_scripts` 等方法来实现兼容是后话 ）