### PR TITLE
代码优化：Global Search

### DIFF
--- a/src/app/service/service_worker/client.ts
+++ b/src/app/service/service_worker/client.ts
@@ -2,7 +2,7 @@ import type { Script, ScriptCode, ScriptRunResource } from "@App/app/repo/script
 import { type Resource } from "@App/app/repo/resource";
 import { type Subscribe } from "@App/app/repo/subscribe";
 import { type Permission } from "@App/app/repo/permission";
-import type { InstallSource, ScriptMenu, ScriptMenuItem } from "./types";
+import type { InstallSource, ScriptMenu, ScriptMenuItem, SearchType } from "./types";
 import { Client } from "@Packages/message/client";
 import type { MessageSend } from "@Packages/message/types";
 import type PermissionVerify from "./permission_verify";
@@ -60,6 +60,10 @@ export class ScriptClient extends Client {
 
   getCode(uuid: string): Promise<ScriptCode | undefined> {
     return this.do("getCode", uuid);
+  }
+
+  getFilterResult(req: { type: SearchType; value: string }): Promise<ScriptCode | undefined> {
+    return this.do("getFilterResult", req);
   }
 
   getScriptRunResource(script: Script): Promise<ScriptRunResource> {

--- a/src/app/service/service_worker/client.ts
+++ b/src/app/service/service_worker/client.ts
@@ -58,10 +58,6 @@ export class ScriptClient extends Client {
     return this.doThrow("fetchInfo", uuid);
   }
 
-  getCode(uuid: string): Promise<ScriptCode | undefined> {
-    return this.do("getCode", uuid);
-  }
-
   getFilterResult(req: { type: SearchType; value: string }): Promise<ScriptCode | undefined> {
     return this.do("getFilterResult", req);
   }

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -324,10 +324,6 @@ export class ScriptService {
     return true;
   }
 
-  getCode(uuid: string) {
-    return this.scriptCodeDAO.get(uuid);
-  }
-
   async getFilterResult(req: { type: SearchType; value: string }) {
     const OPTION_CASE_INSENSITIVE = true;
     const scripts = await this.scriptDAO.all();
@@ -403,7 +399,7 @@ export class ScriptService {
     return Promise.all([
       this.valueService.getScriptValue(ret),
       this.resourceService.getScriptResources(ret, true),
-      this.getCode(script.uuid),
+      this.scriptCodeDAO.get(script.uuid),
     ]).then(([value, resource, code]) => {
       if (!code) {
         throw new Error("code is null");
@@ -709,7 +705,6 @@ export class ScriptService {
     this.group.on("enable", this.enableScript.bind(this));
     this.group.on("fetchInfo", this.fetchInfo.bind(this));
     this.group.on("updateRunStatus", this.updateRunStatus.bind(this));
-    this.group.on("getCode", this.getCode.bind(this));
     this.group.on("getFilterResult", this.getFilterResult.bind(this));
     this.group.on("getScriptRunResource", this.getScriptRunResource.bind(this));
     this.group.on("excludeUrl", this.excludeUrl.bind(this));

--- a/src/app/service/service_worker/types.ts
+++ b/src/app/service/service_worker/types.ts
@@ -3,6 +3,7 @@ import { type URLRuleEntry } from "@App/pkg/utils/url_matcher";
 import { type GetSender } from "@Packages/message/server";
 
 export type InstallSource = "user" | "system" | "sync" | "subscribe" | "vscode";
+export type SearchType = "auto" | "name" | "script_code";
 
 export interface ScriptMatchInfo extends ScriptRunResource {
   scriptUrlPatterns: URLRuleEntry[]; // 已被自定义覆盖的 UrlPatterns

--- a/src/pages/options/routes/ScriptList.tsx
+++ b/src/pages/options/routes/ScriptList.tsx
@@ -82,11 +82,12 @@ import {
   updateEnableStatus,
   synchronizeClient,
   batchDeleteScript,
-  requestScriptCode,
+  requestFilterResult,
 } from "@App/pages/store/features/script";
 import { ValueClient } from "@App/app/service/service_worker/client";
 import { loadScriptFavicons } from "@App/pages/store/utils";
 import { store } from "@App/pages/store/store";
+import type { SearchType } from "@App/app/service/service_worker/types";
 
 type ListType = ScriptLoading;
 type RowCtx = ReturnType<typeof useSortable> | null;
@@ -204,8 +205,6 @@ const EnableSwitch = React.memo(
 );
 EnableSwitch.displayName = "EnableSwitch";
 
-type SearchType = "auto" | "name" | "script_code";
-
 function ScriptList() {
   const [userConfig, setUserConfig] = useState<{
     script: Script;
@@ -224,6 +223,19 @@ function ScriptList() {
   const [selectColumn, setSelectColumn] = useState(0);
   const [savedWidths, setSavedWidths] = useState<{ [key: string]: number } | null>(null);
   const { t } = useTranslation();
+
+  const filterCache: Map<string, any> = new Map<string, any>();
+
+  const setFilterCache = (res: Partial<Record<string, any>>[]) => {
+    filterCache.clear();
+    for (const entry of res) {
+      filterCache.set(entry.uuid, {
+        code: entry.code === true,
+        name: entry.name === true,
+        auto: entry.auto === true,
+      });
+    }
+  };
 
   // 处理拖拽排序
   const sensors = useSensors(
@@ -312,8 +324,16 @@ function ScriptList() {
                   size="small"
                   value={filterKeys[0].type || "auto"}
                   onChange={(value) => {
-                    filterKeys[0].type = value;
-                    setFilterKeys([...filterKeys]);
+                    if (value !== filterKeys[0].type) {
+                      filterKeys[0].type = value;
+                      dispatch(requestFilterResult({ type: value, value: filterKeys[0].value }))
+                        .unwrap()
+                        .then((res) => {
+                          if (filterKeys[0].type !== value) return;
+                          setFilterCache(res as any);
+                          setFilterKeys([...filterKeys]);
+                        });
+                    }
                   }}
                 >
                   <Select.Option value="auto">{t("auto")}</Select.Option>
@@ -332,8 +352,16 @@ function ScriptList() {
                   }
                   value={filterKeys[0].value || ""}
                   onChange={(value) => {
-                    filterKeys[0].value = value;
-                    setFilterKeys([...filterKeys]);
+                    if (value !== filterKeys[0].value) {
+                      filterKeys[0].value = value;
+                      dispatch(requestFilterResult({ value, type: filterKeys[0].type }))
+                        .unwrap()
+                        .then((res) => {
+                          if (filterKeys[0].value !== value) return;
+                          setFilterCache(res as any);
+                          setFilterKeys([...filterKeys]);
+                        });
+                    }
                   }}
                   onSearch={() => {
                     confirm!();
@@ -346,42 +374,18 @@ function ScriptList() {
             if (!value || !value.value) {
               return true;
             }
-            const keyword = value.value.toLocaleLowerCase();
-            row.name = row.name.toLocaleLowerCase();
-            const i18n = i18nName(row).toLocaleLowerCase();
-            // 空格分开关键字搜索
-            const keys = keyword.split(" ");
-            const searchName = (keyword: string) => {
-              return row.name.includes(keyword) || i18n.includes(keyword);
-            };
-            const searchCode = (keyword: string) => {
-              if (!row.code) {
-                // 没有code，请求一下code
-                dispatch(requestScriptCode(row.uuid));
+            const result = filterCache.get(row.uuid);
+            if (!result) return false;
+            switch (value.type) {
+              case "auto":
+                return result.auto;
+              case "script_code":
+                return result.code;
+              case "name":
+                return result.name;
+              default:
                 return false;
-              }
-              return row.code.includes(keyword);
-            };
-            for (const key of keys) {
-              switch (value.type) {
-                case "auto":
-                  if (searchName(key) || searchCode(key)) {
-                    return true;
-                  }
-                  break;
-                case "script_code":
-                  if (searchCode(key)) {
-                    return true;
-                  }
-                  break;
-                case "name":
-                  if (searchName(key)) {
-                    return true;
-                  }
-                  break;
-              }
             }
-            return false;
           },
           onFilterDropdownVisibleChange: (visible) => {
             if (visible) {

--- a/src/pages/options/routes/ScriptList.tsx
+++ b/src/pages/options/routes/ScriptList.tsx
@@ -226,8 +226,9 @@ function ScriptList() {
 
   const filterCache: Map<string, any> = new Map<string, any>();
 
-  const setFilterCache = (res: Partial<Record<string, any>>[]) => {
+  const setFilterCache = (res: Partial<Record<string, any>>[] | null) => {
     filterCache.clear();
+    if (res === null) return;
     for (const entry of res) {
       filterCache.set(entry.uuid, {
         code: entry.code === true,
@@ -326,6 +327,11 @@ function ScriptList() {
                   onChange={(value) => {
                     if (value !== filterKeys[0].type) {
                       filterKeys[0].type = value;
+                      if (!filterKeys[0].value) {
+                        setFilterCache(null);
+                        setFilterKeys([...filterKeys]);
+                        return;
+                      }
                       dispatch(requestFilterResult({ type: value, value: filterKeys[0].value }))
                         .unwrap()
                         .then((res) => {
@@ -354,6 +360,11 @@ function ScriptList() {
                   onChange={(value) => {
                     if (value !== filterKeys[0].value) {
                       filterKeys[0].value = value;
+                      if (!filterKeys[0].value) {
+                        setFilterCache(null);
+                        setFilterKeys([...filterKeys]);
+                        return;
+                      }
                       dispatch(requestFilterResult({ value, type: filterKeys[0].type }))
                         .unwrap()
                         .then((res) => {

--- a/src/pages/store/features/script.ts
+++ b/src/pages/store/features/script.ts
@@ -49,18 +49,6 @@ export const requestDeleteScript = createAsyncThunk("script/deleteScript", async
   return await scriptClient.delete(uuid);
 });
 
-export const requestScriptCode = createAsyncThunk("script/requestScriptCode", async (uuid: string, { getState }) => {
-  const state = getState() as { script: { scripts: ScriptLoading[] } };
-  const script = state.script.scripts.find((s) => s.uuid === uuid);
-
-  // 如果已经有代码了，直接返回
-  if (script?.code !== undefined) {
-    return { code: script.code };
-  }
-
-  return await scriptClient.getCode(uuid);
-});
-
 export const requestFilterResult = createAsyncThunk(
   "script/requestFilterResult",
   async (req: { type: SearchType; value: string }) => {
@@ -192,13 +180,7 @@ export const scriptSlice = createAppSlice({
       )
       .addCase(requestStopScript.fulfilled, (state, action) =>
         updateScript(state.scripts, action.meta.arg, (s) => (s.actionLoading = false))
-      )
-      //处理请求脚本代码
-      .addCase(requestScriptCode.fulfilled, (state, action) => {
-        updateScript(state.scripts, action.meta.arg, (s) => {
-          s.code = action.payload?.code.toLocaleLowerCase();
-        });
-      });
+      );
   },
   selectors: {
     selectScripts: (state) => state.scripts,

--- a/src/pages/store/features/script.ts
+++ b/src/pages/store/features/script.ts
@@ -15,6 +15,7 @@ import {
   ValueClient,
 } from "@App/app/service/service_worker/client";
 import { message } from "../global";
+import type { SearchType } from "@App/app/service/service_worker/types";
 
 export const scriptClient = new ScriptClient(message);
 export const subscribeClient = new SubscribeClient(message);
@@ -59,6 +60,13 @@ export const requestScriptCode = createAsyncThunk("script/requestScriptCode", as
 
   return await scriptClient.getCode(uuid);
 });
+
+export const requestFilterResult = createAsyncThunk(
+  "script/requestFilterResult",
+  async (req: { type: SearchType; value: string }) => {
+    return await scriptClient.getFilterResult(req);
+  }
+);
 
 export type ScriptLoading = Script & {
   enableLoading?: boolean;


### PR DESCRIPTION
优化前：结果一个一个跑出来，不断 rerendering, 超卡
优化后：即时结果

----
尽量不要用交互通讯取了所有scripts 再用交互通讯一个个搞
全部放在SW那边做
一个request, 一个 response
而不是 1 + N (考虑异步处理带来的浏览器rendering, 就是 2+2N了）

ScriptCat这个部份优化做得不好。
那些启动浏览器时载入速度比TM慢也是这些原因

像我的N>200就很明显