### PR TITLE
增加编辑器配置和编辑器类型定义

### DIFF
--- a/src/pages/components/CodeEditor/config.ts
+++ b/src/pages/components/CodeEditor/config.ts
@@ -1,0 +1,3 @@
+const config = {};
+
+export const defaultConfig = JSON.stringify(config, null, 2);

--- a/src/pages/components/CodeEditor/index.tsx
+++ b/src/pages/components/CodeEditor/index.tsx
@@ -1,5 +1,5 @@
 import { LinterWorker } from "@App/pkg/utils/monaco-editor";
-import { editor, Range } from "monaco-editor";
+import { editor, Range, languages } from "monaco-editor";
 import React, { useEffect, useImperativeHandle, useRef, useState } from "react";
 import { globalCache, systemConfig } from "@App/pages/store/global";
 
@@ -10,6 +10,16 @@ type Props = {
   id: string;
   code?: string;
 };
+
+languages.typescript.javascriptDefaults.setCompilerOptions({
+  target: languages.typescript.ScriptTarget.ESNext,
+  allowNonTsExtensions: true,
+  alwaysStrict: true,
+  noUnusedParameters: true,
+  noImplicitUseStrict: true,
+  noUnusedLocals: true,
+  strict: true,
+});
 
 const CodeEditor: React.ForwardRefRenderFunction<{ editor: editor.IStandaloneCodeEditor | undefined }, Props> = (
   { id, className, code, diffCode, editable },


### PR DESCRIPTION
Close #644

现在可以自定义编辑器配置和编辑器类型定义，编辑器配置可以参考 `tsconfig.json` 中的 [compilerOptions](https://www.typescriptlang.org/tsconfig/#compilerOptions) 进行编写

<img width="2520" height="1044" alt="image" src="https://github.com/user-attachments/assets/e54775b6-5a15-4123-b7e9-4ccc1a5fbf56" />
