### PR TITLE
实现 inject into

### DIFF
--- a/example/inject-into.js
+++ b/example/inject-into.js
@@ -1,0 +1,15 @@
+// ==UserScript==
+// @name         Inject into
+// @namespace    https://docs.scriptcat.org/
+// @version      0.1.0
+// @description  将脚本注入到content环境，以绕过CSP检测，请注意此环境无法访问页面的window，只与页面共享document
+// @author       You
+// @match        https://benjamin-philipp.com/test-trusted-types.php
+// @icon         https://www.google.com/s2/favicons?sz=64&domain=benjamin-philipp.com
+// @inject-into  content
+// ==/UserScript==
+
+// 插入元素
+const div = document.createElement("div");
+div.innerHTML = "hello scriptcat";
+document.body.append(div);

--- a/example/inject-into.js
+++ b/example/inject-into.js
@@ -2,7 +2,7 @@
 // @name         Inject into
 // @namespace    https://docs.scriptcat.org/
 // @version      0.1.0
-// @description  将脚本注入到content环境，以绕过CSP检测，请注意此环境无法访问页面的window，只与页面共享document
+// @description  将脚本注入到content环境，以绕过CSP检测，请注意此环境无法访问页面的window，哪怕使用unsafeWindow，只与页面共享document
 // @author       You
 // @match        https://benjamin-philipp.com/test-trusted-types.php
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=benjamin-philipp.com

--- a/packages/message/server.ts
+++ b/packages/message/server.ts
@@ -49,26 +49,30 @@ export class Server {
 
   constructor(
     prefix: string,
-    message: Message,
+    message: Message | Message[],
     private enableConnect: boolean = true
   ) {
     if (this.enableConnect) {
-      message.onConnect((msg: TMessage, con: MessageConnect) => {
-        if (typeof msg.action !== "string") return;
-        this.logger.trace("server onConnect", { msg });
-        if (msg.action?.startsWith(prefix)) {
-          return this.connectHandle(msg.action.slice(prefix.length + 1), msg.data, con);
-        }
-        return false;
+      (Array.isArray(message) ? message : [message]).forEach((msg) => {
+        msg.onConnect((msg: TMessage, con: MessageConnect) => {
+          if (typeof msg.action !== "string") return;
+          this.logger.trace("server onConnect", { msg });
+          if (msg.action?.startsWith(prefix)) {
+            return this.connectHandle(msg.action.slice(prefix.length + 1), msg.data, con);
+          }
+          return false;
+        });
       });
     }
 
-    message.onMessage((msg: TMessage, sendResponse, sender) => {
-      if (typeof msg.action !== "string") return;
-      this.logger.trace("server onMessage", { msg: msg as any });
-      if (msg.action?.startsWith(prefix)) {
-        return this.messageHandle(msg.action.slice(prefix.length + 1), msg.data, sendResponse, sender);
-      }
+    (Array.isArray(message) ? message : [message]).forEach((msg) => {
+      msg.onMessage((msg: TMessage, sendResponse, sender) => {
+        if (typeof msg.action !== "string") return;
+        this.logger.trace("server onMessage", { msg: msg as any });
+        if (msg.action?.startsWith(prefix)) {
+          return this.messageHandle(msg.action.slice(prefix.length + 1), msg.data, sendResponse, sender);
+        }
+      });
       return false;
     });
   }

--- a/src/app/service/content/content.ts
+++ b/src/app/service/content/content.ts
@@ -1,26 +1,40 @@
-import { type ScriptRunResource } from "@App/app/repo/scripts";
 import { Client, sendMessage } from "@Packages/message/client";
 import { type CustomEventMessage } from "@Packages/message/custom_event_message";
 import { forwardMessage, type Server } from "@Packages/message/server";
 import type { Message, MessageSend } from "@Packages/message/types";
 import type { GMInfoEnv } from "./types";
+import type { ScriptLoadInfo } from "../service_worker/types";
+import type { ScriptExecutor } from "./script_executor";
+import { isInjectIntoContent } from "./utils";
 
 // content页的处理
 export default class ContentRuntime {
+  // 运行在content页面的脚本
+  contentScript: Map<string, ScriptLoadInfo> = new Map();
+
   constructor(
+    // 监听来自service_worker的消息
     private extServer: Server,
+    // 监听来自inject的消息
     private server: Server,
+    // 发送给扩展service_worker的通信接口
     private extSend: MessageSend,
-    private msg: Message
+    // 发送给inject的消息接口
+    private msg: Message,
+    // 脚本执行器消息接口
+    private scriptExecutorMsg: Message,
+    private scriptExecutor: ScriptExecutor
   ) {}
 
   init() {
     this.extServer.on("runtime/emitEvent", (data) => {
-      // 转发给inject
+      // 转发给inject和scriptExecutor
+      this.scriptExecutor.emitEvent(data);
       return sendMessage(this.msg, "inject/runtime/emitEvent", data);
     });
     this.extServer.on("runtime/valueUpdate", (data) => {
-      // 转发给inject
+      // 转发给inject和scriptExecutor
+      this.scriptExecutor.valueUpdate(data);
       return sendMessage(this.msg, "inject/runtime/valueUpdate", data);
     });
     forwardMessage("serviceWorker", "script/isInstalled", this.server, this.extSend);
@@ -29,7 +43,7 @@ export default class ContentRuntime {
       "runtime/gmApi",
       this.server,
       this.extSend,
-      (data: { api: string; params: any }) => {
+      (data: { api: string; params: any; uuid: string }) => {
         // 拦截关注的api
         switch (data.api) {
           case "CAT_createBlobUrl": {
@@ -58,10 +72,17 @@ export default class ContentRuntime {
           }
           case "GM_addElement": {
             const [parentNodeId, tagName, tmpAttr] = data.params;
-            let attr = tmpAttr;
+            let attr = { ...tmpAttr };
             let parentNode: EventTarget | undefined;
+            // 判断是不是content脚本发过来的
+            let msg: Message;
+            if (this.contentScript.has(data.uuid)) {
+              msg = this.scriptExecutorMsg;
+            } else {
+              msg = this.msg;
+            }
             if (parentNodeId) {
-              parentNode = (this.msg as CustomEventMessage).getAndDelRelatedTarget(parentNodeId);
+              parentNode = (msg as CustomEventMessage).getAndDelRelatedTarget(parentNodeId);
             }
             const el = <Element>document.createElement(tagName);
 
@@ -81,7 +102,7 @@ export default class ContentRuntime {
               el.textContent = textContent;
             }
             (<Element>parentNode || document.head || document.body || document.querySelector("*")).appendChild(el);
-            const nodeId = (this.msg as CustomEventMessage).sendRelatedTarget(el);
+            const nodeId = (msg as CustomEventMessage).sendRelatedTarget(el);
             return nodeId;
           }
           case "GM_log":
@@ -105,9 +126,28 @@ export default class ContentRuntime {
     );
   }
 
-  start(scripts: ScriptRunResource[], envInfo: GMInfoEnv) {
+  start(scripts: ScriptLoadInfo[], envInfo: GMInfoEnv) {
     // 启动脚本
     const client = new Client(this.msg, "inject");
-    client.do("pageLoad", { scripts, envInfo });
+    // 根据@inject-into content过滤脚本
+    const injectScript: ScriptLoadInfo[] = [];
+    const contentScript: ScriptLoadInfo[] = [];
+    for (const script of scripts) {
+      if (isInjectIntoContent(script)) {
+        contentScript.push(script);
+        continue;
+      }
+      injectScript.push(script);
+    }
+    client.do("pageLoad", { scripts: injectScript, envInfo });
+
+    // 处理注入到content环境的脚本
+    for (const script of contentScript) {
+      this.contentScript.set(script.uuid, script);
+    }
+    // 监听事件
+    this.scriptExecutor.init(envInfo);
+    // 启动脚本
+    this.scriptExecutor.start(contentScript);
   }
 }

--- a/src/app/service/content/inject.ts
+++ b/src/app/service/content/inject.ts
@@ -3,8 +3,8 @@ import type { Message } from "@Packages/message/types";
 import { ExternalWhitelist } from "@App/app/const";
 import { sendMessage } from "@Packages/message/client";
 import type { ScriptExecutor } from "./script_executor";
-import type { ScriptLoadInfo } from "../service_worker/types";
-import type { GMInfoEnv } from "./types";
+import type { EmitEventRequest, ScriptLoadInfo } from "../service_worker/types";
+import type { GMInfoEnv, ValueUpdateData } from "./types";
 
 export class InjectRuntime {
   constructor(
@@ -15,6 +15,15 @@ export class InjectRuntime {
 
   init(envInfo: GMInfoEnv) {
     this.scriptExecutor.init(envInfo);
+
+    this.server.on("runtime/emitEvent", (data: EmitEventRequest) => {
+      // 转发给脚本
+      this.scriptExecutor.emitEvent(data);
+    });
+    this.server.on("runtime/valueUpdate", (data: ValueUpdateData) => {
+      this.scriptExecutor.valueUpdate(data);
+    });
+
     // 注入允许外部调用
     this.externalMessage();
   }

--- a/src/app/service/content/inject.ts
+++ b/src/app/service/content/inject.ts
@@ -1,95 +1,26 @@
 import { type Server } from "@Packages/message/server";
 import type { Message } from "@Packages/message/types";
-import ExecScript from "./exec_script";
-import type { ValueUpdateData, GMInfoEnv, ScriptFunc, PreScriptFunc } from "./types";
-import { addStyle } from "./utils";
-import { getStorageName } from "@App/pkg/utils/utils";
-import type { EmitEventRequest, ScriptLoadInfo } from "../service_worker/types";
 import { ExternalWhitelist } from "@App/app/const";
 import { sendMessage } from "@Packages/message/client";
+import type { ScriptExecutor } from "./script_executor";
+import type { ScriptLoadInfo } from "../service_worker/types";
+import type { GMInfoEnv } from "./types";
 
 export class InjectRuntime {
-  execList: ExecScript[] = [];
-
-  envInfo: GMInfoEnv | undefined;
-
   constructor(
     private server: Server,
-    private msg: Message
+    private msg: Message,
+    private scriptExecutor: ScriptExecutor
   ) {}
 
   init(envInfo: GMInfoEnv) {
-    this.envInfo = envInfo;
-
-    this.server.on("runtime/emitEvent", (data: EmitEventRequest) => {
-      // 转发给脚本
-      const exec = this.execList.find((val) => val.scriptRes.uuid === data.uuid);
-      if (exec) {
-        exec.emitEvent(data.event, data.eventId, data.data);
-      }
-    });
-    this.server.on("runtime/valueUpdate", (data: ValueUpdateData) => {
-      this.execList
-        .filter((val) => val.scriptRes.uuid === data.uuid || getStorageName(val.scriptRes) === data.storageName)
-        .forEach((val) => {
-          val.valueUpdate(data);
-        });
-    });
+    this.scriptExecutor.init(envInfo);
     // 注入允许外部调用
     this.externalMessage();
   }
 
   start(scripts: ScriptLoadInfo[]) {
-    scripts.forEach((script) => {
-      // 如果是EarlyScriptFlag，处理沙盒环境
-      if (EarlyScriptFlag.includes(script.flag)) {
-        for (const val of this.execList) {
-          if (val.scriptRes.flag === script.flag) {
-            // 处理早期脚本的沙盒环境
-            val.dealEarlyScript(this.envInfo!);
-            break;
-          }
-        }
-        return;
-      }
-      // @ts-ignore
-      const scriptFunc = window[script.flag];
-      if (scriptFunc) {
-        this.execScript(script, scriptFunc);
-      } else {
-        // 监听脚本加载,和屏蔽读取
-        Object.defineProperty(window, script.flag, {
-          configurable: true,
-          set: (val: ScriptFunc) => {
-            this.execScript(script, val);
-          },
-        });
-      }
-    });
-  }
-
-  checkEarlyStartScript() {
-    EarlyScriptFlag.forEach((flag) => {
-      // @ts-ignore
-      const scriptFunc = window[flag] as PreScriptFunc;
-      if (scriptFunc) {
-        // @ts-ignore
-        const exec = new ExecScript(scriptFunc.scriptInfo, "content", this.msg, scriptFunc.func, {});
-        this.execList.push(exec);
-        exec.exec();
-      } else {
-        // 监听脚本加载,和屏蔽读取
-        Object.defineProperty(window, flag, {
-          configurable: true,
-          set: (val: PreScriptFunc) => {
-            // @ts-ignore
-            const exec = new ExecScript(val.scriptInfo, "content", this.msg, val.func, {});
-            this.execList.push(exec);
-            exec.exec();
-          },
-        });
-      }
-    });
+    this.scriptExecutor.start(scripts);
   }
 
   externalMessage() {
@@ -147,46 +78,5 @@ export class InjectRuntime {
         }
       }
     }
-  }
-
-  execScript(script: ScriptLoadInfo, scriptFunc: ScriptFunc) {
-    // @ts-ignore
-    delete window[script.flag];
-    const exec = new ExecScript(script, "content", this.msg, scriptFunc, this.envInfo!);
-    this.execList.push(exec);
-    // 注入css
-    if (script.metadata["require-css"]) {
-      for (const val of script.metadata["require-css"]) {
-        const res = script.resource[val];
-        if (res) {
-          addStyle(res.content);
-        }
-      }
-    }
-    if (script.metadata["run-at"] && script.metadata["run-at"][0] === "document-body") {
-      // 等待页面加载完成
-      this.waitBody(() => {
-        exec.exec();
-      });
-    } else {
-      exec.exec();
-    }
-  }
-
-  // 参考了tm的实现
-  waitBody(callback: () => void) {
-    if (document.body) {
-      callback();
-      return;
-    }
-    const listen = () => {
-      document.removeEventListener("load", listen, false);
-      document.removeEventListener("DOMNodeInserted", listen, false);
-      document.removeEventListener("DOMContentLoaded", listen, false);
-      this.waitBody(callback);
-    };
-    document.addEventListener("load", listen, false);
-    document.addEventListener("DOMNodeInserted", listen, false);
-    document.addEventListener("DOMContentLoaded", listen, false);
   }
 }

--- a/src/app/service/content/script_executor.ts
+++ b/src/app/service/content/script_executor.ts
@@ -16,6 +16,10 @@ export class ScriptExecutor {
     private earlyScriptFlag: string[]
   ) {}
 
+  setEarlyStartScriptFlag(flag: string[]) {
+    this.earlyScriptFlag = flag;
+  }
+
   init(envInfo: GMInfoEnv) {
     this.envInfo = envInfo;
   }

--- a/src/app/service/content/script_executor.ts
+++ b/src/app/service/content/script_executor.ts
@@ -11,7 +11,10 @@ export class ScriptExecutor {
 
   envInfo: GMInfoEnv | undefined;
 
-  constructor(private msg: Message) {}
+  constructor(
+    private msg: Message,
+    private earlyScriptFlag: string[]
+  ) {}
 
   init(envInfo: GMInfoEnv) {
     this.envInfo = envInfo;
@@ -36,7 +39,7 @@ export class ScriptExecutor {
   start(scripts: ScriptLoadInfo[]) {
     scripts.forEach((script) => {
       // 如果是EarlyScriptFlag，处理沙盒环境
-      if (EarlyScriptFlag.includes(script.flag)) {
+      if (this.earlyScriptFlag.includes(script.flag)) {
         for (const val of this.execList) {
           if (val.scriptRes.flag === script.flag) {
             // 处理早期脚本的沙盒环境

--- a/src/app/service/content/script_executor.ts
+++ b/src/app/service/content/script_executor.ts
@@ -1,0 +1,129 @@
+import type { Message } from "@Packages/message/types";
+import { getStorageName } from "@App/pkg/utils/utils";
+import type { EmitEventRequest, ScriptLoadInfo } from "../service_worker/types";
+import ExecScript from "./exec_script";
+import type { GMInfoEnv, ValueUpdateData, ScriptFunc, PreScriptFunc } from "./types";
+import { addStyle } from "./utils";
+
+// 脚本执行器
+export class ScriptExecutor {
+  execList: ExecScript[] = [];
+
+  envInfo: GMInfoEnv | undefined;
+
+  constructor(private msg: Message) {}
+
+  init(envInfo: GMInfoEnv) {
+    this.envInfo = envInfo;
+  }
+
+  emitEvent(data: EmitEventRequest) {
+    // 转发给脚本
+    const exec = this.execList.find((val) => val.scriptRes.uuid === data.uuid);
+    if (exec) {
+      exec.emitEvent(data.event, data.eventId, data.data);
+    }
+  }
+
+  valueUpdate(data: ValueUpdateData) {
+    this.execList
+      .filter((val) => val.scriptRes.uuid === data.uuid || getStorageName(val.scriptRes) === data.storageName)
+      .forEach((val) => {
+        val.valueUpdate(data);
+      });
+  }
+
+  start(scripts: ScriptLoadInfo[]) {
+    scripts.forEach((script) => {
+      // 如果是EarlyScriptFlag，处理沙盒环境
+      if (EarlyScriptFlag.includes(script.flag)) {
+        for (const val of this.execList) {
+          if (val.scriptRes.flag === script.flag) {
+            // 处理早期脚本的沙盒环境
+            val.dealEarlyScript(this.envInfo!);
+            break;
+          }
+        }
+        return;
+      }
+      // @ts-ignore
+      const scriptFunc = window[script.flag];
+      if (scriptFunc) {
+        this.execScript(script, scriptFunc);
+      } else {
+        // 监听脚本加载,和屏蔽读取
+        Object.defineProperty(window, script.flag, {
+          configurable: true,
+          set: (val: ScriptFunc) => {
+            this.execScript(script, val);
+          },
+        });
+      }
+    });
+  }
+
+  checkEarlyStartScript() {
+    EarlyScriptFlag.forEach((flag) => {
+      // @ts-ignore
+      const scriptFunc = window[flag] as PreScriptFunc;
+      if (scriptFunc) {
+        // @ts-ignore
+        const exec = new ExecScript(scriptFunc.scriptInfo, "content", this.msg, scriptFunc.func, {});
+        this.execList.push(exec);
+        exec.exec();
+      } else {
+        // 监听脚本加载,和屏蔽读取
+        Object.defineProperty(window, flag, {
+          configurable: true,
+          set: (val: PreScriptFunc) => {
+            // @ts-ignore
+            const exec = new ExecScript(val.scriptInfo, "content", this.msg, val.func, {});
+            this.execList.push(exec);
+            exec.exec();
+          },
+        });
+      }
+    });
+  }
+
+  execScript(script: ScriptLoadInfo, scriptFunc: ScriptFunc) {
+    // @ts-ignore
+    delete window[script.flag];
+    const exec = new ExecScript(script, "content", this.msg, scriptFunc, this.envInfo!);
+    this.execList.push(exec);
+    // 注入css
+    if (script.metadata["require-css"]) {
+      for (const val of script.metadata["require-css"]) {
+        const res = script.resource[val];
+        if (res) {
+          addStyle(res.content);
+        }
+      }
+    }
+    if (script.metadata["run-at"] && script.metadata["run-at"][0] === "document-body") {
+      // 等待页面加载完成
+      this.waitBody(() => {
+        exec.exec();
+      });
+    } else {
+      exec.exec();
+    }
+  }
+
+  // 参考了tm的实现
+  waitBody(callback: () => void) {
+    if (document.body) {
+      callback();
+      return;
+    }
+    const listen = () => {
+      document.removeEventListener("load", listen, false);
+      document.removeEventListener("DOMNodeInserted", listen, false);
+      document.removeEventListener("DOMContentLoaded", listen, false);
+      this.waitBody(callback);
+    };
+    document.addEventListener("load", listen, false);
+    document.addEventListener("DOMNodeInserted", listen, false);
+    document.addEventListener("DOMContentLoaded", listen, false);
+  }
+}

--- a/src/app/service/content/script_executor.ts
+++ b/src/app/service/content/script_executor.ts
@@ -66,7 +66,7 @@ export class ScriptExecutor {
   }
 
   checkEarlyStartScript() {
-    EarlyScriptFlag.forEach((flag) => {
+    this.earlyScriptFlag.forEach((flag) => {
       // @ts-ignore
       const scriptFunc = window[flag] as PreScriptFunc;
       if (scriptFunc) {

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -97,3 +97,7 @@ export function isEarlyStartScript(script: Script) {
     script.metadata["run-at"] && script.metadata["run-at"][0] === "document-start" && script.metadata["early-start"]
   );
 }
+
+export function isInjectIntoContent(script: Script) {
+  return script.metadata["inject-into"] && script.metadata["inject-into"][0] === "content";
+}

--- a/src/app/service/service_worker/client.ts
+++ b/src/app/service/service_worker/client.ts
@@ -2,7 +2,7 @@ import type { Script, ScriptCode, ScriptRunResource } from "@App/app/repo/script
 import { type Resource } from "@App/app/repo/resource";
 import { type Subscribe } from "@App/app/repo/subscribe";
 import { type Permission } from "@App/app/repo/permission";
-import type { InstallSource, ScriptMenu, ScriptMenuItem, SearchType } from "./types";
+import type { InstallSource, ScriptLoadInfo, ScriptMenu, ScriptMenuItem, SearchType } from "./types";
 import { Client } from "@Packages/message/client";
 import type { MessageSend } from "@Packages/message/types";
 import type PermissionVerify from "./permission_verify";
@@ -209,7 +209,7 @@ export class RuntimeClient extends Client {
     return this.do("stopScript", uuid);
   }
 
-  pageLoad(): Promise<{ flag: string; scripts: ScriptRunResource[]; envInfo: GMInfoEnv }> {
+  pageLoad(): Promise<{ flag: string; scripts: ScriptLoadInfo[]; envInfo: GMInfoEnv }> {
     return this.doThrow("pageLoad");
   }
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -8,12 +8,37 @@ import ContentRuntime from "./app/service/content/content";
 import { ScriptExecutor } from "./app/service/content/script_executor";
 import { randomMessageFlag } from "./pkg/utils/utils";
 
+declare global {
+  interface Window {
+    EarlyScriptFlag?: string[];
+  }
+}
+
 if (typeof chrome?.runtime?.onMessage?.addListener !== "function") {
   // ScriptCat 未支持 Firefox MV3
   console.error("Firefox MV3 UserScripts is not yet supported by ScriptCat");
 } else {
   // 建立与service_worker页面的连接
   const send = new ExtensionMessageSend();
+
+  // 处理scriptExecutor
+  const scriptExecutorFlag = randomMessageFlag();
+  const scriptExecutorMsg = new CustomEventMessage(scriptExecutorFlag, true);
+  const scriptExecutor = new ScriptExecutor(new CustomEventMessage(scriptExecutorFlag, false), []);
+  // 处理EarlyScript
+  if (window.EarlyScriptFlag) {
+    scriptExecutor.setEarlyStartScriptFlag(window.EarlyScriptFlag);
+    scriptExecutor.checkEarlyStartScript();
+  } else {
+    // 监听属性设置
+    Object.defineProperty(window, "EarlyScriptFlag", {
+      configurable: true,
+      set: (val: string[]) => {
+        scriptExecutor.setEarlyStartScriptFlag(val);
+        scriptExecutor.checkEarlyStartScript();
+      },
+    });
+  }
 
   // 初始化日志组件
   const loggerCore = new LoggerCore({
@@ -26,22 +51,13 @@ if (typeof chrome?.runtime?.onMessage?.addListener !== "function") {
     loggerCore.logger().debug("content start");
     const extMsg = new ExtensionMessage();
     const msg = new CustomEventMessage(data.flag, true);
-    const scriptExecutorFlag = randomMessageFlag();
-    const scriptExecutorMsg = new CustomEventMessage(scriptExecutorFlag, true);
     const server = new Server("content", [msg, scriptExecutorMsg]);
     // Opera中没有chrome.runtime.onConnect，并且content也不需要chrome.runtime.onConnect
     // 所以不需要处理连接，设置为false
     const extServer = new Server("content", extMsg, false);
     // scriptExecutor的消息接口
     // 初始化运行环境
-    const runtime = new ContentRuntime(
-      extServer,
-      server,
-      send,
-      msg,
-      scriptExecutorMsg,
-      new ScriptExecutor(new CustomEventMessage(scriptExecutorFlag, false), [])
-    );
+    const runtime = new ContentRuntime(extServer, server, send, msg, scriptExecutorMsg, scriptExecutor);
     runtime.init();
     runtime.start(data.scripts, data.envInfo);
   });

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -16,7 +16,7 @@ const logger = new LoggerCore({
 });
 
 const server = new Server("inject", msg);
-const scriptExecutor = new ScriptExecutor(msg);
+const scriptExecutor = new ScriptExecutor(msg, EarlyScriptFlag);
 const runtime = new InjectRuntime(server, msg, scriptExecutor);
 // 检查early-start的脚本
 scriptExecutor.checkEarlyStartScript();

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -7,6 +7,8 @@ import type { GMInfoEnv } from "./app/service/content/types";
 import { InjectRuntime } from "./app/service/content/inject";
 import { ScriptExecutor } from "./app/service/content/script_executor";
 
+/* global MessageFlag, EarlyScriptFlag */
+
 const msg = new CustomEventMessage(MessageFlag, false);
 
 // 加载logger组件

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -2,9 +2,10 @@ import LoggerCore from "./app/logger/core";
 import MessageWriter from "./app/logger/message_writer";
 import { CustomEventMessage } from "@Packages/message/custom_event_message";
 import { Server } from "@Packages/message/server";
-import { InjectRuntime } from "./app/service/content/inject";
 import type { ScriptLoadInfo } from "./app/service/service_worker/types";
 import type { GMInfoEnv } from "./app/service/content/types";
+import { InjectRuntime } from "./app/service/content/inject";
+import { ScriptExecutor } from "./app/service/content/script_executor";
 
 const msg = new CustomEventMessage(MessageFlag, false);
 
@@ -15,9 +16,10 @@ const logger = new LoggerCore({
 });
 
 const server = new Server("inject", msg);
-const runtime = new InjectRuntime(server, msg);
+const scriptExecutor = new ScriptExecutor(msg);
+const runtime = new InjectRuntime(server, msg, scriptExecutor);
 // 检查early-start的脚本
-runtime.checkEarlyStartScript();
+scriptExecutor.checkEarlyStartScript();
 
 server.on("pageLoad", (data: { scripts: ScriptLoadInfo[]; envInfo: GMInfoEnv }) => {
   logger.logger().debug("inject start");


### PR DESCRIPTION
#681

实现 inject into，可以让脚本运行到content页面，让脚本绕过页面的CSP策略

TODO：

- early-start 脚本暂不支持
- content处代码逻辑较乱需要重构整理