### PR TITLE
✨ 为 Firefox mv2 添加激活工具栏按钮的快捷键

### DIFF
--- a/build/pack.js
+++ b/build/pack.js
@@ -76,6 +76,11 @@ firefoxManifest.browser_specific_settings = {
   },
 };
 
+// 为 Firefox 添加激活工具栏按钮的快捷键
+firefoxManifest.commands = {
+  _execute_browser_action: {},
+};
+
 const chrome = new JSZip();
 const firefox = new JSZip();
 


### PR DESCRIPTION
<img width="1916" height="374" alt="图片" src="https://github.com/user-attachments/assets/32e1f33d-660c-4af5-80c8-ca9277b9d8e2" />