### PR TITLE
✨ 为 Firefox mv3 添加激活工具栏按钮的快捷键

### DIFF
--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -84,6 +84,12 @@ firefoxManifest.browser_specific_settings = {
   },
 };
 
+// 为 Firefox 添加激活工具栏按钮的快捷键
+firefoxManifest.commands = {
+  // mv3 的工具栏快捷键为 `_execute_action`，mv2 则是 `_execute_browser_action`
+  _execute_action: {},
+};
+
 const chrome = new JSZip();
 const firefox = new JSZip();
 


### PR DESCRIPTION
mv2 的工具栏快捷键（`_execute_browser_action`）和 mv3 （`_execute_action`）不一样，所以用了两个分支提交。

<img width="1916" height="374" alt="图片" src="https://github.com/user-attachments/assets/21579e75-f305-44f6-aa43-33cdf39e51ae" />