### PR TITLE
⚰️ Firefox：移除 Chrome 特有的 background 权限

### DIFF
--- a/build/pack.js
+++ b/build/pack.js
@@ -81,6 +81,11 @@ firefoxManifest.commands = {
   _execute_browser_action: {},
 };
 
+// 避免将 Chrome 特有权限添加到 Firefox 的 manifest
+firefoxManifest.permissions = firefoxManifest.permissions.filter(
+  (permission) => permission !== "background"
+);
+
 const chrome = new JSZip();
 const firefox = new JSZip();
 


### PR DESCRIPTION
主要是为了去掉 Firefox 扩展调试界面的警告。

<img width="1956" height="568" alt="图片" src="https://github.com/user-attachments/assets/9921e831-a904-48c4-8034-b10be41078a2" />