### PR TITLE
退回 DraggableContainer 的 `React.forwardRef`

### DIFF
--- a/src/pages/options/routes/ScriptList.tsx
+++ b/src/pages/options/routes/ScriptList.tsx
@@ -162,7 +162,7 @@ const DragHandle = () => {
   );
 };
 
-const DraggableContainer = React.forwardRef((props: any, ref: any) => {
+const DraggableContainer = (props: any) => {
   const context = useContext(DraggableContext);
   if (!context) return <></>;
   const { sensors, dispatch, scriptList } = context;
@@ -183,11 +183,11 @@ const DraggableContainer = React.forwardRef((props: any, ref: any) => {
       }}
     >
       <SortableContext items={scriptList.map((s) => ({ ...s, id: s.uuid }))} strategy={verticalListSortingStrategy}>
-        <tbody {...props} ref={ref} />
+        <tbody {...props} />
       </SortableContext>
     </DndContext>
   );
-});
+};
 DraggableContainer.displayName = "DraggableContainer";
 
 const EnableSwitch = React.memo(


### PR DESCRIPTION
DraggableContainer 不需要，不应该加 `React.forwardRef`
这个造成React产生不必要及大量的重绘