### PR TITLE
优化 Message 代码

### DIFF
--- a/packages/message/client.ts
+++ b/packages/message/client.ts
@@ -1,9 +1,9 @@
-import type { MessageConnect, MessageSend, TMessageCommAction, TMessageCommCode } from "./types";
+import type { MessageSend, MessageConnect, TMessageCommAction, TMessageCommCode } from "./types";
 import LoggerCore from "@App/app/logger/core";
 import Logger from "@App/app/logger/logger";
 
-export async function sendMessage<T = any>(msg: MessageSend, action: string, data?: any): Promise<T | undefined> {
-  const res = await msg.sendMessage<TMessageCommCode<T> | TMessageCommAction<T>>({ action, data });
+export async function sendMessage<T = any>(msgSender: MessageSend, action: string, data?: any): Promise<T | undefined> {
+  const res = await msgSender.sendMessage<TMessageCommCode<T> | TMessageCommAction<T>>({ action, data });
   const logger = LoggerCore.getInstance().logger().with({ action, data, response: res });
   logger.trace("sendMessage");
   if (res?.code) {
@@ -19,13 +19,13 @@ export async function sendMessage<T = any>(msg: MessageSend, action: string, dat
   }
 }
 
-export function connect(msg: MessageSend, action: string, data?: any): Promise<MessageConnect> {
-  return msg.connect({ action, data });
+export function connect(msgSender: MessageSend, action: string, data?: any): Promise<MessageConnect> {
+  return msgSender.connect({ action, data });
 }
 
 export class Client {
   constructor(
-    protected msg: MessageSend,
+    protected msgSender: MessageSend,
     protected prefix?: string
   ) {
     if (this.prefix && !this.prefix.endsWith("/")) {
@@ -36,11 +36,11 @@ export class Client {
   }
 
   do<T = any>(action: string, params?: any): Promise<T | undefined> {
-    return sendMessage<T>(this.msg, `${this.prefix}${action}`, params);
+    return sendMessage<T>(this.msgSender, `${this.prefix}${action}`, params);
   }
 
   async doThrow<T = any>(action: string, params?: any): Promise<T> {
-    const ret = await sendMessage<T>(this.msg, `${this.prefix}${action}`, params);
+    const ret = await sendMessage<T>(this.msgSender, `${this.prefix}${action}`, params);
     if (!ret) {
       throw new Error(`doThrow: ${this.prefix}${action}`);
     }

--- a/packages/message/mock_message.ts
+++ b/packages/message/mock_message.ts
@@ -1,4 +1,4 @@
-import type { Message, MessageConnect, MessageSend, TMessage } from "./types";
+import type { Message, MessageConnect, TMessage } from "./types";
 import EventEmitter from "eventemitter3";
 import { sleep } from "@App/pkg/utils/utils";
 
@@ -24,7 +24,7 @@ export class MockMessageConnect implements MessageConnect {
   }
 }
 
-export class MockMessageSend implements MessageSend {
+export class MockMessage implements Message {
   constructor(protected EE: EventEmitter<string, any>) {}
 
   connect(data: TMessage): Promise<MessageConnect> {
@@ -45,9 +45,7 @@ export class MockMessageSend implements MessageSend {
       });
     });
   }
-}
 
-export class MockMessage extends MockMessageSend implements Message {
   onConnect(callback: (data: any, con: MessageConnect) => void): void {
     this.EE.on("connect", (data: any, con: MessageConnect) => {
       callback(data, con);

--- a/packages/message/server.test.ts
+++ b/packages/message/server.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { Server, GetSender } from "./server";
 import { CustomEventMessage } from "./custom_event_message";
-import type { MessageConnect, MessageSender } from "./types";
+import type { MessageConnect, RuntimeMessageSender } from "./types";
 
 describe("Server", () => {
   let contentMessage: CustomEventMessage;
@@ -504,7 +504,7 @@ describe("Server", () => {
   });
 
   describe("GetSender 功能测试", () => {
-    it("应该能够从 MessageSender 获取信息", async () => {
+    it("应该能够从 RuntimeMessageSender 获取信息", async () => {
       let capturedSender: GetSender;
 
       server.on("test", (params, sender) => {
@@ -512,11 +512,11 @@ describe("Server", () => {
       });
 
       // 模拟带有 sender 信息的消息
-      const mockSender: MessageSender = {
+      const mockSender: RuntimeMessageSender = {
         tab: { id: 123 },
         frameId: 456,
         documentId: "doc-123",
-      } as MessageSender;
+      } as RuntimeMessageSender;
 
       // 直接调用 messageHandle 来模拟带 sender 的消息
       const sendResponse = vi.fn();
@@ -538,9 +538,9 @@ describe("Server", () => {
         capturedSender = sender;
       });
 
-      const mockSender: MessageSender = {
+      const mockSender: RuntimeMessageSender = {
         frameId: 456,
-      } as MessageSender;
+      } as RuntimeMessageSender;
 
       const sendResponse = vi.fn();
       (server as any).messageHandle("test", { param: "value" }, sendResponse, mockSender);

--- a/packages/message/types.ts
+++ b/packages/message/types.ts
@@ -25,13 +25,20 @@ export type TMessageCommCode<T = any> = {
 
 export type TMessage<T = any> = TMessageQueue<T> | TMessageCommAction<T> | TMessageCommCode<T>;
 
-export type MessageSender = chrome.runtime.MessageSender;
+export type RuntimeMessageSender = chrome.runtime.MessageSender;
 
-export interface Message extends MessageSend {
-  onConnect(callback: (data: TMessage, con: MessageConnect) => void): void;
-  onMessage(
-    callback: (data: TMessage, sendResponse: (data: any) => void, sender?: MessageSender) => boolean | void
-  ): void;
+export type OnConnectCallback = (data: TMessage, con: MessageConnect) => void;
+export type OnMessageCallback = (
+  data: TMessage,
+  sendResponse: (data: any) => void,
+  sender?: RuntimeMessageSender
+) => boolean | void;
+
+export interface Message {
+  connect(data: TMessage): Promise<MessageConnect>;
+  sendMessage<T = any>(data: TMessage): Promise<T>;
+  onConnect(callback: OnConnectCallback): void;
+  onMessage(callback: OnMessageCallback): void;
 }
 
 export interface MessageSend {

--- a/src/app/logger/message_writer.ts
+++ b/src/app/logger/message_writer.ts
@@ -3,17 +3,13 @@ import type { MessageSend } from "@Packages/message/types";
 
 // 通过通讯机制写入日志
 export default class MessageWriter implements Writer {
-  send: MessageSend;
-
   constructor(
-    send: MessageSend,
+    private msgSender: MessageSend,
     private action: string = "logger"
-  ) {
-    this.send = send;
-  }
+  ) {}
 
   write(level: LogLevel, message: string, label: LogLabel): void {
-    this.send.sendMessage({
+    this.msgSender.sendMessage({
       action: this.action,
       data: {
         id: 0,

--- a/src/app/service/offscreen/client.ts
+++ b/src/app/service/offscreen/client.ts
@@ -4,42 +4,42 @@ import { Client, sendMessage } from "@Packages/message/client";
 import type { MessageSend } from "@Packages/message/types";
 import { type VSCodeConnect } from "./vscode-connect";
 
-export function preparationSandbox(msg: WindowMessage) {
-  return sendMessage(msg, "offscreen/preparationSandbox");
+export function preparationSandbox(windowMessage: WindowMessage) {
+  return sendMessage(windowMessage, "offscreen/preparationSandbox");
 }
 
 // 代理发送消息到ServiceWorker
-export function sendMessageToServiceWorker(msg: WindowMessage, action: string, data?: any) {
-  return sendMessage(msg, "offscreen/sendMessageToServiceWorker", { action, data });
+export function sendMessageToServiceWorker(windowMessage: WindowMessage, action: string, data?: any) {
+  return sendMessage(windowMessage, "offscreen/sendMessageToServiceWorker", { action, data });
 }
 
 // 代理连接ServiceWorker
-export function connectServiceWorker(msg: WindowMessage) {
-  return sendMessage(msg, "offscreen/connectServiceWorker");
+export function connectServiceWorker(windowMessage: WindowMessage) {
+  return sendMessage(windowMessage, "offscreen/connectServiceWorker");
 }
 
 export function proxyUpdateRunStatus(
-  msg: WindowMessage,
+  windowMessage: WindowMessage,
   data: { uuid: string; runStatus: SCRIPT_RUN_STATUS; error?: any; nextruntime?: number }
 ) {
-  return sendMessageToServiceWorker(msg, "script/updateRunStatus", data);
+  return sendMessageToServiceWorker(windowMessage, "script/updateRunStatus", data);
 }
 
-export function runScript(msg: MessageSend, data: ScriptRunResource) {
-  return sendMessage(msg, "offscreen/script/runScript", data);
+export function runScript(msgSender: MessageSend, data: ScriptRunResource) {
+  return sendMessage(msgSender, "offscreen/script/runScript", data);
 }
 
-export function stopScript(msg: MessageSend, uuid: string) {
-  return sendMessage(msg, "offscreen/script/stopScript", uuid);
+export function stopScript(msgSender: MessageSend, uuid: string) {
+  return sendMessage(msgSender, "offscreen/script/stopScript", uuid);
 }
 
-export function createObjectURL(msg: MessageSend, data: Blob, persistence: boolean = false) {
-  return sendMessage(msg, "offscreen/createObjectURL", { data, persistence });
+export function createObjectURL(msgSender: MessageSend, data: Blob, persistence: boolean = false) {
+  return sendMessage(msgSender, "offscreen/createObjectURL", { data, persistence });
 }
 
 export class VscodeConnectClient extends Client {
-  constructor(msg: MessageSend) {
-    super(msg, "offscreen/vscodeConnect");
+  constructor(msgSender: MessageSend) {
+    super(msgSender, "offscreen/vscodeConnect");
   }
 
   connect(params: Parameters<VSCodeConnect["connect"]>[0]): ReturnType<VSCodeConnect["connect"]> {

--- a/src/app/service/offscreen/script.ts
+++ b/src/app/service/offscreen/script.ts
@@ -18,13 +18,13 @@ import type { TDeleteScript, TInstallScript, TEnableScript } from "../queue";
 export class ScriptService {
   logger: Logger;
 
-  scriptClient: ScriptClient = new ScriptClient(this.extensionMessage);
-  resourceClient: ResourceClient = new ResourceClient(this.extensionMessage);
-  valueClient: ValueClient = new ValueClient(this.extensionMessage);
+  scriptClient: ScriptClient = new ScriptClient(this.extMsgSender);
+  resourceClient: ResourceClient = new ResourceClient(this.extMsgSender);
+  valueClient: ValueClient = new ValueClient(this.extMsgSender);
 
   constructor(
     private group: Group,
-    private extensionMessage: MessageSend,
+    private extMsgSender: MessageSend,
     private windowMessage: WindowMessage,
     private messageQueue: MessageQueue
   ) {

--- a/src/app/service/offscreen/vscode-connect.ts
+++ b/src/app/service/offscreen/vscode-connect.ts
@@ -20,9 +20,9 @@ export class VSCodeConnect {
 
   constructor(
     private group: Group,
-    private send: MessageSend
+    private msgSender: MessageSend
   ) {
-    this.scriptClient = new ScriptClient(this.send);
+    this.scriptClient = new ScriptClient(this.msgSender);
   }
 
   connect({ url, reconnect }: { url: string; reconnect: boolean }) {

--- a/src/app/service/service_worker/client.ts
+++ b/src/app/service/service_worker/client.ts
@@ -19,8 +19,8 @@ import { type ScriptInfo } from "@App/pkg/utils/scriptInstall";
 import type { ScriptService } from "./script";
 
 export class ServiceWorkerClient extends Client {
-  constructor(msg: MessageSend) {
-    super(msg, "serviceWorker");
+  constructor(msgSender: MessageSend) {
+    super(msgSender, "serviceWorker");
   }
 
   preparationOffscreen() {
@@ -29,8 +29,8 @@ export class ServiceWorkerClient extends Client {
 }
 
 export class ScriptClient extends Client {
-  constructor(msg: MessageSend) {
-    super(msg, "serviceWorker/script");
+  constructor(msgSender: MessageSend) {
+    super(msgSender, "serviceWorker/script");
   }
 
   // 脚本数据量大的时候，options页要读取全部的数据，可能会导致options页卡顿，直接调用serviceWorker的接口从内存中读取数据
@@ -182,8 +182,8 @@ export class ScriptClient extends Client {
 }
 
 export class ResourceClient extends Client {
-  constructor(msg: MessageSend) {
-    super(msg, "serviceWorker/resource");
+  constructor(msgSender: MessageSend) {
+    super(msgSender, "serviceWorker/resource");
   }
 
   getScriptResources(script: Script): Promise<{ [key: string]: Resource }> {
@@ -196,8 +196,8 @@ export class ResourceClient extends Client {
 }
 
 export class ValueClient extends Client {
-  constructor(msg: MessageSend) {
-    super(msg, "serviceWorker/value");
+  constructor(msgSender: MessageSend) {
+    super(msgSender, "serviceWorker/value");
   }
 
   getScriptValue(script: Script): Promise<{ [key: string]: any }> {
@@ -214,8 +214,8 @@ export class ValueClient extends Client {
 }
 
 export class RuntimeClient extends Client {
-  constructor(msg: MessageSend) {
-    super(msg, "serviceWorker/runtime");
+  constructor(msgSender: MessageSend) {
+    super(msgSender, "serviceWorker/runtime");
   }
 
   runScript(uuid: string) {
@@ -248,8 +248,8 @@ export type GetPopupDataRes = {
 };
 
 export class PopupClient extends Client {
-  constructor(msg: MessageSend) {
-    super(msg, "serviceWorker/popup");
+  constructor(msgSender: MessageSend) {
+    super(msgSender, "serviceWorker/popup");
   }
 
   getPopupData(data: GetPopupDataReq): Promise<GetPopupDataRes> {
@@ -271,8 +271,8 @@ export class PopupClient extends Client {
 }
 
 export class PermissionClient extends Client {
-  constructor(msg: MessageSend) {
-    super(msg, "serviceWorker/runtime/permission");
+  constructor(msgSender: MessageSend) {
+    super(msgSender, "serviceWorker/runtime/permission");
   }
 
   confirm(uuid: string, userConfirm: UserConfirm): Promise<void> {
@@ -305,8 +305,8 @@ export class PermissionClient extends Client {
 }
 
 export class SynchronizeClient extends Client {
-  constructor(msg: MessageSend) {
-    super(msg, "serviceWorker/synchronize");
+  constructor(msgSender: MessageSend) {
+    super(msgSender, "serviceWorker/synchronize");
   }
 
   export(uuids?: string[]) {
@@ -344,8 +344,8 @@ export class SynchronizeClient extends Client {
 }
 
 export class SubscribeClient extends Client {
-  constructor(msg: MessageSend) {
-    super(msg, "serviceWorker/subscribe");
+  constructor(msgSender: MessageSend) {
+    super(msgSender, "serviceWorker/subscribe");
   }
 
   install(subscribe: Subscribe) {
@@ -366,8 +366,8 @@ export class SubscribeClient extends Client {
 }
 
 export class SystemClient extends Client {
-  constructor(msg: MessageSend) {
-    super(msg, "serviceWorker/system");
+  constructor(msgSender: MessageSend) {
+    super(msgSender, "serviceWorker/system");
   }
 
   connectVSCode(params: Parameters<VSCodeConnect["connect"]>[0]): ReturnType<VSCodeConnect["connect"]> {

--- a/src/app/service/service_worker/gm_api.ts
+++ b/src/app/service/service_worker/gm_api.ts
@@ -128,7 +128,7 @@ export default class GMApi {
     private systemConfig: SystemConfig,
     private permissionVerify: PermissionVerify,
     private group: Group,
-    private send: MessageSend,
+    private msgSender: MessageSend,
     private mq: MessageQueueGroup,
     private value: ValueService,
     private gmExternalDependencies: IGMExternalDependencies
@@ -751,7 +751,7 @@ export default class GMApi {
       return this.CAT_fetch(params, sender, resultParam);
     }
     // 再发送到offscreen, 处理请求
-    const offscreenCon = await connect(this.send, "offscreen/gmApi/xmlHttpRequest", request.params[0]);
+    const offscreenCon = await connect(this.msgSender, "offscreen/gmApi/xmlHttpRequest", request.params[0]);
     offscreenCon.onMessage((msg) => {
       // 发送到content
       // 替换msg.data.responseHeaders
@@ -801,7 +801,7 @@ export default class GMApi {
     const options = request.params[1] || {};
     if (options.useOpen === true) {
       // 发送给offscreen页面处理
-      const ok = await sendMessage(this.send, "offscreen/gmApi/openInTab", { url });
+      const ok = await sendMessage(this.msgSender, "offscreen/gmApi/openInTab", { url });
       if (ok) {
         // 由于window.open强制在前台打开标签，因此获取状态为{ active:true }的标签即为新标签
         const tab = await getCurrentTab();
@@ -1078,7 +1078,7 @@ export default class GMApi {
   async GM_setClipboard(request: Request) {
     const [data, type] = request.params;
     const clipboardType = type || "text/plain";
-    await sendMessage(this.send, "offscreen/gmApi/setClipboard", { data, type: clipboardType });
+    await sendMessage(this.msgSender, "offscreen/gmApi/setClipboard", { data, type: clipboardType });
   }
 
   @PermissionVerify.API()

--- a/src/app/service/service_worker/runtime.test.ts
+++ b/src/app/service/service_worker/runtime.test.ts
@@ -7,12 +7,13 @@ import { SCRIPT_STATUS_ENABLE, SCRIPT_TYPE_NORMAL } from "@App/app/repo/scripts"
 import { getCombinedMeta } from "./utils";
 import type { SystemConfig } from "@App/pkg/config/config";
 import type { Group } from "@Packages/message/server";
-import type { MessageSend } from "@Packages/message/types";
+import type { ServiceWorkerMessageSend, WindowMessageBody } from "@Packages/message/window_message";
 import type { MessageQueue } from "@Packages/message/message_queue";
 import type { ValueService } from "./value";
 import type { ScriptService } from "./script";
 import type { ResourceService } from "./resource";
 import type { ScriptDAO } from "@App/app/repo/scripts";
+import type { MessageConnect, TMessage } from "@Packages/message/types";
 
 initTestEnv();
 
@@ -73,7 +74,16 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
     const mockGroup = {
       use: vi.fn().mockReturnThis(),
     } as unknown as Group;
-    const mockSender = {} as MessageSend;
+    const mockSender = {
+      async init() {},
+      messageHandle(_data: WindowMessageBody) {},
+      async connect(_data: TMessage): Promise<MessageConnect> {
+        return {} as MessageConnect;
+      },
+      async sendMessage<T = any>(_data: TMessage): Promise<T> {
+        return {} as T;
+      },
+    } as ServiceWorkerMessageSend;
     const mockMessageQueue = {
       group: vi.fn().mockReturnValue(mockGroup),
     } as unknown as MessageQueue;

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -1,7 +1,7 @@
 import type { EmitEventRequest, ScriptLoadInfo, TScriptMatchInfoEntry } from "./types";
 import type { MessageQueue, MessageQueueGroup } from "@Packages/message/message_queue";
 import type { GetSender, Group } from "@Packages/message/server";
-import type { ExtMessageSender, MessageSender, MessageSend } from "@Packages/message/types";
+import type { ExtMessageSender, RuntimeMessageSender, MessageSend } from "@Packages/message/types";
 import type { Script, SCRIPT_STATUS, ScriptDAO, ScriptRunResource } from "@App/app/repo/scripts";
 import { SCRIPT_STATUS_DISABLE, SCRIPT_STATUS_ENABLE, SCRIPT_TYPE_NORMAL } from "@App/app/repo/scripts";
 import { type ValueService } from "./value";
@@ -85,7 +85,7 @@ export class RuntimeService {
   constructor(
     private systemConfig: SystemConfig,
     private group: Group,
-    private sender: MessageSend,
+    private msgSender: MessageSend,
     mq: MessageQueue,
     private value: ValueService,
     private script: ScriptService,
@@ -195,7 +195,7 @@ export class RuntimeService {
       this.systemConfig,
       permission,
       this.group,
-      this.sender,
+      this.msgSender,
       this.mq,
       this.value,
       new GMExternalDependencies(this)
@@ -602,7 +602,7 @@ export class RuntimeService {
   sendMessageToTab(to: ExtMessageSender, action: string, data: any) {
     if (to.tabId === -1) {
       // 如果是-1, 代表给offscreen发送消息
-      return sendMessage(this.sender, "offscreen/runtime/" + action, data);
+      return sendMessage(this.msgSender, "offscreen/runtime/" + action, data);
     }
     return sendMessage(
       new ExtensionContentMessageSend(to.tabId, {
@@ -618,7 +618,7 @@ export class RuntimeService {
   emitEventToTab(to: ExtMessageSender, req: EmitEventRequest) {
     if (to.tabId === -1) {
       // 如果是-1, 代表给offscreen发送消息
-      return sendMessage(this.sender, "offscreen/runtime/emitEvent", req);
+      return sendMessage(this.msgSender, "offscreen/runtime/emitEvent", req);
     }
     return sendMessage(
       new ExtensionContentMessageSend(to.tabId, {
@@ -660,7 +660,7 @@ export class RuntimeService {
     if (!this.isLoadScripts) {
       return { flag: "", scripts: [] };
     }
-    const chromeSender = sender.getSender() as MessageSender;
+    const chromeSender = sender.getSender() as RuntimeMessageSender;
 
     // 判断是否黑名单（针对网址，与个别脚本设定无关）
     if (this.isUrlBlacklist(chromeSender.url!)) {
@@ -827,7 +827,7 @@ export class RuntimeService {
 
   // 停止脚本
   async stopScript(uuid: string) {
-    return await stopScript(this.sender, uuid);
+    return await stopScript(this.msgSender, uuid);
   }
 
   // 运行脚本
@@ -837,7 +837,7 @@ export class RuntimeService {
       return;
     }
     const res = await this.script.buildScriptRunResource(script);
-    return await runScript(this.sender, res);
+    return await runScript(this.msgSender, res);
   }
 
   compileInjectUserScript(injectJs: string, messageFlag: string, o: Record<string, any>) {

--- a/src/app/service/service_worker/synchronize.ts
+++ b/src/app/service/service_worker/synchronize.ts
@@ -64,7 +64,7 @@ export class SynchronizeService {
   storage: ChromeStorage = new ChromeStorage("sync", true);
 
   constructor(
-    private send: MessageSend,
+    private msgSender: MessageSend,
     private group: Group,
     private script: ScriptService,
     private value: ValueService,
@@ -251,7 +251,7 @@ export class SynchronizeService {
       },
       comment: "Created by Scriptcat",
     });
-    const url = await createObjectURL(this.send, files);
+    const url = await createObjectURL(this.msgSender, files);
     chrome.downloads.download({
       url,
       saveAs: true,

--- a/src/app/service/service_worker/system.ts
+++ b/src/app/service/service_worker/system.ts
@@ -11,7 +11,7 @@ export class SystemService {
   constructor(
     private systemConfig: SystemConfig,
     private group: Group,
-    private sender: MessageSend
+    private msgSender: MessageSend
   ) {}
 
   getFaviconFromDomain(domain: string) {
@@ -19,7 +19,7 @@ export class SystemService {
   }
 
   async init() {
-    const vscodeConnect = new VscodeConnectClient(this.sender);
+    const vscodeConnect = new VscodeConnectClient(this.msgSender);
     // 如果开启了自动连接vscode，则自动连接
     // 使用tx来确保service_worker恢复时不会再执行
     cacheInstance.tx("vscodeReconnect", async (init) => {
@@ -44,7 +44,7 @@ export class SystemService {
       return cacheInstance.getOrSet(cacheKey, async () => {
         return fetch(url)
           .then((response) => response.blob())
-          .then((blob) => createObjectURL(this.sender, blob, true))
+          .then((blob) => createObjectURL(this.msgSender, blob, true))
           .catch(() => {
             return "";
           });

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,12 +1,13 @@
 import LoggerCore from "./app/logger/core";
 import MessageWriter from "./app/logger/message_writer";
-import { ExtensionMessage, ExtensionMessageSend } from "@Packages/message/extension_message";
+import { ExtensionMessage } from "@Packages/message/extension_message";
 import { CustomEventMessage } from "@Packages/message/custom_event_message";
 import { RuntimeClient } from "./app/service/service_worker/client";
 import { Server } from "@Packages/message/server";
 import ContentRuntime from "./app/service/content/content";
 import { ScriptExecutor } from "./app/service/content/script_executor";
 import { randomMessageFlag } from "./pkg/utils/utils";
+import type { Message } from "@Packages/message/types";
 
 declare global {
   interface Window {
@@ -19,7 +20,7 @@ if (typeof chrome?.runtime?.onMessage?.addListener !== "function") {
   console.error("Firefox MV3 UserScripts is not yet supported by ScriptCat");
 } else {
   // 建立与service_worker页面的连接
-  const send = new ExtensionMessageSend();
+  const extMsgComm: Message = new ExtensionMessage(false);
 
   // 处理scriptExecutor
   const scriptExecutorFlag = randomMessageFlag();
@@ -42,22 +43,21 @@ if (typeof chrome?.runtime?.onMessage?.addListener !== "function") {
 
   // 初始化日志组件
   const loggerCore = new LoggerCore({
-    writer: new MessageWriter(send),
+    writer: new MessageWriter(extMsgComm),
     labels: { env: "content" },
   });
 
-  const client = new RuntimeClient(send);
+  const client = new RuntimeClient(extMsgComm);
   client.pageLoad().then((data) => {
     loggerCore.logger().debug("content start");
-    const extMsg = new ExtensionMessage();
-    const msg = new CustomEventMessage(data.flag, true);
-    const server = new Server("content", [msg, scriptExecutorMsg]);
+    const msgInject = new CustomEventMessage(data.flag, true);
+    const server = new Server("content", [msgInject, scriptExecutorMsg]);
     // Opera中没有chrome.runtime.onConnect，并且content也不需要chrome.runtime.onConnect
     // 所以不需要处理连接，设置为false
-    const extServer = new Server("content", extMsg, false);
+    const extServer = new Server("content", extMsgComm, false);
     // scriptExecutor的消息接口
     // 初始化运行环境
-    const runtime = new ContentRuntime(extServer, server, send, msg, scriptExecutorMsg, scriptExecutor);
+    const runtime = new ContentRuntime(extServer, server, extMsgComm, msgInject, scriptExecutorMsg, scriptExecutor);
     runtime.init();
     runtime.start(data.scripts, data.envInfo);
   });

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -6,10 +6,11 @@ import type { ScriptLoadInfo } from "./app/service/service_worker/types";
 import type { GMInfoEnv } from "./app/service/content/types";
 import { InjectRuntime } from "./app/service/content/inject";
 import { ScriptExecutor } from "./app/service/content/script_executor";
+import type { Message } from "@Packages/message/types";
 
 /* global MessageFlag, EarlyScriptFlag */
 
-const msg = new CustomEventMessage(MessageFlag, false);
+const msg: Message = new CustomEventMessage(MessageFlag, false);
 
 // 加载logger组件
 const logger = new LoggerCore({

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,19 +1,19 @@
-import type { MessageSend } from "@Packages/message/types";
+import type { Message } from "@Packages/message/types";
 import LoggerCore from "./app/logger/core";
 import MessageWriter from "./app/logger/message_writer";
 import { OffscreenManager } from "./app/service/offscreen";
-import { ExtensionMessageSend } from "@Packages/message/extension_message";
+import { ExtensionMessage } from "@Packages/message/extension_message";
 
 function main() {
   // 初始化日志组件
-  const extensionMessage: MessageSend = new ExtensionMessageSend();
+  const extMsgSender: Message = new ExtensionMessage();
   const loggerCore = new LoggerCore({
-    writer: new MessageWriter(extensionMessage, "serviceWorker/logger"),
+    writer: new MessageWriter(extMsgSender, "serviceWorker/logger"),
     labels: { env: "offscreen" },
   });
   loggerCore.logger().debug("offscreen start");
   // 初始化管理器
-  const manager = new OffscreenManager(extensionMessage);
+  const manager = new OffscreenManager(extMsgSender);
   manager.initManager();
 }
 

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -5,17 +5,17 @@ import { SandboxManager } from "./app/service/sandbox";
 
 function main() {
   // 建立与offscreen页面的连接
-  const msg = new WindowMessage(window, parent);
+  const windowMessage: WindowMessage = new WindowMessage(window, parent);
 
   // 初始化日志组件
   const loggerCore = new LoggerCore({
-    writer: new MessageWriter(msg, "offscreen/logger"),
+    writer: new MessageWriter(windowMessage, "offscreen/logger"),
     labels: { env: "sandbox" },
   });
   loggerCore.logger().debug("offscreen start");
 
   // 初始化管理器
-  const manager = new SandboxManager(msg);
+  const manager = new SandboxManager(windowMessage);
   manager.initManager();
 }
 

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -9,6 +9,7 @@ import { ServiceWorkerMessageSend } from "@Packages/message/window_message";
 import migrate from "./app/migrate";
 import { fetchIconByDomain } from "./app/service/service_worker/fetch";
 import { msgResponse } from "./app/service/service_worker/utils";
+import type { RuntimeMessageSender } from "@Packages/message/types";
 
 migrate();
 
@@ -77,9 +78,9 @@ async function main() {
 }
 
 const apiActions: {
-  [key: string]: (message: any, _sender: chrome.runtime.MessageSender) => Promise<any> | any;
+  [key: string]: (message: any, _sender: RuntimeMessageSender) => Promise<any> | any;
 } = {
-  async "fetch-icon-by-domain"(message: any, _sender: chrome.runtime.MessageSender) {
+  async "fetch-icon-by-domain"(message: any, _sender: RuntimeMessageSender) {
     const { domain } = message;
     return await fetchIconByDomain(domain);
   },


### PR DESCRIPTION
## 概述

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- close #xxx -->

主要是把現在一堆 Message extends 除去
增強易讀性，維護性

## 变更内容

<!-- - 这个 PR 做了什么？ -->

重新構造 Message及 MessageSend的部份
最終得到

```
export class CustomEventMessage implements Message 
export class ExtensionMessage implements Message
export class MockMessage implements Message
export class WindowMessage implements Message
export class ExtensionContentMessageSend implements MessageSend
export class ServiceWorkerMessageSend implements MessageSend
```

* `chrome.runtime.MessageSender` 取名為 `RuntimeMessageSender` 避免混亂
* 只 send 或 只 receive 的 "Message" 改變數名為 msgSend, msgReceive
* content.ts 中的 ExtensionMessage 和 ExtensionMessageSend 合二之一


### 截图

<!-- 如果可以展示页面，请务必附上截图 -->
