### PR TITLE
脚本注入方式优化

### DIFF
--- a/src/app/service/service_worker/gm_api.ts
+++ b/src/app/service/service_worker/gm_api.ts
@@ -12,7 +12,7 @@ import PermissionVerify, { PermissionVerifyApiGet } from "./permission_verify";
 import { cacheInstance } from "@App/app/cache";
 import EventEmitter from "eventemitter3";
 import { type RuntimeService } from "./runtime";
-import { getIcon, isFirefox, getCurrentTab, openInCurrentTab } from "@App/pkg/utils/utils";
+import { getIcon, isFirefox, getCurrentTab, openInCurrentTab, cleanFileName } from "@App/pkg/utils/utils";
 import { type SystemConfig } from "@App/pkg/config/config";
 import i18next, { i18nName } from "@App/locales/locales";
 import FileSystemFactory from "@Packages/filesystem/factory";
@@ -995,7 +995,7 @@ export default class GMApi {
   async GM_download(request: Request, sender: GetSender) {
     const params = <GMTypes.DownloadDetails>request.params[0];
     // 替换掉windows下文件名的非法字符为 -
-    const fileName = params.name.replace(/[\x00-\x1F\\\/:*?"<>|]+/g, "-").trim();
+    const fileName = cleanFileName(params.name);
     // blob本地文件或显示指定downloadMode为"browser"则直接下载
     if (params.url.startsWith("blob:") || params.downloadMode === "browser") {
       chrome.downloads.download(

--- a/src/app/service/service_worker/index.ts
+++ b/src/app/service/service_worker/index.ts
@@ -16,6 +16,7 @@ import { SystemService } from "./system";
 import { type Logger, LoggerDAO } from "@App/app/repo/logger";
 import { localePath, t } from "@App/locales/locales";
 import { getCurrentTab, InfoNotification } from "@App/pkg/utils/utils";
+import { LocalStorageDAO } from "@App/app/repo/localStorage";
 
 // service worker的管理器
 export default class ServiceWorkerManager {
@@ -42,6 +43,7 @@ export default class ServiceWorkerManager {
 
     const scriptDAO = new ScriptDAO();
     scriptDAO.enableCache();
+    const localStorageDAO = new LocalStorageDAO();
 
     const systemConfig = new SystemConfig(this.mq);
 
@@ -58,7 +60,8 @@ export default class ServiceWorkerManager {
       value,
       script,
       resource,
-      scriptDAO
+      scriptDAO,
+      localStorageDAO
     );
     runtime.init();
     const popup = new PopupService(this.api.group("popup"), this.mq, runtime, scriptDAO, systemConfig);

--- a/src/app/service/service_worker/runtime.test.ts
+++ b/src/app/service/service_worker/runtime.test.ts
@@ -111,7 +111,8 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
       mockScriptService.buildScriptRunResource.mockReturnValue(scriptRunResource);
 
       // Act
-      await runtime.getAndSetUserScriptRegister(script);
+      const scriptMatchInfo = await runtime.buildAndSetScriptMatchInfo(script);
+      expect(scriptMatchInfo).toBeDefined();
       const result = await runtime.getPageScriptMatchingResultByUrl("http://www.example.com/path");
 
       // Assert
@@ -138,7 +139,8 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
       mockScriptService.buildScriptRunResource.mockReturnValue(scriptRunResource);
 
       // Act
-      await runtime.getAndSetUserScriptRegister(script);
+      const scriptMatchInfo = await runtime.buildAndSetScriptMatchInfo(script);
+      expect(scriptMatchInfo).toBeDefined();
 
       // 测试默认查询（不包含无效匹配）
       const defaultResult = await runtime.getPageScriptMatchingResultByUrl("http://www.example.com/path");
@@ -174,7 +176,8 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
       mockScriptService.buildScriptRunResource.mockReturnValue(scriptRunResource);
 
       // Act
-      await runtime.getAndSetUserScriptRegister(script);
+      const scriptMatchInfo = await runtime.buildAndSetScriptMatchInfo(script);
+      expect(scriptMatchInfo).toBeDefined();
 
       // 测试匹配第一个规则
       const result1 = await runtime.getPageScriptMatchingResultByUrl("http://www.example.com/path");
@@ -213,7 +216,8 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
       mockScriptService.buildScriptRunResource.mockReturnValue(scriptRunResource);
 
       // Act
-      await runtime.getAndSetUserScriptRegister(script);
+      const scriptMatchInfo = await runtime.buildAndSetScriptMatchInfo(script);
+      expect(scriptMatchInfo).toBeDefined();
 
       // 测试被include但不被exclude的URL
       const includeResult = await runtime.getPageScriptMatchingResultByUrl("http://www.example.com/user");
@@ -249,7 +253,8 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
       mockScriptService.buildScriptRunResource.mockReturnValue(scriptRunResource);
 
       // Act
-      await runtime.getAndSetUserScriptRegister(script);
+      const scriptMatchInfo = await runtime.buildAndSetScriptMatchInfo(script);
+      expect(scriptMatchInfo).toBeDefined();
 
       // 测试正常URL
       const normalResult = await runtime.getPageScriptMatchingResultByUrl("http://www.example.com/page");
@@ -280,7 +285,7 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
       });
 
       // Act & Assert
-      await expect(runtime.getAndSetUserScriptRegister(script)).rejects.toThrow("Build script run resource failed");
+      await expect(runtime.buildAndSetScriptMatchInfo(script)).rejects.toThrow("Build script run resource failed");
     });
 
     it("应该正确处理空metadata的脚本", async () => {
@@ -293,7 +298,8 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
       mockScriptService.buildScriptRunResource.mockReturnValue(scriptRunResource);
 
       // Act
-      await runtime.getAndSetUserScriptRegister(script);
+      const scriptMatchInfo = await runtime.buildAndSetScriptMatchInfo(script);
+      expect(scriptMatchInfo).toBeUndefined();
       const result = await runtime.getPageScriptMatchingResultByUrl("http://www.example.com/path");
 
       // Assert
@@ -308,7 +314,8 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
       mockScriptService.buildScriptRunResource.mockReturnValue(scriptRunResource);
 
       // Act
-      await runtime.getAndSetUserScriptRegister(script);
+      const scriptMatchInfo = await runtime.buildAndSetScriptMatchInfo(script);
+      expect(scriptMatchInfo).toBeDefined();
 
       // Assert
       const result = await runtime.getPageScriptMatchingResultByUrl("http://www.example.com/path");

--- a/src/app/service/service_worker/runtime.test.ts
+++ b/src/app/service/service_worker/runtime.test.ts
@@ -13,6 +13,7 @@ import type { ValueService } from "./value";
 import type { ScriptService } from "./script";
 import type { ResourceService } from "./resource";
 import type { ScriptDAO } from "@App/app/repo/scripts";
+import { LocalStorageDAO } from "@App/app/repo/localStorage";
 
 initTestEnv();
 
@@ -79,7 +80,10 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
     } as unknown as MessageQueue;
     const mockValueService = {} as ValueService;
     const mockResourceService = {} as ResourceService;
-    const mockScriptDAO = {} as ScriptDAO;
+    const mockScriptDAO = {
+      all: vi.fn().mockResolvedValue([]),
+    } as unknown as ScriptDAO;
+    const mockLocalStorageDAO = new LocalStorageDAO();
 
     runtime = new RuntimeService(
       mockSystemConfig as unknown as SystemConfig,
@@ -89,7 +93,8 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
       mockValueService,
       mockScriptService as unknown as ScriptService,
       mockResourceService,
-      mockScriptDAO
+      mockScriptDAO,
+      mockLocalStorageDAO
     );
   });
 
@@ -110,7 +115,7 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
       const result = await runtime.getPageScriptMatchingResultByUrl("http://www.example.com/path");
 
       // Assert
-      expect(mockScriptService.buildScriptRunResource).toHaveBeenCalledWith(script, undefined);
+      expect(mockScriptService.buildScriptRunResource).toHaveBeenCalledWith(script, script.uuid);
       expect(result.has(script.uuid)).toBe(true);
 
       const matchInfo = result.get(script.uuid);
@@ -142,7 +147,7 @@ describe("RuntimeService - getAndSetUserScriptRegister 脚本匹配", () => {
       const allResult = await runtime.getPageScriptMatchingResultByUrl("http://www.example.com/path", true);
 
       // Assert
-      expect(mockScriptService.buildScriptRunResource).toHaveBeenCalledWith(script, undefined);
+      expect(mockScriptService.buildScriptRunResource).toHaveBeenCalledWith(script, script.uuid);
 
       // 默认查询应该不包含被排除的脚本
       expect(defaultResult.has(script.uuid)).toBe(false);

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -943,7 +943,7 @@ export class RuntimeService {
           } else {
             // 如果没有缓存数据，则从数据库加载，解决浏览器重新启动后缓存丢失的问题
             const scripts = (await this.scriptDAO.all()).sort((a, b) => a.sort - b.sort);
-            Promise.all(
+            await Promise.all(
               scripts.map(async (script) => {
                 if (script.type !== SCRIPT_TYPE_NORMAL) {
                   return;
@@ -1027,7 +1027,7 @@ export class RuntimeService {
     this.scriptMatchCache!.delete(uuid);
     this.scriptMatch.clearRules(uuid);
     this.scriptMatch.clearRules(`${uuid}${ORIGINAL_URLMATCH_SUFFIX}`);
-    this.saveScriptMatchInfo();
+    await this.saveScriptMatchInfo();
   }
 
   // 构建脚本匹配信息并存入缓存

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -580,8 +580,6 @@ export class RuntimeService {
       console.error("chrome.userScripts.resetWorldConfiguration() failed.", e);
     }
 
-    // 只有early-start脚本需要使用userScript.register注册
-    // 其它脚本将源代码发送到content.js中由content.js注入
     const particularScriptList = await this.getParticularScriptList();
     // getContentAndInjectScript依赖loadScriptMatchInfo
     // 需要等getParticularScriptList完成后再执行
@@ -674,7 +672,6 @@ export class RuntimeService {
   }
 
   async pageLoad(_: any, sender: GetSender) {
-    console.log("pageLoad", this.isLoadScripts);
     if (!this.isLoadScripts) {
       return { flag: "", scripts: [] };
     }
@@ -1082,8 +1079,6 @@ export class RuntimeService {
   }
 
   // 构建userScript注册信息
-  // 只有early-start脚本需要使用userScript.register注册
-  // 其它脚本保存@match等信息到缓存中，由content.js注入
   async getAndSetUserScriptRegister(script: Script) {
     const preDocumentStartScript = isEarlyStartScript(script);
     const scriptRes = await this.buildScriptMatchInfoEntry(script);

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -432,8 +432,8 @@ export class RuntimeService {
     let flag = await this.localStorageDAO.get("scriptInjectMessageFlag");
     if (!flag) {
       flag = { key: "scriptInjectMessageFlag", value: randomMessageFlag() };
+      await this.localStorageDAO.save(flag);
     }
-    await this.localStorageDAO.save(flag);
     return flag.value;
   }
 

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -941,13 +941,13 @@ export class RuntimeService {
             }
           } else {
             // 如果没有缓存数据，则读取所有的页面脚本，处理@match等信息
-            // const list = (await this.scriptDAO.all()).filter((script) => script.type === SCRIPT_TYPE_NORMAL);
-            // for (const script of list) {
-            //   const res = await this.buildScriptMatchInfoEntry(script);
-            //   if (res) {
-            //     this.addScriptMatchEntry(scriptMatchCache, res);
-            //   }
-            // }
+            const list = (await this.scriptDAO.all()).filter((script) => script.type === SCRIPT_TYPE_NORMAL);
+            for (const script of list) {
+              const res = await this.buildScriptMatchInfoEntry(script);
+              if (res) {
+                this.addScriptMatchEntry(scriptMatchCache, res as TScriptMatchInfoEntry);
+              }
+            }
           }
         })
         .then(() => {
@@ -1037,13 +1037,7 @@ export class RuntimeService {
 
   // 构建脚本匹配信息
   async buildScriptMatchInfoEntry(script: Script) {
-    const preDocumentStartScript = isEarlyStartScript(script);
-    let scriptFlag: string | undefined;
-    if (preDocumentStartScript) {
-      //preDocumentStart脚本使用uuid作为flag
-      scriptFlag = script.uuid;
-    }
-    const scriptRes = await this.script.buildScriptRunResource(script, scriptFlag);
+    const scriptRes = await this.script.buildScriptRunResource(script, script.uuid);
     const { metadata, originalMetadata } = scriptRes;
     const metaMatch = metadata.match;
     const metaInclude = metadata.include;
@@ -1131,6 +1125,8 @@ export class RuntimeService {
     if (scriptRes.metadata["run-at"]) {
       registerScript.runAt = getRunAt(scriptRes.metadata["run-at"]);
     }
+
+    await this.addScriptMatch(scriptRes as TScriptMatchInfoEntry);
 
     return {
       registerScript,

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -938,13 +938,15 @@ export class RuntimeService {
             }
           } else {
             // 如果没有缓存数据，则读取所有的页面脚本，处理@match等信息
-            const list = (await this.scriptDAO.all()).filter((script) => script.type === SCRIPT_TYPE_NORMAL);
-            for (const script of list) {
-              const res = await this.buildScriptMatchInfoEntry(script);
-              if (res) {
-                this.addScriptMatchEntry(scriptMatchCache, res as TScriptMatchInfoEntry);
-              }
-            }
+            const allScripts = await this.scriptDAO.all();
+            await Promise.all(
+              allScripts.map(async (script) => {
+                const res = await this.buildScriptMatchInfoEntry(script);
+                if (res) {
+                  this.addScriptMatchEntry(scriptMatchCache, res as TScriptMatchInfoEntry);
+                }
+              })
+            ); // 确保所有脚本都加入缓存
           }
         })
         .then(() => {

--- a/src/app/service/service_worker/utils.test.ts
+++ b/src/app/service/service_worker/utils.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { isBase64, parseUrlSRI, getCombinedMeta, selfMetadataUpdate } from "./utils";
+import { isBase64, parseUrlSRI, getCombinedMeta, selfMetadataUpdate, getUserScriptRegister } from "./utils";
 import type { SCMetadata, Script } from "@App/app/repo/scripts";
 import { SCRIPT_TYPE_NORMAL, SCRIPT_STATUS_ENABLE, SCRIPT_RUN_STATUS_COMPLETE } from "@App/app/repo/scripts";
+import type { ScriptMatchInfo } from "../types";
 
 describe("parseUrlSRI", () => {
   it("should parse URL SRI", () => {
@@ -206,5 +207,50 @@ describe("selfMetadataUpdate", () => {
     const result = selfMetadataUpdate(script, "test", mixedValues);
 
     expect(result.selfMetadata?.test).toEqual(["valid", "another-valid"]);
+  });
+});
+
+describe("getUserScriptRegister", () => {
+  it("should return a valid RegisteredUserScript object", () => {
+    const mockScriptMatchInfo: ScriptMatchInfo = {
+      uuid: "test-uuid",
+      name: "Test Script",
+      code: "console.log('test');",
+      metadata: {
+        "run-at": ["document-end"],
+        noframes: [],
+      },
+      scriptUrlPatterns: [
+        {
+          ruleType: 1, // MATCH_INCLUDE
+          ruleContent: "*://example.com/*",
+          ruleTag: "match",
+          patternString: "*://example.com/*",
+        },
+      ],
+      originalUrlPatterns: [],
+      // 其他必需字段
+      namespace: "test",
+      type: 1,
+      status: 1,
+      sort: 0,
+      runStatus: "running",
+      createtime: Date.now(),
+      checktime: Date.now(),
+      value: {},
+      flag: "test",
+      resource: {},
+      originalMetadata: {},
+    };
+
+    const result = getUserScriptRegister(mockScriptMatchInfo);
+
+    expect(result).toHaveProperty("registerScript");
+    expect(result.registerScript.id).toBe("test-uuid");
+    expect(result.registerScript.js).toHaveLength(1);
+    expect(result.registerScript.matches).toContain("*://example.com/*");
+    expect(result.registerScript.allFrames).toBe(false);
+    expect(result.registerScript.world).toBe("MAIN");
+    expect(result.registerScript.runAt).toBe("document_end");
   });
 });

--- a/src/app/service/service_worker/utils.test.ts
+++ b/src/app/service/service_worker/utils.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { isBase64, parseUrlSRI, getCombinedMeta, selfMetadataUpdate, getUserScriptRegister } from "./utils";
 import type { SCMetadata, Script } from "@App/app/repo/scripts";
 import { SCRIPT_TYPE_NORMAL, SCRIPT_STATUS_ENABLE, SCRIPT_RUN_STATUS_COMPLETE } from "@App/app/repo/scripts";
-import type { ScriptMatchInfo } from "../types";
+import type { ScriptMatchInfo } from "./types";
 
 describe("parseUrlSRI", () => {
   it("should parse URL SRI", () => {

--- a/src/content.ts
+++ b/src/content.ts
@@ -14,6 +14,8 @@ declare global {
   }
 }
 
+console.log("content.js");
+
 if (typeof chrome?.runtime?.onMessage?.addListener !== "function") {
   // ScriptCat 未支持 Firefox MV3
   console.error("Firefox MV3 UserScripts is not yet supported by ScriptCat");

--- a/src/content.ts
+++ b/src/content.ts
@@ -14,8 +14,6 @@ declare global {
   }
 }
 
-console.log("content.js");
-
 if (typeof chrome?.runtime?.onMessage?.addListener !== "function") {
   // ScriptCat 未支持 Firefox MV3
   console.error("Firefox MV3 UserScripts is not yet supported by ScriptCat");

--- a/src/pages/components/PopupWarnings/index.tsx
+++ b/src/pages/components/PopupWarnings/index.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button } from "@arco-design/web-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { isUserScriptsAvailable, getBrowserType, BrowserType } from "@App/pkg/utils/utils";
+import { checkUserScriptsAvailable, getBrowserType, BrowserType } from "@App/pkg/utils/utils";
 import edgeMobileQrCode from "@App/assets/images/edge_mobile_qrcode.png";
 
 interface PopupWarningsProps {
@@ -15,7 +15,7 @@ function PopupWarnings({ isBlacklist }: PopupWarningsProps) {
   const [permissionReqResult, setPermissionReqResult] = useState("");
 
   const updateIsUserScriptsAvailableState = async () => {
-    const flag = await isUserScriptsAvailable();
+    const flag = await checkUserScriptsAvailable();
     setIsUserScriptsAvailableState(flag);
   };
 

--- a/src/pkg/utils/utils.test.ts
+++ b/src/pkg/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, it } from "vitest";
-import { checkSilenceUpdate } from "./utils";
+import { checkSilenceUpdate, cleanFileName } from "./utils";
 import { ltever, versionCompare } from "@App/pkg/utils/semver";
 import { nextTime } from "./cron";
 import dayjs from "dayjs";
@@ -239,5 +239,26 @@ describe("checkSilenceUpdate", () => {
         }
       )
     ).toBe(false);
+  });
+});
+
+describe("cleanFileName", () => {
+  it("should replace illegal characters with dashes", () => {
+    expect(cleanFileName("file/name")).toBe("file-name");
+    expect(cleanFileName("file\\name")).toBe("file-name");
+    expect(cleanFileName("file:name")).toBe("file-name");
+    expect(cleanFileName("file*name")).toBe("file-name");
+  });
+
+  it("should trim spaces", () => {
+    expect(cleanFileName("  file  ")).toBe("file");
+  });
+
+  it("should handle empty string", () => {
+    expect(cleanFileName("")).toBe("");
+  });
+
+  it("should handle valid filename", () => {
+    expect(cleanFileName("valid_file.txt")).toBe("valid_file.txt");
   });
 });

--- a/src/pkg/utils/utils.ts
+++ b/src/pkg/utils/utils.ts
@@ -313,3 +313,8 @@ export const obtainBlackList = (strBlacklist: string | null | undefined) => {
 export function toCamelCase(key: SystemConfigKey) {
   return key.replace(/_([a-z])/g, (g) => g[1].toUpperCase()).replace(/^([a-z])/, (g) => g.toUpperCase());
 }
+
+export function cleanFileName(name: string): string {
+  // eslint-disable-next-line no-control-regex, no-useless-escape
+  return name.replace(/[\x00-\x1F\\\/:*?"<>|]+/g, "-").trim();
+}

--- a/src/pkg/utils/utils.ts
+++ b/src/pkg/utils/utils.ts
@@ -172,7 +172,7 @@ export function errorMsg(e: any): string {
 }
 
 // 预计报错有机会在异步Promise裡发生，不一定是 chrome.userScripts.getScripts
-export async function isUserScriptsAvailable() {
+export async function checkUserScriptsAvailable() {
   try {
     // Property access which throws if developer mode is not enabled.
     // Method call which throws if API permission or toggle is not enabled.

--- a/tests/pages/popup/App.test.tsx
+++ b/tests/pages/popup/App.test.tsx
@@ -81,7 +81,7 @@ vi.mock("../store/global", () => ({
 
 // Mock utils
 vi.mock("@App/pkg/utils/utils", () => ({
-  isUserScriptsAvailable: vi.fn(() => true),
+  checkUserScriptsAvailable: vi.fn(() => true),
   getBrowserType: vi.fn(() => "chrome"),
   BrowserType: {
     Chrome: "chrome",


### PR DESCRIPTION
## 概述

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- close #xxx -->

close #751 #742 #740 #135

原来注入的flag使用chrome.session存储，每次重启浏览器时会清空，重启时没有flag会重新走注册脚本的逻辑，导致冷启动的标签无法运行脚本

现在持久化了注入脚本与注入的flag，重启时不会丢失flag信息，冷启动时可以正常运行脚本

另外在启动的时候会读取脚本资源，没有脚本资源的话将从网络中下载，此时如果网络很慢，也会影响脚本的注入速度

---

记录一下另外的注入方式，只注入content.js，不使用userScript注入页面脚本，在pageLoad时，将脚本代码也发送到content.js，由content.js处理userscript的注入与run-at，TM就是如此操作，但是early-start的脚本还是必须使用现有的方式注入

```js
// mv2时的inject也是由content.js注入

// 注入运行框架
const temp = document.createElementNS("http://www.w3.org/1999/xhtml", "script");
temp.setAttribute("type", "text/javascript");
temp.setAttribute("charset", "UTF-8");
temp.textContent = `(function (ScriptFlag) {\n${injectJs1}\n})('${scriptFlag}')`;
temp.className = "injected-js";
document.documentElement.appendChild(temp);
temp.remove();
```

## 变更内容

<!-- - 这个 PR 做了什么？ -->

### 截图

<!-- 如果可以展示页面，请务必附上截图 -->
