### PR TITLE
修正 chrome.tabs.query

### DIFF
--- a/src/app/service/service_worker/gm_api.ts
+++ b/src/app/service/service_worker/gm_api.ts
@@ -542,7 +542,7 @@ export default class GMApi {
       requestHeaders: requestHeaders,
     };
     rule.priority = 1;
-    const tabs = await chrome.tabs.query({ windowType: "normal" });
+    const tabs = await chrome.tabs.query({});
     const excludedTabIds: number[] = [];
     for (const tab of tabs) {
       if (tab.id) {


### PR DESCRIPTION
## 概述

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- close #xxx -->

chrome.tabs.query 会取得其他特殊 tabs
应加入 `windowType: "normal"` 避免取得例如 DevTool / Popup 等东西
https://developer.chrome.com/docs/extensions/reference/api/tabs#type-WindowType

## 变更内容

<!-- - 这个 PR 做了什么？ -->

### 截图

<!-- 如果可以展示页面，请务必附上截图 -->
