### PR TITLE
（小改动）防止脚本安装链结因脚本名字改了而被误判为安装而非更新

### DIFF
--- a/src/app/repo/scripts.test.ts
+++ b/src/app/repo/scripts.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  ScriptDAO,
+  type Script,
+  SCRIPT_TYPE_NORMAL,
+  SCRIPT_STATUS_ENABLE,
+  SCRIPT_RUN_STATUS_COMPLETE,
+} from "./scripts";
+
+const baseMeta = {
+  name: ["测试脚本"],
+  namespace: ["test-namespace"],
+  version: ["1.0.0"],
+  author: ["测试作者"],
+  copyright: ["(c) 测试"],
+  grant: ["GM_xmlhttpRequest"],
+  match: ["https://example.com/*"],
+  license: ["MIT"],
+};
+
+const makeBaseScript = (overrides: Partial<Script>): Script => ({
+  uuid: "uuid-base",
+  name: "测试脚本",
+  namespace: "test-namespace",
+  author: "测试作者",
+  type: SCRIPT_TYPE_NORMAL,
+  status: SCRIPT_STATUS_ENABLE,
+  sort: 0,
+  runStatus: SCRIPT_RUN_STATUS_COMPLETE,
+  createtime: Date.now(),
+  updatetime: Date.now(),
+  checktime: Date.now(),
+  origin: "https://example.com/script.user.js",
+  metadata: { ...baseMeta },
+  ...overrides,
+});
+
+describe("ScriptDAO.searchExistingScript", () => {
+  let dao: ScriptDAO;
+
+  beforeEach(() => {
+    dao = new ScriptDAO();
+  });
+
+  it("应能在 scriptcat 场景下匹配到已存在脚本（忽略脚本名差异并校验作者/授权/匹配等信息）", async () => {
+    const existing = makeBaseScript({
+      uuid: "sc-1",
+      origin: "https://scriptcat.org/scripts/code/1234/old-name.js",
+    });
+    await dao.save(existing);
+
+    const target: Script = makeBaseScript({
+      uuid: "target-1",
+      origin: "https://scriptcat.org/scripts/code/1234/new-name.js",
+      metadata: {
+        ...baseMeta,
+        // 无 updateurl/downloadurl => 走 scriptcat 分支
+      } as any,
+    });
+
+    const found = await dao.searchExistingScript(target);
+    expect(found[0]?.uuid).toBe("sc-1");
+  });
+
+  it("应能在 greasyfork 场景下匹配（忽略文件名差异，基于 id 与 update/download URL）", async () => {
+    const existing = makeBaseScript({
+      uuid: "gf-1",
+      origin: "https://update.greasyfork.org/scripts/1234/old.meta.js",
+      metadata: {
+        ...baseMeta,
+        updateurl: ["https://update.greasyfork.org/scripts/1234/old.meta.js"],
+        downloadurl: ["https://update.greasyfork.org/scripts/1234/old.user.js"],
+      } as any,
+    });
+    await dao.save(existing);
+
+    const target: Script = makeBaseScript({
+      uuid: "target-2",
+      origin: "https://update.greasyfork.org/scripts/1234/new-name.meta.js",
+      metadata: {
+        ...baseMeta,
+        updateurl: ["https://update.greasyfork.org/scripts/1234/new-name.meta.js"],
+        downloadurl: ["https://update.greasyfork.org/scripts/1234/new-name.user.js"],
+      } as any,
+    });
+
+    const found = await dao.searchExistingScript(target);
+    expect(found[0]?.uuid).toBe("gf-1");
+  });
+
+  it("只有 updateurl 也可以匹配 greasyfork 脚本", async () => {
+    const existing = makeBaseScript({
+      uuid: "gf-2",
+      origin: "https://update.greasyfork.org/scripts/5678/keep.meta.js",
+      metadata: {
+        ...baseMeta,
+        updateurl: ["https://update.greasyfork.org/scripts/5678/keep.meta.js"],
+      } as any,
+    });
+    await dao.save(existing);
+
+    const target: Script = makeBaseScript({
+      uuid: "target-3",
+      origin: "https://update.greasyfork.org/scripts/5678/changed-name.meta.js",
+      metadata: {
+        ...baseMeta,
+        updateurl: ["https://update.greasyfork.org/scripts/5678/changed-name.meta.js"],
+      } as any,
+    });
+
+    const found = await dao.searchExistingScript(target);
+    expect(found[0]?.uuid).toBe("gf-2");
+  });
+
+  it("当元数据关键信息不一致（如 grant）时不应匹配", async () => {
+    const existing = makeBaseScript({
+      uuid: "mismatch-1",
+      origin: "https://scriptcat.org/scripts/code/42/old.js",
+    });
+    await dao.save(existing);
+
+    const target: Script = makeBaseScript({
+      uuid: "target-4",
+      origin: "https://scriptcat.org/scripts/code/42/new.js",
+      metadata: {
+        ...baseMeta,
+        grant: ["none"], // 与 existing 不同
+      } as any,
+    });
+
+    const found = await dao.searchExistingScript(target);
+    expect(found[0]).toBeUndefined();
+  });
+
+  it("不同域名/来源不应匹配", async () => {
+    const existing = makeBaseScript({
+      uuid: "domain-1",
+      origin: "https://scriptcat.org/scripts/code/999/old.js",
+    });
+    await dao.save(existing);
+
+    const target: Script = makeBaseScript({
+      uuid: "target-5",
+      origin: "https://update.greasyfork.org/scripts/999/new.meta.js",
+      metadata: {
+        ...baseMeta,
+        updateurl: ["https://update.greasyfork.org/scripts/999/new.meta.js"],
+      } as any,
+    });
+
+    const found = await dao.searchExistingScript(target);
+    expect(found[0]).toBeUndefined();
+  });
+});

--- a/src/app/service/service_worker/client.ts
+++ b/src/app/service/service_worker/client.ts
@@ -47,7 +47,7 @@ export class ScriptClient extends Client {
 
   // 获取安装信息
   getInstallInfo(uuid: string) {
-    return this.do<[boolean, ScriptInfo]>("getInstallInfo", uuid);
+    return this.do<[boolean, ScriptInfo, { byWebRequest?: boolean }]>("getInstallInfo", uuid);
   }
 
   install(script: Script, code: string, upsertBy: InstallSource = "user"): Promise<{ update: boolean }> {

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -107,7 +107,7 @@ export class ScriptService {
         // 读取脚本url内容, 进行安装
         const logger = this.logger.with({ url: targetUrl });
         logger.debug("install script");
-        this.openInstallPageByUrl(targetUrl, "user")
+        this.openInstallPageByUrl(targetUrl, { source: "user", byWebRequest: true })
           .catch((e) => {
             logger.error("install script error", Logger.E(e));
             // 不再重定向当前url
@@ -205,10 +205,13 @@ export class ScriptService {
     );
   }
 
-  public async openInstallPageByUrl(url: string, source: InstallSource): Promise<{ success: boolean; msg: string }> {
+  public async openInstallPageByUrl(
+    url: string,
+    options: { source: InstallSource; byWebRequest?: boolean }
+  ): Promise<{ success: boolean; msg: string }> {
     const uuid = uuidv4();
     try {
-      await this.openUpdateOrInstallPage(uuid, url, source, false);
+      await this.openUpdateOrInstallPage(uuid, url, options, false);
       timeoutExecution(
         `${cIdKey}_cleanup_${uuid}`,
         () => {
@@ -711,7 +714,14 @@ export class ScriptService {
     return script;
   }
 
-  async openUpdateOrInstallPage(uuid: string, url: string, upsertBy: InstallSource, update: boolean, logger?: Logger) {
+  async openUpdateOrInstallPage(
+    uuid: string,
+    url: string,
+    options: { source: InstallSource; byWebRequest?: boolean },
+    update: boolean,
+    logger?: Logger
+  ) {
+    const upsertBy = options.source;
     const code = await fetchScriptBody(url);
     if (update && (await this.systemConfig.getSilenceUpdateScript())) {
       try {
@@ -735,7 +745,7 @@ export class ScriptService {
     if (!metadata) {
       throw new Error("parse script info failed");
     }
-    const si = [update, createScriptInfo(uuid, code, url, upsertBy, metadata)];
+    const si = [update, createScriptInfo(uuid, code, url, upsertBy, metadata), options];
     await cacheInstance.set(`${CACHE_KEY_SCRIPT_INFO}${uuid}`, si);
     return 1;
   }
@@ -751,7 +761,7 @@ export class ScriptService {
     });
     const url = downloadUrl || checkUpdateUrl!;
     try {
-      const ret = await this.openUpdateOrInstallPage(uuid, url, source, true, logger);
+      const ret = await this.openUpdateOrInstallPage(uuid, url, { source }, true, logger);
       if (ret === 2) return; // slience update
       // 打开安装页面
       openInCurrentTab(`/src/install.html?uuid=${uuid}`);
@@ -1141,7 +1151,7 @@ export class ScriptService {
   }
 
   importByUrl(url: string) {
-    return this.openInstallPageByUrl(url, "user");
+    return this.openInstallPageByUrl(url, { source: "user" });
   }
 
   setCheckUpdateUrl({

--- a/src/app/service/service_worker/subscribe.ts
+++ b/src/app/service/service_worker/subscribe.ts
@@ -231,7 +231,7 @@ export class SubscribeService {
         if (true === (await this.trySilenceUpdate(code, url))) {
           // slience update
         } else {
-          const si = [false, createScriptInfo(uuid, code, url, source, metadata)];
+          const si = [false, createScriptInfo(uuid, code, url, source, metadata), {}];
           await cacheInstance.set(`${CACHE_KEY_SCRIPT_INFO}${uuid}`, si);
           chrome.tabs.create({
             url: `/src/install.html?uuid=${uuid}`,

--- a/src/pages/install/App.tsx
+++ b/src/pages/install/App.tsx
@@ -88,10 +88,12 @@ function App() {
       const uuid = locationUrl.searchParams.get("uuid");
       let info: ScriptInfo | undefined;
       let isKnownUpdate: boolean = false;
+      let paramOptions = {};
       if (uuid) {
         const cachedInfo = await scriptClient.getInstallInfo(uuid);
         if (cachedInfo?.[0]) isKnownUpdate = true;
         info = cachedInfo?.[1] || undefined;
+        paramOptions = cachedInfo?.[2] || {};
         if (!info) {
           throw new Error("fetch script info failed");
         }
@@ -145,7 +147,7 @@ function App() {
         diffCode = prepare.oldSubscribe?.code;
       } else {
         const knownUUID = isKnownUpdate ? info.uuid : undefined;
-        prepare = await prepareScriptByCode(code, url, knownUUID);
+        prepare = await prepareScriptByCode(code, url, knownUUID, false, undefined, paramOptions);
         action = prepare.script;
         if (prepare.oldScript) {
           oldVersion = prepare.oldScript!.metadata!.version![0] || "";


### PR DESCRIPTION
## 概述

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- close #xxx -->


有时候， GreasyFork的脚本名字因为更改了，如果我用链结去安装，因为它的名字对不上，以为是新安装
GreasyFork的腳本有 `@updateURL` 可以检查是不是同一个脚本

## 变更内容

<!-- - 这个 PR 做了什么？ -->

### 截图

<!-- 如果可以展示页面，请务必附上截图 -->
