### PR TITLE
避开CSP限制导致CSS无法注入

### DIFF
--- a/src/app/service/content/script_executor.ts
+++ b/src/app/service/content/script_executor.ts
@@ -3,7 +3,7 @@ import { getStorageName } from "@App/pkg/utils/utils";
 import type { EmitEventRequest } from "../service_worker/types";
 import ExecScript from "./exec_script";
 import type { GMInfoEnv, ScriptFunc, ValueUpdateDataEncoded } from "./types";
-import { addStyle, definePropertyListener } from "./utils";
+import { addStyleSheet, definePropertyListener } from "./utils";
 import type { TScriptInfo } from "@App/app/repo/scripts";
 import { DefinedFlags } from "../service_worker/runtime.consts";
 
@@ -116,7 +116,7 @@ export class ScriptExecutor {
       for (const val of metadata["require-css"]) {
         const res = resource[val];
         if (res) {
-          addStyle(res.content);
+          addStyleSheet(res.content);
         }
       }
     }

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -166,6 +166,16 @@ export function addStyle(css: string): HTMLStyleElement {
   return document.documentElement.appendChild(dom);
 }
 
+export function addStyleSheet(css: string): CSSStyleSheet {
+  // see https://unarist.hatenablog.com/entry/2020/07/06/012540
+  const sheet = new CSSStyleSheet();
+  // it might return as Promise
+  sheet.replaceSync(css);
+  // adoptedStyleSheets is FrozenArray so it has to be re-assigned.
+  document.adoptedStyleSheets = document.adoptedStyleSheets.concat(sheet);
+  return sheet;
+}
+
 export function metadataBlankOrTrue(metadata: SCMetadata, key: string): boolean {
   const s = metadata[key]?.[0];
   return s === "" || s === "true";


### PR DESCRIPTION
## 概述 Descriptions

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- Describe related issue(s) if any. -->
<!-- close #xxx -->


```js
// ==UserScript==
// @name         Inject CSS under CSP limitation
// @namespace    https://docs.scriptcat.org/
// @version      0.1.0
// @description  try to take over the world!
// @author       You
// @match        https://*/*
// @grant        none
// @require-css  https://samplesdl.me/training_html-css/style.css
// ==/UserScript==

(function() {
    'use strict';

    console.log(123)
    // Your code here...
})();

```

在这执行 https://content-security-policy.com/


注： 不同于 GM_addStyle.  `@require-css` 不需要在 `<html>` 或 `<head>` 插 HTMLStyleElement
GM_addStyle 不能这样做因为会改变行为


## 变更内容 Changes

<!-- - 这个 PR 做了什么？ -->
<!-- - What does this PR do? -->

### 截图 Screenshots

<!-- 如果可以展示页面，请务必附上截图 -->
<!-- If it can be illustrated, please provide a screenshot. -->
