### PR TITLE
fix: 沙盒 console 应从网页环境隔离

### DIFF
--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -240,6 +240,10 @@ const sharedInitCopy = USE_PSEUDO_WINDOW
       ...overridedDescs,
     });
 
+// 把沙盒的 console 和网页的 console 隔离
+const initConsoleDescs = Object.getOwnPropertyDescriptors(console);
+const ConsolePrototype = Object.getPrototypeOf(console);
+
 type GMWorldContext = typeof globalThis & Record<PropertyKey, any>;
 
 const isPrimitive = (x: any) => x !== Object(x);
@@ -387,6 +391,9 @@ export const createProxyContext = <const Context extends GMWorldContext>(context
     // 目前 TM 只支援 null. ScriptCat不需要grant预设启用？
     mySandbox.onurlchange = null;
   }
+
+  // 从网页 console 隔离出来的沙盒 console
+  mySandbox.console = Object.create(ConsolePrototype, initConsoleDescs);
 
   return mySandbox;
 };


### PR DESCRIPTION
## 概述 Descriptions

可以留待 1.3 BETA
随你

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- Describe related issue(s) if any. -->
<!-- close #xxx -->

```js
// ==UserScript==
// @name         Sandbox Test
// @namespace    https://bbs.tampermonkey.net.cn/
// @version      0.1.0
// @description  try to take over the world!
// @author       You
// @match        https://www.ign.com/wikis/starcraft/Terran_Story*
// @grant        unsafeWindow
// ==/UserScript==

/* global ChessKit */

const tag = GM_info.scriptHandler === "ScriptCat" ? "SC" : "TM";

const deferred = () => {
  let resolve;
  let reject;
  const promise = new Promise((res, rej) => {
    resolve = res;
    reject = rej;
  });
  return { promise, resolve, reject };
};

unsafeWindow[`sandboxTest${tag}`] = async function () {
    console.log(`---- ${tag} ----`);

    console.log("B1", `${window}` === "[object Window]");
    console.log("B2", typeof window.addEventListener === "function");
    console.log("B3", typeof window.dispatchEvent === "function");
    console.log("B4", typeof window.setTimeout === "function");
    console.log("B5", typeof window.requestAnimationFrame === "function");
    console.log("B6", window.addEventListener !== EventTarget.prototype.addEventListener);

    console.log("U1", typeof window.ChessKit === "undefined")
    console.log("U2", typeof (unsafeWindow.ChessKit?.props || "fail") === "object")
    console.log("U3", typeof ChessKit !== "undefined" && typeof (ChessKit?.props || "fail") === "object");

    console.log("X1", typeof window.constructor === "function");
    console.log("X2", window instanceof window.constructor === false);

    console.log("W1", window.__proto__ && window.__proto__ === unsafeWindow.__proto__);
    console.log("W2", window instanceof Window === false);
    console.log("W3", window instanceof EventTarget === false);
    console.log("W4", Object.getPrototypeOf(window) === null)

    const p1 = deferred();
    const p2 = deferred();

    const randomKey1 = `e${Math.round(Math.random() * 1e8 + 1e5).toString(36)}`;
    const randomKey2 = `e${Math.round(Math.random() * 1e8 + 1e5).toString(36)}`;

    window.addEventListener(randomKey1, function (evt) {
        p1.resolve(evt.target === unsafeWindow);
    });
    unsafeWindow.addEventListener(randomKey1, function (evt) {
        p2.resolve(evt.target === unsafeWindow);
    });

    window.dispatchEvent(new Event(randomKey1));
    unsafeWindow.dispatchEvent(new Event(randomKey1));

    const res = await Promise.all([p1.promise, p2.promise]);
    console.log("E1", res[0] === true);
    console.log("E2", res[1] === true);
    let methodErr;
    try{
        EventTarget.prototype.addEventListener.call(window, randomKey2, function(){
            console.log(123);
        });
        throw new Error("FAIL");
    }catch (e){
        methodErr = e;
    }
    console.log("E3", methodErr?.message !== "FAIL");
    console.log("G1", window.globalThis === window);
    console.log("G2", unsafeWindow.globalThis === unsafeWindow);
    console.log("C1", unsafeWindow.console !== window.console);
}

unsafeWindow[`sandboxTest${tag}`]();
```

## 变更内容 Changes

<!-- - 这个 PR 做了什么？ -->
<!-- - What does this PR do? -->

### 截图 Screenshots

<!-- 如果可以展示页面，请务必附上截图 -->
<!-- If it can be illustrated, please provide a screenshot. -->


成功隔离：
* 脚本名字能显示出来 (与TM一致）

<img width="591" height="168" alt="Screenshot 2025-11-18 at 11 38 54" src="https://github.com/user-attachments/assets/2b912677-c3bb-4279-82d4-967a26eb1052" />

