### PR TITLE
fix: 修正`AppContext`错误引用`"monaco-editor"`

### DIFF
--- a/src/pages/components/CodeEditor/index.tsx
+++ b/src/pages/components/CodeEditor/index.tsx
@@ -2,6 +2,9 @@ import { editor, Range } from "monaco-editor";
 import React, { useEffect, useImperativeHandle, useRef, useState } from "react";
 import { globalCache, systemConfig } from "@App/pages/store/global";
 import { LinterWorker } from "@App/pkg/utils/monaco-editor";
+import { fnPlaceHolder } from "@App/pages/store/AppContext";
+
+fnPlaceHolder.setEditorTheme = (theme: string) => editor.setTheme(theme);
 
 type Props = {
   className?: string;

--- a/src/pages/store/AppContext.tsx
+++ b/src/pages/store/AppContext.tsx
@@ -1,9 +1,12 @@
 import React, { useState, createContext, type ReactNode, useEffect, useContext } from "react";
 import { messageQueue } from "./global";
-import { editor } from "monaco-editor";
 import { type TKeyValue } from "@Packages/message/message_queue";
 import { changeLanguage } from "@App/locales/locales";
 import { SystemConfigChange } from "@App/pkg/config/config";
+
+export const fnPlaceHolder = {
+  setEditorTheme: null,
+} as { setEditorTheme: ((theme: string) => void) | null };
 
 export type ThemeParam = { theme: "auto" | "light" | "dark" };
 export interface AppContextType {
@@ -49,12 +52,12 @@ const setAppColorTheme = (theme: "light" | "dark" | "auto") => {
     case "dark":
       document.documentElement.classList.add("dark");
       document.body.setAttribute("arco-theme", "dark");
-      editor.setTheme("vs-dark");
+      fnPlaceHolder.setEditorTheme?.("vs-dark");
       break;
     case "light":
       document.documentElement.classList.remove("dark");
       document.body.removeAttribute("arco-theme");
-      editor.setTheme("vs");
+      fnPlaceHolder.setEditorTheme?.("vs");
       break;
   }
 };


### PR DESCRIPTION
## 概述 Descriptions

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- Describe related issue(s) if any. -->
<!-- close #xxx -->

Popup页面 不需要 `"monaco-editor"`

## 变更内容 Changes

<!-- - 这个 PR 做了什么？ -->
<!-- - What does this PR do? -->

### 截图 Screenshots

<!-- 如果可以展示页面，请务必附上截图 -->
<!-- If it can be illustrated, please provide a screenshot. -->
