### PR TITLE
[MV2] 修改 dealScript 处理，不需使用RegExp，让浏览器自行判断特殊字符转换

### DIFF
--- a/src/pkg/utils/utils.ts
+++ b/src/pkg/utils/utils.ts
@@ -17,14 +17,11 @@ export function randomString(e: number) {
   return n;
 }
 
-export function dealSymbol(source: string): string {
-  source = source.replace(/("|\\)/g, "\\$1");
-  source = source.replace(/(\r\n|\n)/g, "\\n");
-  return source;
-}
-
 export function dealScript(source: string): string {
-  return dealSymbol(source);
+  // 双引号会加quote. 其他特殊字符也会转换一下。然后整个文字加双引号表示字串
+  // 例子 `This is a "Apple".\n123\n\r456` => `"This is a \\"Apple\\".\\n123\\n\\r456"`
+  // 兼容旧代码，头尾引号删去。
+  return JSON.stringify(source).slice(1, -1);
 }
 
 export function isFirefox(): boolean {


### PR DESCRIPTION
## 概述 Descriptions

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- Describe related issue(s) if any. -->
<!-- close #xxx -->

现时 dealScript 只针对引号和换行符
但实际转换不应如此

实际应用
```ts
            chrome.tabs.executeScript(sender.tabId!, {
              frameId: sender.frameId,
              code: `(function(){
                let temp = document.createElementNS("http://www.w3.org/1999/xhtml", "script");
                    temp.setAttribute('type', 'text/javascript');
                    temp.setAttribute('charset', 'UTF-8');
                    temp.textContent = "${script.code}";
                    temp.className = "injected-js";
                    document.documentElement.appendChild(temp);
                    temp.remove();
                }())`,
              runAt,
            });
```

改用原生方法 JSON.parse(string)，浏览器内部API 自行判断如何「字串化」

例子 `This is a "Apple".\n123\n\r456` => `"This is a \\"Apple\\".\\n123\\n\\r456"`

[surrogates 也会编码成 `"\\uxxxx"`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#well-formed_json.stringify)


## 变更内容 Changes

<!-- - 这个 PR 做了什么？ -->
<!-- - What does this PR do? -->

### 截图 Screenshots

<!-- 如果可以展示页面，请务必附上截图 -->
<!-- If it can be illustrated, please provide a screenshot. -->
