### PR TITLE
[MV2] gecko `browser_specific_settings` 加入 `data_collection_permissions`

### DIFF
--- a/build/pack.js
+++ b/build/pack.js
@@ -73,6 +73,15 @@ firefoxManifest.browser_specific_settings = {
         : "8e515334-52b5-4cc5-b4e8-675d50af677d"
     }}`,
     strict_min_version: "91.1.0",
+    data_collection_permissions:  {
+      "required": [
+        "none" // 没有必须传送至第三方的资料。安装转页没有记录用户何时何地安装了什么。
+      ],
+      "optional": [
+        "authenticationInfo", // 使用 Cloud Backup / Import 时，有传送用户的资料至第三方作登入验证
+        "personallyIdentifyingInfo" // 使用 电邮 或 帐密 让第三方识别个人身份进行 Cloud Backup / Import
+      ]
+    }
   },
 };
 


### PR DESCRIPTION
## 概述 Descriptions

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- Describe related issue(s) if any. -->
<!-- close #xxx -->

<img width="629" height="217" alt="Screenshot 2025-11-21 at 20 28 40" src="https://github.com/user-attachments/assets/0615defb-4b4e-4c79-b0ee-224ed6f6cc82" />


The "data_collection_permissions" property is missing.

Warning: "/browser_specific_settings/gecko/data_collection_permissions" property will be required in the future. Please add this key to the manifest. More information at: https://mzl.la/firefox-builtin-data-consent
  




https://blog.mozilla.org/addons/2025/10/23/data-collection-consent-changes-for-new-firefox-extensions/


<img width="861" height="643" alt="Screenshot 2025-11-21 at 20 31 12" src="https://github.com/user-attachments/assets/6176493e-aae2-4966-9265-b135874cd4d0" />


https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/



----

For a userscript manager (like Violentmonkey / Tampermonkey / Firemonkey / ScriptCat-style extensions), what you declare in the new Firefox *built-in consent* system depends entirely on what **your extension itself** sends out over the network – *not* what arbitrary user scripts might do on their own.

1. **Do we send anything to our own (or third-party) servers, besides normal permission-driven HTTP requests directly made by pages or scripts at user direction?**

   * **No →** use `required: ["none"]`.
2. **Do we send crash reports, anonymous usage metrics, or environment info?**

   * **Yes →** add `technicalAndInteraction` to `optional`.
3. **Do we have sign-in / account features, or otherwise store user identifiers?**

   * **Yes →** likely add `authenticationInfo` (and possibly `personallyIdentifyingInfo`) to `required` or `optional` depending on whether the feature is mandatory.
4. **Do we collect any data that reveals browsing behavior tied to a person/account?**

   * **Yes →** treat as `personallyIdentifyingInfo` at least.

----


## 变更内容 Changes

<!-- - 这个 PR 做了什么？ -->
<!-- - What does this PR do? -->


```

    data_collection_permissions:  {
      "required": [
        "none" // 没有必须传送至第三方的资料。安装转页没有记录用户何时何地安装了什么。
      ],
      "optional": [
        "authenticationInfo", // 使用 Cloud Backup / Import 时，有传送用户的资料至第三方作登入验证
        "personallyIdentifyingInfo" // 使用 电邮 或 帐密 让第三方识别个人身份进行 Cloud Backup / Import
      ]
    }
```

### 截图 Screenshots

<!-- 如果可以展示页面，请务必附上截图 -->
<!-- If it can be illustrated, please provide a screenshot. -->
