### PR TITLE
fix(ui): 使用 autoFocus 避免 `.focus()` 对动态生成的 input 呼叫失败

### DIFF
--- a/src/pages/options/routes/script/ScriptEditor.tsx
+++ b/src/pages/options/routes/script/ScriptEditor.tsx
@@ -889,12 +889,6 @@ function ScriptEditor() {
                 }}
                 onClick={() => {
                   setShowSearchInput(!showSearchInput);
-                  setTimeout(
-                    () =>
-                      showSearchInput &&
-                      (document.querySelector("#editor_search_scripts_input") as HTMLInputElement)?.focus(),
-                    1
-                  );
                 }}
               >
                 <div className="flex justify-between items-center">
@@ -911,7 +905,8 @@ function ScriptEditor() {
                   <Input
                     placeholder={t("search_scripts")}
                     allowClear
-                    value={searchKeyword}
+                    autoFocus
+                    defaultValue={searchKeyword}
                     onChange={(value) => setSearchKeyword(value)}
                     size="mini"
                     id="editor_search_scripts_input"


### PR DESCRIPTION
## 概述 Descriptions

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- Describe related issue(s) if any. -->
<!-- close #xxx -->


## 变更内容 Changes

<!-- - 这个 PR 做了什么？ -->
<!-- - What does this PR do? -->


1） autoFocus
2）defaultValue （React 不是 Vue 的 two-way binding 问题不重复说明）

### 截图 Screenshots

<!-- 如果可以展示页面，请务必附上截图 -->
<!-- If it can be illustrated, please provide a screenshot. -->
