### PR TITLE
修正 getISOWeek

### DIFF
--- a/src/app/service/sandbox/runtime.ts
+++ b/src/app/service/sandbox/runtime.ts
@@ -281,12 +281,18 @@ export class Runtime {
   // 2009 年第 53 周： 2009/12/28 (Mon) - 2010/01/03 (Sun)
   // 2010 年第 52 周： 2010/12/27 (Mon) - 2011/01/02 (Sun)
   getISOWeek(date: Date): number {
-    const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate())); // remove the time
-    // Set to nearest Thursday: current date + 4 - current day number (Monday = 1)
+    // 使用传入日期的年月日创建 UTC 日期对象，忽略本地时间部分，避免时区影响
+    const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+
+    // 将日期调整到本周的星期四（ISO 8601 规定：周数以星期四所在周为准）
+    // 计算方式：当前日期 + 4 − 当前星期几（星期一 = 1，星期日 = 7）
     d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
-    // Get first day of year
+
+    // 获取该星期四所在年份的第一天（UTC）
     const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-    // Calculate full weeks to nearest Thursday
+
+    // 计算从年初到该星期四的天数差
+    // 再换算为周数，并向上取整，得到 ISO 周数
     return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
   }
 


### PR DESCRIPTION
## 概述 Descriptions

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- Describe related issue(s) if any. -->
<!-- close #xxx -->

1. 现在的 getWeek 不符合 ISO 8601
2. 现在的代码会导致年末周判断出错


<img width="222" height="102" alt="Screenshot 2026-01-02 at 17 43 01" src="https://github.com/user-attachments/assets/7e5487ff-6648-4abd-a111-ef8fe45b2a57" />

2004/12/31 是新一周，定时脚本执行了一次
2005/1/1 又是新一周，定时脚本又执行了一次

这里用符合  ISO 8601 的 getISOWeek 就能确保每7天都是执行一次，不会受到年尾日子影响。


https://zh.wikipedia.org/wiki/ISO%E9%80%B1%E6%97%A5%E6%9B%86

<img width="505" height="231" alt="Screenshot 2026-01-02 at 18 03 40" src="https://github.com/user-attachments/assets/a282e040-0669-49ab-8363-9ac7b776d0b8" />




## 变更内容 Changes

<!-- - 这个 PR 做了什么？ -->
<!-- - What does this PR do? -->

### 截图 Screenshots

<!-- 如果可以展示页面，请务必附上截图 -->
<!-- If it can be illustrated, please provide a screenshot. -->


## 打印測試

```js


const getWeek = (date) => {
    // 使用传入日期的年月日创建 UTC 日期对象，忽略本地时间部分，避免时区影响
    const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));

    // 将日期调整到本周的星期四（ISO 8601 规定：周数以星期四所在周为准）
    // 计算方式：当前日期 + 4 − 当前星期几（星期一 = 1，星期日 = 7）
    d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));

    // 获取该星期四所在年份的第一天（UTC）
    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));

    // 计算从年初到该星期四的天数差
    // 再换算为周数，并向上取整，得到 ISO 周数
    return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
}



for (let year = 2004; year <= 2010; year++) {
  console.log(` ==== ${year} ==== `)
  let date0 = new Date(`${year}/12/22`).getTime();
  for (let i = 0; i < 14; i++) {
    const q = new Date(date0 + i * 24 * 60 * 60 * 1000);
    const m = q.toLocaleString("en-US", { month: "short", day: "2-digit", weekday: "short", year: "numeric" });
    console.log(m, getWeek(q));

  }
}
```



<img width="433" height="727" alt="Screenshot 2026-01-02 at 18 03 19" src="https://github.com/user-attachments/assets/81c87081-843f-4470-ace9-dad4790e18e1" />

