### PR TITLE
Fix #1151: 修正按钮渲染逻辑，避免 render 阶段副作用，改用 JSX 条件渲染 & named slot

### DIFF
--- a/src/pages/components/FileSystemParams/index.tsx
+++ b/src/pages/components/FileSystemParams/index.tsx
@@ -9,14 +9,14 @@ const FileSystemParams: React.FC<{
   headerContent: React.ReactNode | string;
   onChangeFileSystemType: (type: FileSystemType) => void;
   onChangeFileSystemParams: (params: any) => void;
-  actions: React.ReactNode;
+  children: React.ReactNode;
   fileSystemType: FileSystemType;
   fileSystemParams: any;
 }> = ({
   onChangeFileSystemType,
   onChangeFileSystemParams,
   headerContent,
-  actions,
+  children,
   fileSystemType,
   fileSystemParams,
 }) => {
@@ -69,7 +69,7 @@ const FileSystemParams: React.FC<{
             </Select.Option>
           ))}
         </Select>
-        {actions}
+        {children}
         {netDiskType && netDiskName && (
           <Popconfirm
             key="netdisk-unbind"

--- a/src/pages/components/RuntimeSetting/index.tsx
+++ b/src/pages/components/RuntimeSetting/index.tsx
@@ -88,65 +88,6 @@ const RuntimeSetting: React.FC = () => {
                     {t("use_file_system")}
                   </Typography.Text>
                 }
-                actions={
-                  <>
-                    <Button
-                      key="save"
-                      type="primary"
-                      onClick={async () => {
-                        try {
-                          await FileSystemFactory.create(fileSystemType, fileSystemParams);
-                        } catch (e) {
-                          Message.error(`${t("account_validation_failed")}: ${e}`);
-                          return;
-                        }
-                        const params = { ...fileSystemParams };
-                        params[fileSystemType] = fileSystemParams;
-                        systemConfig.setCatFileStorage({
-                          status: "success",
-                          filesystem: fileSystemType,
-                          params,
-                        });
-                        setStatus("success");
-                        Message.success(t("save_success")!);
-                      }}
-                    >
-                      {t("save")}
-                    </Button>
-                    <Button
-                      key="reset"
-                      onClick={() => {
-                        systemConfig.setCatFileStorage({
-                          status: "unset",
-                          filesystem: "webdav",
-                          params: {},
-                        });
-                        setStatus("unset");
-                        setFilesystemParam({});
-                        setFilesystemType("webdav");
-                      }}
-                      type="primary"
-                      status="danger"
-                    >
-                      {t("reset")}
-                    </Button>
-                    <Button
-                      key="open"
-                      type="secondary"
-                      onClick={async () => {
-                        try {
-                          let fs = await FileSystemFactory.create(fileSystemType, fileSystemParams);
-                          fs = await fs.openDir("ScriptCat/app");
-                          window.open(await fs.getDirUrl(), "_black");
-                        } catch (e) {
-                          Message.error(`${t("account_validation_failed")}: ${e}`);
-                        }
-                      }}
-                    >
-                      {t("open_directory")}
-                    </Button>
-                  </>
-                }
                 fileSystemType={fileSystemType}
                 fileSystemParams={fileSystemParams}
                 onChangeFileSystemType={(type) => {
@@ -155,7 +96,63 @@ const RuntimeSetting: React.FC = () => {
                 onChangeFileSystemParams={(params) => {
                   setFilesystemParam(params);
                 }}
-              />
+              >
+                <Button
+                  key="save"
+                  type="primary"
+                  onClick={async () => {
+                    try {
+                      await FileSystemFactory.create(fileSystemType, fileSystemParams);
+                    } catch (e) {
+                      Message.error(`${t("account_validation_failed")}: ${e}`);
+                      return;
+                    }
+                    const params = { ...fileSystemParams };
+                    params[fileSystemType] = fileSystemParams;
+                    systemConfig.setCatFileStorage({
+                      status: "success",
+                      filesystem: fileSystemType,
+                      params,
+                    });
+                    setStatus("success");
+                    Message.success(t("save_success")!);
+                  }}
+                >
+                  {t("save")}
+                </Button>
+                <Button
+                  key="reset"
+                  onClick={() => {
+                    systemConfig.setCatFileStorage({
+                      status: "unset",
+                      filesystem: "webdav",
+                      params: {},
+                    });
+                    setStatus("unset");
+                    setFilesystemParam({});
+                    setFilesystemType("webdav");
+                  }}
+                  type="primary"
+                  status="danger"
+                >
+                  {t("reset")}
+                </Button>
+                <Button
+                  key="open"
+                  type="secondary"
+                  onClick={async () => {
+                    try {
+                      let fs = await FileSystemFactory.create(fileSystemType, fileSystemParams);
+                      fs = await fs.openDir("ScriptCat/app");
+                      window.open(await fs.getDirUrl(), "_black");
+                    } catch (e) {
+                      Message.error(`${t("account_validation_failed")}: ${e}`);
+                    }
+                  }}
+                >
+                  {t("open_directory")}
+                </Button>
+              </FileSystemParams>
               {status === "unset" && <Typography.Text type="secondary">{t("not_set")}</Typography.Text>}
               {status === "success" && <Typography.Text type="success">{t("in_use")}</Typography.Text>}
               {status === "error" && <Typography.Text type="error">{t("storage_error")}</Typography.Text>}

--- a/src/pages/options/routes/Setting.tsx
+++ b/src/pages/options/routes/Setting.tsx
@@ -178,31 +178,6 @@ function Setting() {
                 {t("enable_script_sync_to")}
               </Checkbox>
             }
-            actions={
-              <>
-                <Button
-                  key="save"
-                  type="primary"
-                  onClick={async () => {
-                    // Save to the configuration
-                    // Perform validation if enabled
-                    if (cloudSync.enable) {
-                      Message.info(t("cloud_sync_account_verification")!);
-                      try {
-                        await FileSystemFactory.create(cloudSync.filesystem, cloudSync.params[cloudSync.filesystem]);
-                      } catch (e) {
-                        Message.error(`${t("cloud_sync_verification_failed")}: ${JSON.stringify(Logger.E(e))}`);
-                        return;
-                      }
-                    }
-                    submitCloudSync();
-                    Message.success(t("save_success")!);
-                  }}
-                >
-                  {t("save")}
-                </Button>
-              </>
-            }
             fileSystemType={cloudSync.filesystem}
             fileSystemParams={cloudSync.params[cloudSync.filesystem] || {}}
             onChangeFileSystemType={(type) => {
@@ -214,7 +189,29 @@ function Setting() {
                 params: { ...cloudSync.params, [cloudSync.filesystem]: params },
               }));
             }}
-          />
+          >
+            <Button
+              key="save"
+              type="primary"
+              onClick={async () => {
+                // Save to the configuration
+                // Perform validation if enabled
+                if (cloudSync.enable) {
+                  Message.info(t("cloud_sync_account_verification")!);
+                  try {
+                    await FileSystemFactory.create(cloudSync.filesystem, cloudSync.params[cloudSync.filesystem]);
+                  } catch (e) {
+                    Message.error(`${t("cloud_sync_verification_failed")}: ${JSON.stringify(Logger.E(e))}`);
+                    return;
+                  }
+                }
+                submitCloudSync();
+                Message.success(t("save_success")!);
+              }}
+            >
+              {t("save")}
+            </Button>
+          </FileSystemParams>
         </Space>
       </Card>
 

--- a/src/pages/options/routes/Tools.tsx
+++ b/src/pages/options/routes/Tools.tsx
@@ -100,63 +100,60 @@ function Tools() {
               onChangeFileSystemParams={(params) => {
                 setBackup({ ...backup, params: { ...backup.params, [backup.filesystem]: params } });
               }}
-              actions={
-                <>
-                  <Button
-                    key="backup"
-                    type="primary"
-                    loading={loading.cloud}
-                    onClick={() => {
-                      // Store parameters
-                      submitBackup();
-                      setLoading((prev) => ({ ...prev, cloud: true }));
-                      Message.info(t("preparing_backup")!);
-                      synchronizeClient
-                        .backupToCloud(backup.filesystem, backup.params[backup.filesystem])
-                        .then(() => {
-                          Message.success(t("backup_success")!);
-                        })
-                        .catch((e) => {
-                          Message.error(`${t("backup_failed")}: ${e}`);
-                        })
-                        .finally(() => {
-                          setLoading((prev) => ({ ...prev, cloud: false }));
-                        });
-                    }}
-                  >
-                    {t("backup")}
-                  </Button>
-                  <Button
-                    key="list"
-                    type="primary"
-                    loading={loading.cloud}
-                    onClick={async () => {
-                      setLoading((prev) => ({ ...prev, cloud: true }));
-                      try {
-                        let fs = await FileSystemFactory.create(backup.filesystem, backup.params[backup.filesystem]);
-                        fs = await fs.openDir("ScriptCat");
-                        let list = await fs.list();
-                        list.sort((a, b) => b.updatetime - a.updatetime);
-                        // Filter non-zip files
-                        list = list.filter((file) => file.name.endsWith(".zip"));
-                        if (list.length === 0) {
-                          Message.info(t("no_backup_files")!);
-                        } else {
-                          setBackupFileList(list);
-                        }
-                      } catch (e) {
-                        Message.error(`${t("get_backup_files_failed")}: ${e}`);
-                      }
-                      setLoading((prev) => ({ ...prev, cloud: false }));
-                    }}
-                  >
-                    {t("backup_list")}
-                  </Button>
-                </>
-              }
               fileSystemType={backup.filesystem}
               fileSystemParams={backup.params[backup.filesystem] || {}}
-            />
+            >
+              <Button
+                key="backup"
+                type="primary"
+                loading={loading.cloud}
+                onClick={() => {
+                  // Store parameters
+                  submitBackup();
+                  setLoading((prev) => ({ ...prev, cloud: true }));
+                  Message.info(t("preparing_backup")!);
+                  synchronizeClient
+                    .backupToCloud(backup.filesystem, backup.params[backup.filesystem])
+                    .then(() => {
+                      Message.success(t("backup_success")!);
+                    })
+                    .catch((e) => {
+                      Message.error(`${t("backup_failed")}: ${e}`);
+                    })
+                    .finally(() => {
+                      setLoading((prev) => ({ ...prev, cloud: false }));
+                    });
+                }}
+              >
+                {t("backup")}
+              </Button>
+              <Button
+                key="list"
+                type="primary"
+                loading={loading.cloud}
+                onClick={async () => {
+                  setLoading((prev) => ({ ...prev, cloud: true }));
+                  try {
+                    let fs = await FileSystemFactory.create(backup.filesystem, backup.params[backup.filesystem]);
+                    fs = await fs.openDir("ScriptCat");
+                    let list = await fs.list();
+                    list.sort((a, b) => b.updatetime - a.updatetime);
+                    // Filter non-zip files
+                    list = list.filter((file) => file.name.endsWith(".zip"));
+                    if (list.length === 0) {
+                      Message.info(t("no_backup_files")!);
+                    } else {
+                      setBackupFileList(list);
+                    }
+                  } catch (e) {
+                    Message.error(`${t("get_backup_files_failed")}: ${e}`);
+                  }
+                  setLoading((prev) => ({ ...prev, cloud: false }));
+                }}
+              >
+                {t("backup_list")}
+              </Button>
+            </FileSystemParams>
             <Drawer
               width={400}
               title={


### PR DESCRIPTION
## 概述 Descriptions

<!-- 如果有关联的 issue，请在下面记载 -->
<!-- Describe related issue(s) if any. -->
<!-- close #xxx -->

@CodFrm  以后AI做出来的PR 只会愈来愈多。Copliot找到的问题麻烦认真看待一下。
Codex在React元件定义里把state 做浅拷贝 再插React元件。。。太可怕了

## 变更内容 Changes

<!-- - 这个 PR 做了什么？ -->
<!-- - What does this PR do? -->

### 截图 Screenshots

<!-- 如果可以展示页面，请务必附上截图 -->
<!-- If it can be illustrated, please provide a screenshot. -->


---


## 为什么要做这个改动（背景）

在 React 中，**render 阶段不应该产生副作用，也不应该修改已有的 state 或 props**。
旧实现中，在函数组件的 render 过程中，通过 `push` 的方式向按钮数组中追加元素，这属于 **在 render 阶段修改数组引用的副作用行为**。

虽然目前代码仍然可以正常运行，但在以下场景中可能会产生问题：

* React **Strict Mode** 下 render 可能被执行两次，导致重复 push
* **Concurrent Rendering** 场景中行为不可预测
* 破坏 React 的 **声明式渲染模型**
* 增加潜在的渲染 Bug 和维护成本

因此，有必要对这部分代码进行重构优化。


## 这个 PR 做了什么改动

### ❌ 旧实现方式（不推荐）

在 render 阶段对数组进行操作，根据条件 `push` 新按钮：

```tsx
const actionButtons = [...baseButtons];
if (netDiskType) {
  actionButtons.push(<Popconfirm ... />);
}
```

问题在于：

* render 阶段产生副作用
* 修改了数组结构
* 逻辑分散，不直观


### ✅ 新实现方式（推荐）

将按钮是否显示的逻辑**直接写在 JSX 中，通过条件渲染控制**：

```tsx
<>
  {baseButtons}
  {netDiskType && netDiskName && (
    <Popconfirm ... />
  )}
</>
```

这样做的好处是：

* 不再修改任何传入的数组或 props
* 渲染逻辑一目了然
* 完全符合 React 的声明式写法


## 这次改动带来的价值

1. **避免 render 阶段的副作用**

   * 不再使用 `push`、mutation 等操作
   * 更安全，符合 React 官方推荐实践

2. **逻辑更清晰、语义更直观**

   * “什么时候显示解除绑定按钮”在 JSX 中一眼可见
   * 不需要追踪数组是如何被修改的

3. **减少潜在 Bug**

   * 避免 Strict Mode 下的重复渲染问题
   * 对未来 Concurrent Rendering 更友好

4. **更容易维护和调试**

   * JSX 即最终渲染结果
   * 按钮之间是明确的“兄弟关系”，而不是被动插入

## 总结

这次 PR 的核心思想是：

> **从「命令式、在 render 中修改数据结构」
> 转变为「声明式、在 JSX 中条件渲染 UI」**

这是一个改动不大、但**代码质量明显提升**的重构：

* 风格更现代
* 可读性更好
* 潜在问题更少
* 更符合 React 在函数组件与 Hooks 时代的最佳实践

属于一次**低风险、高收益的质量优化改动**。
