### PR TITLE
fix install url #1235

### DIFF
--- a/src/pages/install/App.tsx
+++ b/src/pages/install/App.tsx
@@ -656,7 +656,8 @@ function App() {
     if (searchParamUrl) {
       try {
         // 取url=之后的所有内容
-        const rawUrl = location.search.match(/\?url=(.+)/)?.[1] || searchParamUrl;
+        const idx = location.search.indexOf("url=");
+        const rawUrl = idx !== -1 ? location.search.slice(idx + 4) : searchParamUrl;
         const urlObject = new URL(rawUrl);
         // 验证解析后的 URL 是否具备核心要素，确保安全性与合法性
         if (urlObject.protocol && urlObject.hostname && urlObject.pathname) {


### PR DESCRIPTION
如果用户是从 GreasyFork ScriptCat 以外的地方取得脚本
例如下载网址
可能需要包含 & 后完整的网址
（注释本身也是写 `取url=之后的所有内容`)

示范用例子 （我手上没有这类网址作正式展示）
https://github.com/diegovdev/moodle-save-all-resources/raw/refs/heads/master/moodle-save-all-resources.user.js?lang=ja&region=jp



<img width="917" height="211" alt="Screenshot 2026-02-16 at 10 16 26" src="https://github.com/user-attachments/assets/2c617cd4-e1b6-4073-aba4-6b11170c12e0" />
