### PR TITLE
修复弹出内容跟随屏幕滚动的问题 - v2

### DIFF
--- a/src/pages/components/layout/MainLayout.tsx
+++ b/src/pages/components/layout/MainLayout.tsx
@@ -303,9 +303,9 @@ const MainLayout: React.FC<{
       }}
       getPopupContainer={(node) => {
         let p = node.parentNode as Element;
-        p = p.closest("button")?.parentNode as Element || p; // 確保 ancestor 沒有 button 元素
-        p = p.closest("span")?.parentNode as Element || p; // 確保 ancestor 沒有 span 元素
-        p = p.closest("aside")?.parentNode as Element || p; // 確保 ancestor 沒有 aside 元素
+        p = (p.closest("button")?.parentNode as Element) || p; // 確保 ancestor 沒有 button 元素
+        p = (p.closest("span")?.parentNode as Element) || p; // 確保 ancestor 沒有 span 元素
+        p = (p.closest("aside")?.parentNode as Element) || p; // 確保 ancestor 沒有 aside 元素
         return p;
       }}
     >


### PR DESCRIPTION
#1256 
#1259 

## inline 系 - button, span

### Before

<img width="119" height="96" alt="Screenshot 2026-02-17 at 8 05 18" src="https://github.com/user-attachments/assets/b682ca0a-a5da-4eee-ae2e-d444598e6e2a" />

<img width="71" height="111" alt="Screenshot 2026-02-17 at 8 49 28" src="https://github.com/user-attachments/assets/abac52d0-20d2-4527-a1d7-8f5c23532a21" />

### After

<img width="454" height="99" alt="Screenshot 2026-02-17 at 8 55 12" src="https://github.com/user-attachments/assets/53f5c393-9064-4584-a998-c97097854448" />

<img width="148" height="105" alt="Screenshot 2026-02-17 at 8 53 05" src="https://github.com/user-attachments/assets/6f1acf1e-e733-407b-9c86-41fe92cf57db" />



## aside （座标抽离）


### Before


<img width="245" height="310" alt="Screenshot 2026-02-17 at 8 14 17" src="https://github.com/user-attachments/assets/5370c63e-3451-4a66-b3ad-b7a9d3492af7" />

### After

<img width="222" height="216" alt="Screenshot 2026-02-17 at 8 54 11" src="https://github.com/user-attachments/assets/11765701-80a5-43ba-ba19-7b82fe2fbaf4" />



---

这个改动确保 getPopupContainer 不会被 button / span / aside 包住