### PR TITLE
[v1.4] 新增批次检查脚本的 timeout, 避免一个脚本更新时间太长导致所有脚本检查失败

### DIFF
--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -10,7 +10,6 @@ import {
   getBrowserType,
   getStorageName,
   openInCurrentTab,
-  sleep,
   stringMatching,
 } from "@App/pkg/utils/utils";
 import { ltever } from "@App/pkg/utils/semver";
@@ -773,6 +772,8 @@ export class ScriptService {
         setTimeout(resolve, Math.round(MIN_DELAY + ((++i / n + Math.random()) / 2) * (MAX_DELAY - MIN_DELAY)))
       );
 
+    const CHECK_UPDATE_TIMEOUT_MS = 300_000; // 5 分钟超时
+
     const results = new Map<
       string,
       | false
@@ -783,21 +784,37 @@ export class ScriptService {
         }
     >();
 
+    // 预初始化 Map 确保顺序
+    for (const uuid of uuids as string[]) {
+      results.set(uuid, false);
+    }
+
+    const abortController = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const timeoutPromise = new Promise<void>((resolve) => {
+      timeoutId = setTimeout(() => {
+        abortController.abort();
+        resolve();
+      }, CHECK_UPDATE_TIMEOUT_MS);
+    });
+
     await Promise.race([
-      sleep(300_000), // 5 minutes
+      timeoutPromise,
       Promise.allSettled(
         (uuids as string[]).map(async (uuid, _idx) => {
-          results.set(uuid, false); // 確保次序
           const script = scripts[_idx];
           const res =
             !script || script.uuid !== uuid || !checkScripts.includes(script)
               ? false
-              : await this._checkUpdateAvailable(script, delayFn);
+              : await this._checkUpdateAvailable(script, delayFn, abortController.signal);
           if (!res) return false;
           results.set(uuid, res);
           return res;
         })
-      ),
+      ).finally(() => {
+        clearTimeout(timeoutId);
+      }),
     ]);
     return [...results.values()];
   }
@@ -809,7 +826,8 @@ export class ScriptService {
       checkUpdateUrl?: string;
       metadata: Partial<Record<string, any>>;
     },
-    delayFn?: () => Promise<any>
+    delayFn?: () => Promise<any>,
+    signal?: AbortSignal
   ): Promise<false | { updateAvailable: true; code: string; metadata: SCMetadata }> {
     const { uuid, name, checkUpdateUrl } = script;
 
@@ -821,8 +839,12 @@ export class ScriptService {
       name,
     });
     try {
-      if (delayFn) await delayFn();
-      const code = await fetchScriptBody(checkUpdateUrl);
+      if (delayFn) {
+        if (signal?.aborted) return false;
+        await delayFn();
+      }
+      if (signal?.aborted) return false;
+      const code = await fetchScriptBody(checkUpdateUrl, signal);
       const metadata = parseMetadata(code);
       if (!metadata) {
         logger.error("parse metadata failed");

--- a/src/pkg/utils/script.ts
+++ b/src/pkg/utils/script.ts
@@ -46,8 +46,9 @@ export function parseMetadata(code: string): SCMetadata | null {
 }
 
 // 从网址取得脚本代码
-export async function fetchScriptBody(url: string): Promise<string> {
+export async function fetchScriptBody(url: string, signal?: AbortSignal): Promise<string> {
   const resp = await fetch(url, {
+    signal,
     headers: {
       "Cache-Control": "no-cache",
     },


### PR DESCRIPTION
更新时间超过 5分钟会被视为更新检查失败，直接跳过显示
这种脚本必须在手动更新那边

不加的话，一个导致其他脚本的更新都不显示了