### PR TITLE
🐛 修复 ScriptEditor 脚本列表硬编码暗色背景

### DIFF
--- a/src/pages/options/routes/script/ScriptEditor.tsx
+++ b/src/pages/options/routes/script/ScriptEditor.tsx
@@ -930,7 +930,12 @@ function ScriptEditor() {
                           : editor.isChanged
                             ? "rgb(var(--warning-6))"
                             : "var(--color-text-2)",
-                        backgroundColor: selectedScript === script.uuid ? "var(--color-fill-2)" : "",
+                        backgroundColor:
+                          selectedScript === script.uuid
+                            ? "var(--editor-bg-selected)"
+                            : editor
+                              ? "var(--editor-bg-open)"
+                              : "var(--editor-bg-default)",
                         paddingRight: "32px", // 为删除按钮留出空间
                       }}
                       onClick={() => {

--- a/src/pages/options/routes/script/index.css
+++ b/src/pages/options/routes/script/index.css
@@ -5,6 +5,19 @@
   white-space: nowrap;
 }
 
+/* ScriptEditor 脚本列表颜色变量 */
+body {
+  --editor-bg-selected: #D4D7DE;
+  --editor-bg-open: #EBEBEB;
+  --editor-bg-default: #F5F5F5;
+}
+
+body[arco-theme='dark'] {
+  --editor-bg-selected: #414958;
+  --editor-bg-open: #474747;
+  --editor-bg-default: #333333;
+}
+
 .script-code-editor {
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
## Summary
- #1258 中引入了硬编码的暗色 hex 值（`#414958`/`#474747`/`#333333`）和 RGB 文字颜色，导致脚本列表在亮色模式下也显示为暗色背景
- 改用 Arco Design CSS 变量（`--color-fill-2`, `--color-text-2`, `--color-text-3`, `--warning-6`），使脚本列表在亮色/暗色模式下都能正确显示
- 用 `opacity` 替代手动计算 RGBA alpha，简化逻辑

## Test plan
- [ ] 亮色模式下打开脚本编辑器，确认脚本列表背景为正常亮色
- [ ] 暗色模式下打开脚本编辑器，确认脚本列表背景为正常暗色
- [ ] 选中脚本时背景高亮正确
- [ ] 已修改脚本显示黄色文字
- [ ] 禁用脚本显示半透明效果