### PR TITLE
修复运行日志页面日期选择弹出框被容器裁剪的问题

### DIFF
--- a/src/pages/components/layout/MainLayout.tsx
+++ b/src/pages/components/layout/MainLayout.tsx
@@ -123,6 +123,7 @@ const getSafePopupParent = (p: Element) => {
   p = (p.closest("button")?.parentNode as Element) || p; // 確保 ancestor 沒有 button 元素
   p = (p.closest("span")?.parentNode as Element) || p; // 確保 ancestor 沒有 span 元素
   p = (p.closest(".arco-collapse-item-content")?.parentNode as Element) || p; // 確保 ancestor 沒有 .arco-collapse-item-content 元素
+  p = (p.closest(".arco-card")?.parentNode as Element) || p; // 確保 ancestor 沒有 .arco-card 元素
   p = (p.closest("aside")?.parentNode as Element) || p; // 確保 ancestor 沒有 aside 元素
   return p;
 };

--- a/src/pages/options/routes/Logger.tsx
+++ b/src/pages/options/routes/Logger.tsx
@@ -133,7 +133,6 @@ function LoggerPage() {
                   style={{ width: 400 }}
                   showTime
                   shortcutsPlacementLeft
-                  getPopupContainer={() => document.body}
                   value={[startTime * 1000, endTime * 1000]}
                   onChange={(_, time) => {
                     setStartTime(time[0].unix());


### PR DESCRIPTION
之前 
https://github.com/scriptscat/scriptcat/pull/1290/commits/acaf1feab4a68c3747b1724a817eaf3d77f77779

的做法又是 会变成不跟随 scroll 移动

正确是 设置在 .arco-card 上一层