### PR TITLE
✨ 脚本列表最后更新列添加检查更新图标

### DIFF
--- a/src/pages/options/routes/ScriptList/components.tsx
+++ b/src/pages/options/routes/ScriptList/components.tsx
@@ -135,6 +135,7 @@ export const UpdateTimeCell = React.memo(({ className, script }: { className?: s
   const { t } = useTranslation();
   const [checking, setChecking] = React.useState(false);
   const handleClick = () => {
+    if (checking) return;
     if (!script.checkUpdateUrl) {
       Message.warning(t("update_not_supported")!);
       return;


### PR DESCRIPTION
## Summary
- 在脚本列表"最后更新"列的时间文本右侧添加了 `IconSync` 检查更新图标
- 仅当脚本有 `checkUpdateUrl` 时显示图标
- 图标默认半透明，hover 时高亮，检查中自动旋转，给用户明确的操作提示和加载反馈
- 时间文本的原有点击检查更新行为保持不变

closes #1143

## Test plan
- [ ] 在脚本列表中确认有 `checkUpdateUrl` 的脚本显示检查更新图标
- [ ] 确认没有 `checkUpdateUrl` 的脚本不显示图标
- [ ] 点击图标触发检查更新，图标旋转
- [ ] 检查完成后图标停止旋转
- [ ] hover 图标时透明度变化正常
- [ ] 点击时间文本仍可触发检查更新