### PR TITLE
ui: 正确显示格式化错误

### DIFF
--- a/packages/message/server.ts
+++ b/packages/message/server.ts
@@ -104,6 +104,19 @@ type ApiFunction = (params: any, con: IGetSender) => Promise<any> | any | void;
 type ApiFunctionSync = (params: any, con: IGetSender) => any;
 type MiddlewareFunction = (params: any, con: IGetSender, next: () => Promise<any> | any) => Promise<any> | any;
 
+const formatErrorToClient = (e: any) => {
+  if (!e) return `${e}`;
+  if (typeof e?.message === "string") return e.message;
+  if (typeof e === "object") {
+    try {
+      return JSON.stringify(e);
+    } catch {
+      // ignored
+    }
+  }
+  return e.toString();
+};
+
 export class Server {
   private apiFunctionMap: Map<string, ApiFunction> = new Map();
 
@@ -159,7 +172,7 @@ export class Server {
               data && con.sendMessage({ code: 0, data });
             })
             .catch((e: Error) => {
-              con.sendMessage({ code: -1, message: e.message || e.toString() });
+              con.sendMessage({ code: -1, message: formatErrorToClient(e) });
               this.logger.error("connectHandle error", Logger.E(e));
             });
           return true;
@@ -191,7 +204,7 @@ export class Server {
               }
             })
             .catch((e: Error) => {
-              sendResponse({ code: -1, message: e.message || e.toString() });
+              sendResponse({ code: -1, message: formatErrorToClient(e) });
               this.logger.error("messageHandle error", Logger.E(e));
             });
           return true;
@@ -199,7 +212,7 @@ export class Server {
           sendResponse({ code: 0, data: ret });
         }
       } catch (e: any) {
-        sendResponse({ code: -1, message: e.message || e.toString() });
+        sendResponse({ code: -1, message: formatErrorToClient(e) });
         this.logger.error("messageHandle error", Logger.E(e));
       }
     } else {


### PR DESCRIPTION
## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->
e 是物件。单纯 `.toString()` 会直接显示成 `[object Object]`

## Screenshots / 截图

<!-- Screenshots / 截图-->

在clean browser 安装scriptcat, 选 dropbox，点备份，然后关掉弹出的画面，返回ScriptCat页面

修正后显示 `{"error":{}}`

<img width="893" height="414" alt="Screenshot 2026-03-22 at 14 22 24" src="https://github.com/user-attachments/assets/ccf556af-4fd6-4195-bfe4-087b631dbfe9" />
