### PR TITLE
Editor: 修正 Ctrl-F Ctrl-H

### DIFF
--- a/src/pages/options/routes/script/ScriptEditor.tsx
+++ b/src/pages/options/routes/script/ScriptEditor.tsx
@@ -550,6 +550,7 @@ function ScriptEditor() {
         {
           id: "find",
           title: t("find"),
+          hotKey: KeyMod.CtrlCmd | KeyCode.KeyF,
           hotKeyString: "Ctrl+F",
           action(_script, e) {
             e.getAction("actions.find")?.run();
@@ -558,6 +559,7 @@ function ScriptEditor() {
         {
           id: "replace",
           title: t("replace"),
+          hotKey: KeyMod.CtrlCmd | KeyCode.KeyH,
           hotKeyString: "Ctrl+H",
           action(_script, e) {
             e.getAction("editor.action.startFindReplaceAction")?.run();


### PR DESCRIPTION
## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

`Ctrl-H` 在 macOS 是缩小视窗
针对特殊按键（Ctrl Z X C V A 以外）
应加入hotKey以确保 monaco 会执行 preventDefault

## Screenshots / 截图

<!-- Screenshots / 截图-->
