### PR TITLE
UserConfigPanel CSS 修正

### DIFF
--- a/src/pages/components/UserConfigPanel/index.css
+++ b/src/pages/components/UserConfigPanel/index.css
@@ -1,0 +1,12 @@
+.modal-config .arco-tabs {
+  position: static;
+}
+
+.modal-config .arco-tabs-pane {
+  max-height: calc(100vh - 400px);
+  overflow: auto;
+}
+
+.modal-config .arco-form-item:last-child {
+  margin-bottom: 0;
+}

--- a/src/pages/components/UserConfigPanel/index.tsx
+++ b/src/pages/components/UserConfigPanel/index.tsx
@@ -20,6 +20,7 @@ import { ValueClient } from "@App/app/service/service_worker/client";
 import { message } from "@App/pages/store/global";
 import type { TKeyValuePair } from "@App/pkg/utils/message_value";
 import { encodeRValue } from "@App/pkg/utils/message_value";
+import "./index.css";
 
 const FormItem = Form.Item;
 
@@ -52,6 +53,7 @@ const UserConfigPanel: React.FC<{
   return (
     <Modal
       visible={visible}
+      className={"modal-config"}
       title={`${script.name} ${t("config")}`} // 替换为键值对应的英文文本
       okText={<Popover content={t("save_only_current_group")}>{t("save")}</Popover>}
       cancelText={t("close")} // 替换为键值对应的英文文本

--- a/src/pages/components/layout/MainLayout.tsx
+++ b/src/pages/components/layout/MainLayout.tsx
@@ -122,6 +122,7 @@ const importByUrls = async (urls: string[]): Promise<TImportStat | undefined> =>
 const getSafePopupParent = (p: Element) => {
   p = (p.closest("button")?.parentNode as Element) || p; // 確保 ancestor 沒有 button 元素
   p = (p.closest("span")?.parentNode as Element) || p; // 確保 ancestor 沒有 span 元素
+  p = (p.closest(".arco-form-item-control-children")?.parentNode as Element) || p; // 確保 ancestor 沒有 .form-item-control-children 元素
   p = (p.closest(".arco-collapse-item-content")?.parentNode as Element) || p; // 確保 ancestor 沒有 .arco-collapse-item-content 元素
   p = (p.closest(".arco-card")?.parentNode as Element) || p; // 確保 ancestor 沒有 .arco-card 元素
   p = (p.closest("aside")?.parentNode as Element) || p; // 確保 ancestor 沒有 aside 元素


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

fix #1358

* `.arco-tabs` dont need to have sizing model inside modal
* add tabs pane `.arco-tabs-pane` height limit to avoid display issue (show scrollbar with overflow auto)
* remove bottom margin (item gap) for last `.arco-form-item`

## Screenshots / 截图

<!-- Screenshots / 截图-->
