### PR TITLE
修正本机档案拖拉安装时错误设置origin问题

### DIFF
--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -409,6 +409,31 @@ export class ScriptService {
     if (updatetime) {
       script.updatetime = updatetime;
     }
+    // 拖拉安装等同本地创建脚本
+    if (script.origin?.startsWith("file:///*from-local*/")) {
+      script.origin = "";
+      script.originDomain = "";
+      script.downloadUrl = "";
+      script.checkUpdateUrl = "";
+    }
+    // 处理 ScriptCat 旧版本进行安装时的 origin 错误 ( 1.2.x & 1.3.x & 1.4.x - 自 commit d9b0eeede1a8b114f79a43fade99d825323c63f6 @ 2025.07.23 )
+    if (oldScript?.origin?.startsWith("file:///*from-local*/") || oldScript?.origin?.startsWith("file://-/")) {
+      oldScript.origin = "";
+      oldScript.originDomain = "";
+      oldScript.downloadUrl = "";
+      oldScript.checkUpdateUrl = "";
+    }
+    // 现存的脚本：以最初的安装(即creationtime)为标准
+    if (oldScript && script.createtime === oldScript.createtime) {
+      // 如果最初是从网络安装，之后拖拉安装本机档案，则保留origin资讯。用于更新检查。
+      // 如果本机安装的版本号较低，则会在下次更新检查时提醒有更新。那个时候，用户可以选择更新至网络上最新版本，或忽略并保留本机版本
+      if (oldScript && oldScript.origin && !script.origin) {
+        script.origin = oldScript.origin;
+        script.originDomain = oldScript.originDomain;
+        script.downloadUrl = oldScript.downloadUrl;
+        script.checkUpdateUrl = oldScript.checkUpdateUrl;
+      }
+    }
     return this.scriptDAO
       .save(script)
       .then(async () => {

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -416,7 +416,7 @@ export class ScriptService {
       script.downloadUrl = "";
       script.checkUpdateUrl = "";
     }
-    // 处理 ScriptCat 旧版本进行安装时的 origin 错误 ( 1.2.x & 1.3.x & 1.4.x - 自 commit d9b0eeede1a8b114f79a43fade99d825323c63f6 @ 2025.07.23 )
+    // 处理 ScriptCat 旧版本进行安装时的 origin 错误 ( 1.0.0-beta.2 ~ 1.4.x - 自 commit d9b0eeede1a8b114f79a43fade99d825323c63f6 @ 2025.07.23 )
     if (oldScript?.origin?.startsWith("file:///*from-local*/") || oldScript?.origin?.startsWith("file://-/")) {
       oldScript.origin = "";
       oldScript.originDomain = "";

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -416,23 +416,23 @@ export class ScriptService {
       script.downloadUrl = "";
       script.checkUpdateUrl = "";
     }
-    // 处理 ScriptCat 旧版本进行安装时的 origin 错误 ( 1.0.0-beta.2 ~ 1.4.x - 自 commit d9b0eeede1a8b114f79a43fade99d825323c63f6 @ 2025.07.23 )
-    if (oldScript?.origin?.startsWith("file:///*from-local*/") || oldScript?.origin?.startsWith("file://-/")) {
-      oldScript.origin = "";
-      oldScript.originDomain = "";
-      oldScript.downloadUrl = "";
-      oldScript.checkUpdateUrl = "";
-    }
-    // 现存的脚本：以最初的安装(即creationtime)为标准
-    if (oldScript && script.createtime === oldScript.createtime) {
-      // 如果最初是从网络安装，之后拖拉安装本机档案，则保留origin资讯。用于更新检查。
-      // 如果本机安装的版本号较低，则会在下次更新检查时提醒有更新。那个时候，用户可以选择更新至网络上最新版本，或忽略并保留本机版本
-      if (oldScript && oldScript.origin && !script.origin) {
-        script.origin = oldScript.origin;
-        script.originDomain = oldScript.originDomain;
-        script.downloadUrl = oldScript.downloadUrl;
-        script.checkUpdateUrl = oldScript.checkUpdateUrl;
-      }
+    // 现存的脚本：以最初的安装(即 createtime)为标准，回填 origin 用于更新检查。
+    // 如果最初是从网络安装，之后拖拉安装本机档案，则保留 origin 资讯。
+    // 如果本机安装的版本号较低，则会在下次更新检查时提醒有更新。那个时候，用户可以选择更新至网络上最新版本，或忽略并保留本机版本。
+    // 跳过 ScriptCat 旧版本 (1.0.0-beta.2 ~ 1.4.x，自 commit d9b0eeede1a8b114f79a43fade99d825323c63f6 @ 2025.07.23)
+    // 误写入的 file:///*from-local*/ 与 file://-/ 前缀
+    if (
+      oldScript &&
+      script.createtime === oldScript.createtime &&
+      oldScript.origin &&
+      !script.origin &&
+      !oldScript.origin.startsWith("file:///*from-local*/") &&
+      !oldScript.origin.startsWith("file://-/")
+    ) {
+      script.origin = oldScript.origin;
+      script.originDomain = oldScript.originDomain;
+      script.downloadUrl = oldScript.downloadUrl;
+      script.checkUpdateUrl = oldScript.checkUpdateUrl;
     }
     return this.scriptDAO
       .save(script)


### PR DESCRIPTION
## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

自 2025.07.23 的 commit d9b0eeede1a8b114f79a43fade99d825323c63f6 起，
当进行本机拖拉安装等动作时
安装的脚本会设为假链结并长期储存在 `chrome.storage.local`

这导致每次更新出现 fetch error (误判为网址连结脚本）

如果最初安装是网上安装，然后手动安装了本地版本，origin会被改成假链结然后完全无法取得新更新

## Screenshots / 截图

<!-- Screenshots / 截图-->

---

### 测试方法1
* 手动拖拉一个新脚本，确认被视为本地脚本而非网址连结脚

### 测试方法2
* 先安装一个脚本，然后下载把脚本改一下，在本地进行手动拖拉安装
