### PR TITLE
(Codex) 修正 `synchronize.ts` 避免 误判和误删

### DIFF
--- a/src/app/service/service_worker/synchronize.test.ts
+++ b/src/app/service/service_worker/synchronize.test.ts
@@ -543,6 +543,35 @@ console.log("ok");`
     expect(order).toEqual(["sync:list", "sync:digest", "delete:from-user", "delete:digest"]);
   });
 
+  it("scriptsDelete skips enqueue when all entries are deleteBy=sync", async () => {
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        getCloudSync: vi.fn().mockResolvedValue({ ...syncConfig, enable: true }),
+      } as any,
+      {
+        scriptCodeDAO: {},
+        all: vi.fn().mockResolvedValue([]),
+      } as any
+    );
+
+    const buildSpy = vi.spyOn(service as any, "buildFileSystem");
+    const getCloudSyncSpy = (service as any).systemConfig.getCloudSync as ReturnType<typeof vi.fn>;
+
+    await service.scriptsDelete([{ uuid: "a", deleteBy: "sync" } as any, { uuid: "b", deleteBy: "sync" } as any]);
+    await flushMicrotasks();
+
+    // 全部来源是 sync（来自 syncOnce 内部的 deleteScript 回灌），应直接 return
+    // 不应去读取云同步配置，也不应建立任何文件系统连接
+    expect(getCloudSyncSpy).not.toHaveBeenCalled();
+    expect(buildSpy).not.toHaveBeenCalled();
+  });
+
   it("cloudSyncConfigChange swallows buildFileSystem error", async () => {
     const service = new SynchronizeService(
       {} as any,

--- a/src/app/service/service_worker/synchronize.test.ts
+++ b/src/app/service/service_worker/synchronize.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SynchronizeService } from "./synchronize";
+import { initTestEnv } from "@Tests/utils";
+import type FileSystem from "@Packages/filesystem/filesystem";
+import type { CloudSyncConfig } from "@App/pkg/config/config";
+
+initTestEnv();
+
+const syncConfig: CloudSyncConfig = {
+  enable: true,
+  syncDelete: true,
+  syncStatus: true,
+  filesystem: "webdav",
+  params: {},
+};
+
+const createFs = (overrides: Partial<FileSystem> = {}): FileSystem =>
+  ({
+    verify: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue([]),
+    open: vi.fn(),
+    openDir: vi.fn(),
+    create: vi.fn().mockResolvedValue({
+      write: vi.fn().mockResolvedValue(undefined),
+    }),
+    createDir: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    getDirUrl: vi.fn().mockResolvedValue(""),
+    ...overrides,
+  }) as unknown as FileSystem;
+
+describe("SynchronizeService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chrome.storage.local.clear();
+  });
+
+  it("serializes concurrent syncOnce calls", async () => {
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const order: string[] = [];
+    const fs1 = createFs({
+      list: vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          order.push("first:start");
+          await firstGate;
+          order.push("first:end");
+          return [];
+        })
+        .mockResolvedValue([]),
+    });
+    const fs2 = createFs({
+      list: vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          order.push("second:start");
+          return [];
+        })
+        .mockResolvedValue([]),
+    });
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        scriptCodeDAO: {},
+        all: vi.fn().mockResolvedValue([]),
+      } as any
+    );
+
+    const first = service.syncOnce(syncConfig, fs1);
+    await Promise.resolve();
+    const second = service.syncOnce(syncConfig, fs2);
+    await Promise.resolve();
+
+    expect(order).toEqual(["first:start"]);
+    expect((fs2.list as any).mock.calls.length).toBe(0);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(["first:start", "first:end", "second:start"]);
+  });
+
+  it("does not delete orphan cloud script without meta", async () => {
+    const fs = createFs({
+      list: vi.fn().mockResolvedValue([
+        {
+          name: "orphan.user.js",
+          path: "orphan.user.js",
+          size: 1,
+          digest: "d1",
+          createtime: 1,
+          updatetime: 1,
+        },
+      ]),
+    });
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        scriptCodeDAO: {},
+        all: vi.fn().mockResolvedValue([]),
+      } as any
+    );
+
+    await service.syncOnce(syncConfig, fs);
+
+    expect(fs.delete).not.toHaveBeenCalled();
+  });
+
+  it("waits for installScript during pullScript", async () => {
+    let releaseInstall!: () => void;
+    const installGate = new Promise<void>((resolve) => {
+      releaseInstall = resolve;
+    });
+    const installScript = vi.fn().mockImplementation(() => installGate);
+    const fs = createFs({
+      open: vi.fn().mockImplementation(async (file) => ({
+        read: vi.fn().mockResolvedValue(
+          file.name.endsWith(".user.js")
+            ? `// ==UserScript==
+// @name Pull Test
+// @namespace sync-test
+// @match https://example.com/*
+// ==/UserScript==
+console.log("ok");`
+            : JSON.stringify({ uuid: "pull-uuid" })
+        ),
+      })),
+    });
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {
+        installScript,
+      } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        scriptCodeDAO: {},
+      } as any
+    );
+
+    let settled = false;
+    const pullPromise = service
+      .pullScript(
+        fs,
+        {
+          script: {
+            name: "pull-uuid.user.js",
+            path: "pull-uuid.user.js",
+            size: 1,
+            digest: "d1",
+            createtime: 1,
+            updatetime: 1,
+          },
+          meta: {
+            name: "pull-uuid.meta.json",
+            path: "pull-uuid.meta.json",
+            size: 1,
+            digest: "d2",
+            createtime: 1,
+            updatetime: 1,
+          },
+        },
+        undefined
+      )
+      .then(() => {
+        settled = true;
+      });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    releaseInstall();
+    await pullPromise;
+
+    expect(installScript).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(true);
+  });
+});

--- a/src/app/service/service_worker/synchronize.test.ts
+++ b/src/app/service/service_worker/synchronize.test.ts
@@ -3,6 +3,7 @@ import { SynchronizeService } from "./synchronize";
 import { initTestEnv } from "@Tests/utils";
 import type FileSystem from "@Packages/filesystem/filesystem";
 import type { CloudSyncConfig } from "@App/pkg/config/config";
+import { stackAsyncTask } from "@App/pkg/utils/async_queue";
 
 initTestEnv();
 
@@ -394,5 +395,183 @@ console.log("ok");`
     expect(order).toContain("push:end");
     expect(order).toContain("digest:list");
     expect(order.indexOf("push:end")).toBeLessThan(order.indexOf("digest:list"));
+  });
+
+  it("scriptInstall enters cloud_sync queue and updates digest after push", async () => {
+    let releaseSync!: () => void;
+    const syncGate = new Promise<void>((resolve) => {
+      releaseSync = resolve;
+    });
+    const order: string[] = [];
+
+    // 第一个占用队列的 syncOnce，gate 在 updateFileDigest 阶段
+    const syncFs = createFs({
+      list: vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          order.push("sync:list");
+          return [];
+        })
+        .mockImplementationOnce(async () => {
+          order.push("sync:digest");
+          await syncGate;
+          return [];
+        }),
+    });
+
+    const installFs = createFs();
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        getCloudSync: vi.fn().mockResolvedValue({ ...syncConfig, enable: true }),
+      } as any,
+      {
+        scriptCodeDAO: {},
+        all: vi.fn().mockResolvedValue([]),
+      } as any
+    );
+
+    vi.spyOn(service as any, "buildFileSystem").mockResolvedValue(installFs);
+    vi.spyOn(service, "pushScript").mockImplementation(async () => {
+      order.push("install:push");
+    });
+    const realUpdateDigest = service.updateFileDigest.bind(service);
+    vi.spyOn(service, "updateFileDigest").mockImplementation(async (fs) => {
+      if (fs === installFs) {
+        order.push("install:digest");
+        return;
+      }
+      await realUpdateDigest(fs);
+    });
+
+    const syncPromise = service.syncOnce(syncConfig, syncFs);
+    await flushMicrotasks();
+    expect(order).toEqual(["sync:list", "sync:digest"]);
+
+    await service.scriptInstall({
+      script: { uuid: "u1", name: "t" } as any,
+      upsertBy: "user",
+    } as any);
+    await flushMicrotasks();
+
+    // syncOnce 还没释放，install 的 pushScript 不能跑
+    expect(order).toEqual(["sync:list", "sync:digest"]);
+
+    releaseSync();
+    await syncPromise;
+
+    // 在同一队列上排一个 barrier，barrier 完成意味着 install 任务也已完成
+    await stackAsyncTask("cloud_sync_queue", async () => "barrier");
+
+    expect(order).toEqual(["sync:list", "sync:digest", "install:push", "install:digest"]);
+  });
+
+  it("scriptsDelete enters cloud_sync queue and updates digest after deleting", async () => {
+    let releaseSync!: () => void;
+    const syncGate = new Promise<void>((resolve) => {
+      releaseSync = resolve;
+    });
+    const order: string[] = [];
+
+    const syncFs = createFs({
+      list: vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          order.push("sync:list");
+          return [];
+        })
+        .mockImplementationOnce(async () => {
+          order.push("sync:digest");
+          await syncGate;
+          return [];
+        }),
+    });
+
+    const deleteFs = createFs();
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        getCloudSync: vi.fn().mockResolvedValue({ ...syncConfig, enable: true }),
+      } as any,
+      {
+        scriptCodeDAO: {},
+        all: vi.fn().mockResolvedValue([]),
+      } as any
+    );
+
+    vi.spyOn(service as any, "buildFileSystem").mockResolvedValue(deleteFs);
+    vi.spyOn(service, "deleteCloudScript").mockImplementation(async (_fs: any, uuid: string) => {
+      order.push(`delete:${uuid}`);
+    });
+    const realUpdateDigest = service.updateFileDigest.bind(service);
+    vi.spyOn(service, "updateFileDigest").mockImplementation(async (fs) => {
+      if (fs === deleteFs) {
+        order.push("delete:digest");
+        return;
+      }
+      await realUpdateDigest(fs);
+    });
+
+    const syncPromise = service.syncOnce(syncConfig, syncFs);
+    await flushMicrotasks();
+    expect(order).toEqual(["sync:list", "sync:digest"]);
+
+    await service.scriptsDelete([
+      { uuid: "from-user", deleteBy: "user" } as any,
+      { uuid: "from-sync", deleteBy: "sync" } as any,
+    ]);
+    await flushMicrotasks();
+
+    // syncOnce 还没释放，delete 任务一步都不能跑
+    expect(order).toEqual(["sync:list", "sync:digest"]);
+
+    releaseSync();
+    await syncPromise;
+    await stackAsyncTask("cloud_sync_queue", async () => "barrier");
+
+    // deleteBy === "sync" 的不应触发云端删除；并且 digest 必须在删除全部完成后才更新
+    expect(order).toEqual(["sync:list", "sync:digest", "delete:from-user", "delete:digest"]);
+  });
+
+  it("cloudSyncConfigChange swallows buildFileSystem error", async () => {
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        scriptCodeDAO: {},
+        all: vi.fn().mockResolvedValue([]),
+      } as any
+    );
+
+    const buildErr = new Error("build fs failed");
+    vi.spyOn(service as any, "buildFileSystem").mockRejectedValue(buildErr);
+    const errorSpy = vi.spyOn(service.logger, "error").mockImplementation(() => undefined as any);
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+
+    try {
+      service.cloudSyncConfigChange({ ...syncConfig, enable: true });
+      await flushMicrotasks();
+
+      expect(errorSpy).toHaveBeenCalledWith("cloud sync config change error", expect.anything());
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", unhandled);
+    }
   });
 });

--- a/src/app/service/service_worker/synchronize.test.ts
+++ b/src/app/service/service_worker/synchronize.test.ts
@@ -29,6 +29,13 @@ const createFs = (overrides: Partial<FileSystem> = {}): FileSystem =>
     ...overrides,
   }) as unknown as FileSystem;
 
+// 等待若干轮微任务，确保所有已就绪的 await 都被推进
+const flushMicrotasks = async (rounds = 10) => {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+};
+
 describe("SynchronizeService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,25 +48,26 @@ describe("SynchronizeService", () => {
       releaseFirst = resolve;
     });
     const order: string[] = [];
-    const fs1 = createFs({
-      list: vi
-        .fn()
-        .mockImplementationOnce(async () => {
-          order.push("first:start");
-          await firstGate;
-          order.push("first:end");
-          return [];
-        })
-        .mockResolvedValue([]),
-    });
+    // gate 放在第一轮的最后一步（updateFileDigest 内部的 fs.list）
+    // 这样如果未来锁粒度被改小，第二轮提前进入也会被这个测试捕获
+    const fs1List = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        order.push("first:list");
+        return [];
+      })
+      .mockImplementationOnce(async () => {
+        order.push("first:digest");
+        await firstGate;
+        order.push("first:end");
+        return [];
+      });
+    const fs1 = createFs({ list: fs1List });
     const fs2 = createFs({
-      list: vi
-        .fn()
-        .mockImplementationOnce(async () => {
-          order.push("second:start");
-          return [];
-        })
-        .mockResolvedValue([]),
+      list: vi.fn().mockImplementation(async () => {
+        order.push("second:list");
+        return [];
+      }),
     });
     const service = new SynchronizeService(
       {} as any,
@@ -76,17 +84,18 @@ describe("SynchronizeService", () => {
     );
 
     const first = service.syncOnce(syncConfig, fs1);
-    await Promise.resolve();
     const second = service.syncOnce(syncConfig, fs2);
-    await Promise.resolve();
+    await flushMicrotasks();
 
-    expect(order).toEqual(["first:start"]);
+    // 第一轮已经跑到末尾的 updateFileDigest，第二轮一步都没开始
+    expect(order).toEqual(["first:list", "first:digest"]);
     expect((fs2.list as any).mock.calls.length).toBe(0);
 
     releaseFirst();
     await Promise.all([first, second]);
 
-    expect(order).toEqual(["first:start", "first:end", "second:start"]);
+    // 第一轮整体结束（first:end）后第二轮才能开始（second:list）
+    expect(order.slice(0, 4)).toEqual(["first:list", "first:digest", "first:end", "second:list"]);
   });
 
   it("does not delete orphan cloud script without meta", async () => {
@@ -119,6 +128,61 @@ describe("SynchronizeService", () => {
     await service.syncOnce(syncConfig, fs);
 
     expect(fs.delete).not.toHaveBeenCalled();
+  });
+
+  it("preserves cloudStatus for skipped orphan uuid when writing scriptcat-sync.json", async () => {
+    const orphanStatus = { enable: false, sort: 7, updatetime: 100 };
+    const writeMock = vi.fn().mockResolvedValue(undefined);
+    const fs = createFs({
+      list: vi.fn().mockResolvedValue([
+        {
+          name: "orphan.user.js",
+          path: "orphan.user.js",
+          size: 1,
+          digest: "d1",
+          createtime: 1,
+          updatetime: 1,
+        },
+        {
+          name: "scriptcat-sync.json",
+          path: "scriptcat-sync.json",
+          size: 1,
+          digest: "d2",
+          createtime: 1,
+          updatetime: 1,
+        },
+      ]),
+      open: vi.fn().mockResolvedValue({
+        read: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            version: "1.0.0",
+            status: { scripts: { orphan: orphanStatus } },
+          })
+        ),
+      }),
+      create: vi.fn().mockResolvedValue({ write: writeMock }),
+    });
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        scriptCodeDAO: {},
+        all: vi.fn().mockResolvedValue([]),
+      } as any
+    );
+
+    await service.syncOnce(syncConfig, fs);
+
+    // 第一次 write 是 scriptcat-sync.json 的内容
+    expect(writeMock).toHaveBeenCalled();
+    const writtenContent = writeMock.mock.calls[0][0] as string;
+    const written = JSON.parse(writtenContent);
+    expect(written.status.scripts.orphan).toEqual(orphanStatus);
   });
 
   it("waits for installScript during pullScript", async () => {
@@ -192,5 +256,143 @@ console.log("ok");`
 
     expect(installScript).toHaveBeenCalledTimes(1);
     expect(settled).toBe(true);
+  });
+
+  it("waits for deleteScript before updating file digest", async () => {
+    let releaseDelete!: () => void;
+    const deleteGate = new Promise<void>((resolve) => {
+      releaseDelete = resolve;
+    });
+    const order: string[] = [];
+    const deleteScript = vi.fn().mockImplementation(async () => {
+      order.push("delete:start");
+      await deleteGate;
+      order.push("delete:end");
+    });
+    // fs.list 第二次调用对应 updateFileDigest，这是 syncOnce 的最后一步
+    const fsList = vi
+      .fn()
+      .mockImplementationOnce(async () => [
+        {
+          name: "del-uuid.meta.json",
+          path: "del-uuid.meta.json",
+          size: 1,
+          digest: "d1",
+          createtime: 1,
+          updatetime: 1,
+        },
+      ])
+      .mockImplementationOnce(async () => {
+        order.push("digest:list");
+        return [];
+      });
+    const fs = createFs({
+      list: fsList,
+      open: vi.fn().mockResolvedValue({
+        read: vi.fn().mockResolvedValue(JSON.stringify({ uuid: "del-uuid", isDeleted: true })),
+      }),
+    });
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      { deleteScript } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        scriptCodeDAO: {},
+        all: vi.fn().mockResolvedValue([
+          {
+            uuid: "del-uuid",
+            name: "del",
+            updatetime: 1,
+            createtime: 1,
+            status: 1,
+            sort: 0,
+            metadata: {},
+          },
+        ]),
+      } as any
+    );
+
+    const promise = service.syncOnce(syncConfig, fs);
+    await flushMicrotasks();
+
+    // delete 已经开始但没结束，updateFileDigest 还没被调用
+    expect(order).toEqual(["delete:start"]);
+
+    releaseDelete();
+    await promise;
+
+    // delete 必须在 updateFileDigest 之前完成
+    expect(order).toEqual(["delete:start", "delete:end", "digest:list"]);
+  });
+
+  it("waits for pushScript before updating file digest", async () => {
+    let releasePush!: () => void;
+    const pushGate = new Promise<void>((resolve) => {
+      releasePush = resolve;
+    });
+    const order: string[] = [];
+    // pushScript 内部第一步是 fs.create(uuid.user.js)，gate 在这里就能拦住整个 push
+    const fsCreate = vi.fn().mockImplementation(async (filename: string) => {
+      if (filename === "push-uuid.user.js") {
+        order.push("push:start");
+        await pushGate;
+        order.push("push:end");
+      }
+      return { write: vi.fn().mockResolvedValue(undefined) };
+    });
+    const fsList = vi
+      .fn()
+      .mockImplementationOnce(async () => [])
+      .mockImplementationOnce(async () => {
+        order.push("digest:list");
+        return [];
+      });
+    const fs = createFs({
+      list: fsList,
+      create: fsCreate,
+    });
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        scriptCodeDAO: {
+          get: vi.fn().mockResolvedValue({ code: "// code" }),
+        },
+        all: vi.fn().mockResolvedValue([
+          {
+            uuid: "push-uuid",
+            name: "push",
+            updatetime: 1,
+            createtime: 1,
+            status: 1,
+            sort: 0,
+            metadata: {},
+          },
+        ]),
+      } as any
+    );
+
+    const promise = service.syncOnce(syncConfig, fs);
+    await flushMicrotasks();
+
+    // push 已经开始但没结束，updateFileDigest 还没被调用
+    expect(order).toEqual(["push:start"]);
+
+    releasePush();
+    await promise;
+
+    // push 必须在 updateFileDigest 之前完成
+    expect(order).toContain("push:end");
+    expect(order).toContain("digest:list");
+    expect(order.indexOf("push:end")).toBeLessThan(order.indexOf("digest:list"));
   });
 });

--- a/src/app/service/service_worker/synchronize.ts
+++ b/src/app/service/service_worker/synchronize.ts
@@ -33,6 +33,7 @@ import { ExtVersion } from "@App/app/const";
 import { dayFormat } from "@App/pkg/utils/day_format";
 import i18n, { i18nName } from "@App/locales/locales";
 import { InfoNotification } from "./utils";
+import { stackAsyncTask } from "@App/pkg/utils/async_queue";
 
 // type SynchronizeTarget = "local";
 
@@ -65,6 +66,8 @@ type ScriptcatSyncStatus = {
 };
 
 type PushScriptParam = TInstallScriptParams;
+
+const SYNC_SERVICE_TASK_KEY = "cloud_sync";
 
 export class SynchronizeService {
   logger: Logger;
@@ -329,6 +332,10 @@ export class SynchronizeService {
 
   // 同步一次
   async syncOnce(syncConfig: CloudSyncConfig, fs: FileSystem) {
+    return stackAsyncTask(SYNC_SERVICE_TASK_KEY, () => this.syncOnceInternal(syncConfig, fs));
+  }
+
+  private async syncOnceInternal(syncConfig: CloudSyncConfig, fs: FileSystem) {
     this.logger.info("start sync once");
     // 获取文件列表
     const list = await fs.list();
@@ -402,7 +409,7 @@ export class SynchronizeService {
               const metaObj = JSON.parse(metaJson) as SyncMeta;
               if (metaObj.isDeleted) {
                 // 删除脚本
-                this.script.deleteScript(script.uuid, "sync");
+                await this.script.deleteScript(script.uuid, "sync");
                 InfoNotification(
                   i18n.t("notification.script_sync_delete"),
                   i18n.t("notification.script_sync_delete_desc", { scriptName: i18nName(script) })
@@ -410,7 +417,7 @@ export class SynchronizeService {
               } else {
                 // 否则认为是一个无效的.meta文件，进行删除，并进行同步
                 await fs.delete(file.meta!.name);
-                result.push(this.pushScript(fs, script));
+                await this.pushScript(fs, script);
               }
             })()
           );
@@ -436,8 +443,11 @@ export class SynchronizeService {
       // 如果脚本不存在，但文件存在，则安装脚本
       if (file.script) {
         if (!file.meta) {
-          // 如果.meta文件不存在，则删除脚本文件，并跳过
-          result.push(fs.delete(file.script.name));
+          // .meta 文件可能尚未上传完成，跳过本次以避免误删云端脚本
+          this.logger.warn("skip orphan cloud script without meta", {
+            uuid,
+            file: file.script.name,
+          });
           return;
         }
         updateScript.set(uuid, true);
@@ -616,7 +626,7 @@ export class SynchronizeService {
           script.status = status.enable ? SCRIPT_STATUS_ENABLE : SCRIPT_STATUS_DISABLE;
         }
       }
-      this.script.installScript({
+      await this.script.installScript({
         script,
         code,
         upsertBy: "sync",
@@ -630,33 +640,37 @@ export class SynchronizeService {
   cloudSyncConfigChange(value: CloudSyncConfig) {
     if (value.enable) {
       // 开启云同步同步
-      this.buildFileSystem(value).then(async (fs) => {
-        await this.syncOnce(value, fs);
-        // 开启定时器, 一小时一次
-        chrome.alarms.get("cloudSync", (alarm) => {
-          const lastError = chrome.runtime.lastError;
-          if (lastError) {
-            console.error("chrome.runtime.lastError in chrome.alarms.get:", lastError);
-            // 非预期的异常API错误，停止处理
-          }
-          if (!alarm) {
-            chrome.alarms.create(
-              "cloudSync",
-              {
-                periodInMinutes: 60,
-              },
-              () => {
-                const lastError = chrome.runtime.lastError;
-                if (lastError) {
-                  console.error("chrome.runtime.lastError in chrome.alarms.create:", lastError);
-                  // Starting in Chrome 117, the number of active alarms is limited to 500. Once this limit is reached, chrome.alarms.create() will fail.
-                  console.error("Chrome alarm is unable to create. Please check whether limit is reached.");
+      this.buildFileSystem(value)
+        .then(async (fs) => {
+          await this.syncOnce(value, fs);
+          // 开启定时器, 一小时一次
+          chrome.alarms.get("cloudSync", (alarm) => {
+            const lastError = chrome.runtime.lastError;
+            if (lastError) {
+              console.error("chrome.runtime.lastError in chrome.alarms.get:", lastError);
+              // 非预期的异常API错误，停止处理
+            }
+            if (!alarm) {
+              chrome.alarms.create(
+                "cloudSync",
+                {
+                  periodInMinutes: 60,
+                },
+                () => {
+                  const lastError = chrome.runtime.lastError;
+                  if (lastError) {
+                    console.error("chrome.runtime.lastError in chrome.alarms.create:", lastError);
+                    // Starting in Chrome 117, the number of active alarms is limited to 500. Once this limit is reached, chrome.alarms.create() will fail.
+                    console.error("Chrome alarm is unable to create. Please check whether limit is reached.");
+                  }
                 }
-              }
-            );
-          }
+              );
+            }
+          });
+        })
+        .catch((e) => {
+          this.logger.error("cloud sync config change error", Logger.E(e));
         });
-      });
     } else {
       // 停止计时器
       chrome.alarms.clear("cloudSync");
@@ -670,9 +684,12 @@ export class SynchronizeService {
     // 判断是否开启了同步
     const config = await this.systemConfig.getCloudSync();
     if (config.enable) {
-      this.buildFileSystem(config).then(async (fs) => {
+      stackAsyncTask(SYNC_SERVICE_TASK_KEY, async () => {
+        const fs = await this.buildFileSystem(config);
         await this.pushScript(fs, params.script);
-        this.updateFileDigest(fs);
+        await this.updateFileDigest(fs);
+      }).catch((e) => {
+        this.logger.error("push script on install error", Logger.E(e));
       });
     }
   }
@@ -681,13 +698,17 @@ export class SynchronizeService {
     // 判断是否开启了同步
     const config = await this.systemConfig.getCloudSync();
     if (config.enable) {
-      this.buildFileSystem(config).then(async (fs) => {
+      stackAsyncTask(SYNC_SERVICE_TASK_KEY, async () => {
+        const fs = await this.buildFileSystem(config);
         for (const { uuid, deleteBy } of data) {
           if (deleteBy === "sync") {
             continue;
           }
           await this.deleteCloudScript(fs, uuid, config.syncDelete);
         }
+        await this.updateFileDigest(fs);
+      }).catch((e) => {
+        this.logger.error("delete cloud script error", Logger.E(e));
       });
     }
   }

--- a/src/app/service/service_worker/synchronize.ts
+++ b/src/app/service/service_worker/synchronize.ts
@@ -712,15 +712,18 @@ export class SynchronizeService {
   }
 
   async scriptsDelete(data: TDeleteScript[]) {
+    // 过滤掉来源为 sync 的删除事件，避免 syncOnce 内部触发的 mq 回灌
+    // 又排一次 buildFileSystem + updateFileDigest 的空跑任务
+    const items = data.filter((d) => d.deleteBy !== "sync");
+    if (!items.length) {
+      return;
+    }
     // 判断是否开启了同步
     const config = await this.systemConfig.getCloudSync();
     if (config.enable) {
       stackAsyncTask(SYNC_SERVICE_TASK_KEY, async () => {
         const fs = await this.buildFileSystem(config);
-        for (const { uuid, deleteBy } of data) {
-          if (deleteBy === "sync") {
-            continue;
-          }
+        for (const { uuid } of items) {
           await this.deleteCloudScript(fs, uuid, config.syncDelete);
         }
         await this.updateFileDigest(fs);

--- a/src/app/service/service_worker/synchronize.ts
+++ b/src/app/service/service_worker/synchronize.ts
@@ -67,7 +67,7 @@ type ScriptcatSyncStatus = {
 
 type PushScriptParam = TInstallScriptParams;
 
-const SYNC_SERVICE_TASK_KEY = "cloud_sync";
+const SYNC_SERVICE_TASK_KEY = "cloud_sync_queue";
 
 export class SynchronizeService {
   logger: Logger;
@@ -332,7 +332,13 @@ export class SynchronizeService {
 
   // 同步一次
   async syncOnce(syncConfig: CloudSyncConfig, fs: FileSystem) {
-    return stackAsyncTask(SYNC_SERVICE_TASK_KEY, () => this.syncOnceInternal(syncConfig, fs));
+    return stackAsyncTask(SYNC_SERVICE_TASK_KEY, async () => {
+      try {
+        await this.syncOnceInternal(syncConfig, fs);
+      } catch (e) {
+        this.logger.error("sync once error", Logger.E(e));
+      }
+    });
   }
 
   private async syncOnceInternal(syncConfig: CloudSyncConfig, fs: FileSystem) {
@@ -393,6 +399,9 @@ export class SynchronizeService {
     // 对比脚本列表和文件列表,进行同步
     const result: Promise<void>[] = [];
     const updateScript: Map<string, boolean> = new Map();
+    // 记录被跳过的孤儿云端脚本（仅 .user.js 无 .meta.json）
+    // 避免本机回写 scriptcat-sync.json 时丢失对应 uuid 的云端 status
+    const skippedOrphanUuids = new Set<string>();
     // 需要是同步操作，后续上传剩下的脚本
     // 最后使用 Promise.allSettled 进行等待
     uuidMap.forEach((file, uuid) => {
@@ -448,6 +457,7 @@ export class SynchronizeService {
             uuid,
             file: file.script.name,
           });
+          skippedOrphanUuids.add(uuid);
           return;
         }
         updateScript.set(uuid, true);
@@ -509,6 +519,13 @@ export class SynchronizeService {
           }
         })
       );
+      // 保留被跳过的 orphan uuid 的云端 status，避免覆盖另一台设备半上传的状态
+      skippedOrphanUuids.forEach((uuid) => {
+        const status = cloudStatus[uuid];
+        if (status) {
+          scriptcatSync.status.scripts[uuid] = status;
+        }
+      });
       // 保存脚本猫同步状态
       const syncFile = await fs.create("scriptcat-sync.json");
       await syncFile.write(JSON.stringify(scriptcatSync, null, 2));


### PR DESCRIPTION


**1. 给云同步加“同机串行锁”**
文件：synchronize.ts

改动：`syncOnce()` 外面包了一层 `stackAsyncTask("cloud_sync", ...)`。

意图：
同一台设备上，云同步原本可能被多个入口同时触发，比如：
- 扩展启动时
- `cloud_sync` 配置变化时
- 定时 `alarm` 到点时
- 本地安装脚本后
- 本地删除脚本后

原先这些路径可能并发跑，导致几个问题：
- 两次同步同时读同一批云端文件，判断依据已经过期
- 一个同步刚写完文件，另一个同步又用旧快照覆盖
- `file_digest` 被后一个旧结果回写
- 删除、上传、拉取互相打架

现在意图很简单：
同一时刻，同机只允许一个 cloud sync 相关任务执行，后来的排队，不并发。

---

**2. 把真正的同步逻辑移到 `syncOnceInternal()`**
文件：synchronize.ts

改动：`syncOnce()` 只负责进队列，原逻辑挪到私有方法 `syncOnceInternal()`。

意图：
这是配合第 1 点做的结构调整。目的不是改行为，而是：
- 保持原同步逻辑基本不动
- 只在入口层统一加串行控制
- 降低改动面，避免大改业务逻辑

这是很典型的“外层加调度，内层保留原实现”。

---

**3. 同步里遇到云端删除标记时，真正等待本地删除完成**
文件：synchronize.ts

改动：原来是
`this.script.deleteScript(script.uuid, "sync");`
现在改成
`await this.script.deleteScript(script.uuid, "sync");`

意图：
原实现是“发起删除就继续往下跑”，这会产生时序错误：
- 本地脚本还没删完
- 但本轮 `syncOnce()` 可能已经继续写 `scriptcat-sync.json`
- 甚至已经更新 digest，标记“同步完成”

这样会出现“逻辑上说删了，实际上本地还没删完”的中间态。

现在改成等待删除完成，意图是：
这一轮同步里，凡是决定要删本地脚本，就等它真的删完，再继续后续状态同步和收尾。

---

**4. 修复 `result.push(...)` 在异步内部追加任务但不会被 `Promise.allSettled` 等到的问题**
文件：synchronize.ts

改动：
原来有一段逻辑是：
- 先把一个 async 函数塞进 `result`
- 这个 async 函数运行中，又 `result.push(this.pushScript(...))`

我把它改成：
- 在同一个 async 任务里直接 `await this.pushScript(...)`
- 不再在运行过程中动态往 `result` 里追加新 Promise

意图：
`Promise.allSettled(result)` 只会等调用当时数组里已有的 Promise。
如果 Promise 运行到一半才 `result.push(...)` 新任务，这个新任务通常不会被本轮 `allSettled` 等到。

原先风险是：
- 主流程以为所有同步动作做完了
- 实际还有一个补救上传还在后台跑
- 然后就提前写状态文件、提前更新 digest、提前结束同步

现在的意图是：
每个分支自己的后续动作，必须在自己那个 Promise 里完整跑完，不能偷偷追加“游离任务”。

---

**5. 遇到“只有 `.user.js`、没有 `.meta.json`”的云端孤儿文件时，不再直接删云端脚本**
文件：synchronize.ts

改动：
原来逻辑是：
如果云端有 `xxx.user.js`，但没有 `xxx.meta.json`，就直接 `fs.delete(file.script.name)`。

现在改成：
- 不删
- 记一条 warning
- 跳过本轮

意图：
原逻辑太激进。因为这种状态不一定是脏数据，也可能只是“另一台设备刚上传到一半”：
- 先写了 `.user.js`
- `.meta.json` 还没来得及写
- 你这台设备正好开始同步
- 结果把对方刚上传的脚本删了

这属于典型的“把中间态误判成坏数据”。

现在改成跳过，意图是：
面对疑似半上传状态，宁可保守，不做破坏性处理。
等下一轮同步再看它是否补完整。

这是这次改动里很重要的一点，直接针对“不稳定网络/中断过程/多设备并发上传”场景。

---

**6. `pullScript()` 里真正等待 `installScript()` 完成**
文件：synchronize.ts

改动：原来是
`this.script.installScript(...)`
现在改成
`await this.script.installScript(...)`

意图：
云端拉取脚本时，原实现也是“发起安装就算成功”，这有几个问题：
- `pullScript()` 提前返回
- 外层 `syncOnce()` 以为这个脚本已经同步完成
- 实际本地数据库、代码存储、资源更新可能还没做完

这样会造成：
- 状态文件写早了
- digest 写早了
- 下一轮同步拿到不一致状态

现在改成等待安装完成，意图是：
“拉取成功”必须以本地真正安装落库成功为准，不是以“已经调用了安装函数”为准。

---

**7. 本地安装脚本后的增量云同步，也走同一个串行队列**
文件：synchronize.ts

改动：
`scriptInstall()` 原来是直接 `buildFileSystem(...).then(...)`
现在改成：
- 进入 `cloud_sync` 串行队列
- 再执行 `pushScript`
- 再 `await updateFileDigest`
- 有异常则记录日志

意图：
本地安装脚本后会立即往云端推送。
如果这个推送和定时同步、启动同步同时发生，原先会并发冲突。

现在让它也进入同一队列，意图是：
“全量同步”和“安装后的单脚本上传”共享同一调度通道，避免互相覆盖。

另外这里顺手把 `updateFileDigest(fs)` 改成了 `await`。
原因很直接：digest 是同步状态的一部分，不该异步悬空。

---

**8. 本地删除脚本后的云端删除，也走同一个串行队列，并在结束后刷新 digest**
文件：synchronize.ts

改动：
`scriptsDelete()` 原来也是直接 `buildFileSystem(...).then(...)`
现在改成：
- 进入 `cloud_sync` 串行队列
- 顺序执行每个云端删除
- 结束后 `await updateFileDigest(fs)`
- 有异常则记录日志

意图：
和第 7 点同理。
删除操作如果和别的同步并发，风险更高，因为删除本身就是破坏性动作。

现在这样改，目的有两个：
- 删除动作和别的同步串行化
- 删除后立刻刷新 `file_digest`，避免本地还记着旧云端摘要

否则下一次同步可能继续拿旧 digest 做“无变化判断”，出现误判。

---

**9. `cloudSyncConfigChange()` 增加 `.catch(...)`，避免未处理 Promise 异常**
文件：synchronize.ts

改动：
原来 `this.buildFileSystem(value).then(async (fs) => { ... })`
后面没有 `.catch(...)`。
现在补了 `.catch(...)`，统一记日志。

意图：
原先如果这里任何一步抛异常：
- 建文件系统失败
- 初次同步失败
- 其他 await 失败

可能产生未处理的 Promise rejection。
这不一定直接破坏业务，但会让错误变成“静默漂浮”状态，不利于排查，也可能污染后续执行。

现在补 catch，意图是：
至少保证这条异步链的失败被显式记录，而不是悄悄漏掉。

---

**10. 新增测试，专门验证这次修的同步行为**
文件：synchronize.test.ts

现在保留的 3 个测试，意图分别是：

- `serializes concurrent syncOnce calls`
  验证两个 `syncOnce()` 并发调用时，第二个不会抢先进入，而是等第一个结束后再跑。
  这是验证“同机串行锁”确实生效。

- `does not delete orphan cloud script without meta`
  验证云端只有 `.user.js`、没有 `.meta.json` 时，不会再直接删除脚本文件。
  这是验证“面对半上传中间态，改为保守跳过”。

- `waits for installScript during pullScript`
  验证 `pullScript()` 不会在 `installScript()` 还没完成时提前返回。
  这是验证“拉取成功必须等本地安装完成”。


---

这次保留的改动，核心目标不是“让同步更积极”，而是“让同步在并发、半完成状态、异步未等待场景下更保守、更串行、更不容易误判和误删”。