### PR TITLE
(Codex) 修复 `packages/filesystem` 中认证恢复与删除幂等问题

### DIFF
--- a/packages/filesystem/auth.test.ts
+++ b/packages/filesystem/auth.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthVerify } from "./auth";
+import { LocalStorageDAO } from "@App/app/repo/localStorage";
+
+describe("AuthVerify", () => {
+  const localStorageDAO = new LocalStorageDAO();
+  const key = "netdisk:token:onedrive";
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await chrome.storage.local.clear();
+  });
+
+  it("expired token refresh network failure should reject, not fallback old token", async () => {
+    await localStorageDAO.saveValue(key, {
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      createtime: Date.now() - 3600000 - 1000,
+    });
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValueOnce(new Error("refresh network failed")));
+
+    await expect(AuthVerify("onedrive")).rejects.toThrow("refresh network failed");
+  });
+
+  it("non-expired token should return cached token without refresh", async () => {
+    await localStorageDAO.saveValue(key, {
+      accessToken: "cached-access",
+      refreshToken: "cached-refresh",
+      createtime: Date.now(),
+    });
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(AuthVerify("onedrive")).resolves.toBe("cached-access");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/filesystem/auth.test.ts
+++ b/packages/filesystem/auth.test.ts
@@ -1,14 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthVerify } from "./auth";
 import { LocalStorageDAO } from "@App/app/repo/localStorage";
 
 describe("AuthVerify", () => {
   const localStorageDAO = new LocalStorageDAO();
   const key = "netdisk:token:onedrive";
+  let originalFetch: typeof fetch;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     await chrome.storage.local.clear();
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    vi.stubGlobal("fetch", originalFetch);
   });
 
   it("expired token refresh network failure should reject, not fallback old token", async () => {

--- a/packages/filesystem/auth.ts
+++ b/packages/filesystem/auth.ts
@@ -100,7 +100,8 @@ export async function AuthVerify(netDiskType: NetDiskType, invalid?: boolean) {
     await localStorageDAO.saveValue(key, token);
   }
   // token过期或者失效
-  if (Date.now() >= token.createtime + 3600000 || invalid) {
+  const expired = Date.now() >= token.createtime + 3600000;
+  if (expired || invalid) {
     // 大于一小时刷新token
     try {
       const resp = await RefreshToken(netDiskType, token.refreshToken);
@@ -119,9 +120,10 @@ export async function AuthVerify(netDiskType: NetDiskType, invalid?: boolean) {
       };
       // 更新token
       await localStorageDAO.saveValue(key, token);
-    } catch (_) {
-      // 报错返回原token
-      return token.accessToken;
+    } catch (e) {
+      // 已过期或已被服务端判定失效的 token 不能继续回退使用
+      console.warn(e);
+      throw e;
     }
   } else {
     return token.accessToken;

--- a/packages/filesystem/dropbox/dropbox.test.ts
+++ b/packages/filesystem/dropbox/dropbox.test.ts
@@ -1,0 +1,17 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import DropboxFileSystem from "./dropbox";
+
+describe("DropboxFileSystem", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("delete should be idempotent on path not found", async () => {
+    const fs = new DropboxFileSystem("/", "token");
+    vi.spyOn(fs, "request").mockRejectedValue(
+      new Error('Dropbox API Error: 409 - {"error_summary":"path_lookup/not_found/..."}')
+    );
+
+    await expect(fs.delete("missing.txt")).resolves.toBeUndefined();
+  });
+});

--- a/packages/filesystem/dropbox/dropbox.ts
+++ b/packages/filesystem/dropbox/dropbox.ts
@@ -78,14 +78,28 @@ export default class DropboxFileSystem implements FileSystem {
   request(url: string, config?: RequestInit, nothen?: boolean) {
     config = config || {};
     const headers = <Headers>config.headers || new Headers();
-    headers.append(`Authorization`, `Bearer ${this.accessToken}`);
+    headers.set(`Authorization`, `Bearer ${this.accessToken}`);
     config.headers = headers;
-    const ret = fetch(url, config);
+    const doFetch = () => fetch(url, config);
+    const retryWithFreshToken = async () => {
+      const token = await AuthVerify("dropbox", true);
+      this.accessToken = token;
+      headers.set(`Authorization`, `Bearer ${this.accessToken}`);
+      return doFetch();
+    };
     if (nothen) {
-      return <Promise<Response>>ret;
+      return doFetch().then(async (resp) => {
+        if (resp.status === 401) {
+          return retryWithFreshToken();
+        }
+        return resp;
+      });
     }
-    return ret
+    return doFetch()
       .then(async (response) => {
+        if (response.status === 401) {
+          response = await retryWithFreshToken();
+        }
         if (!response.ok) {
           const errorText = await response.text();
           throw new Error(`Dropbox API Error: ${response.status} - ${errorText}`);
@@ -126,13 +140,20 @@ export default class DropboxFileSystem implements FileSystem {
     const myHeaders = new Headers();
     myHeaders.append("Content-Type", "application/json");
 
-    await this.request("https://api.dropboxapi.com/2/files/delete_v2", {
-      method: "POST",
-      headers: myHeaders,
-      body: JSON.stringify({
-        path: fullPath,
-      }),
-    });
+    try {
+      await this.request("https://api.dropboxapi.com/2/files/delete_v2", {
+        method: "POST",
+        headers: myHeaders,
+        body: JSON.stringify({
+          path: fullPath,
+        }),
+      });
+    } catch (e: any) {
+      if (e.message?.includes("path_lookup/not_found") || e.message?.includes("path/not_found")) {
+        return;
+      }
+      throw e;
+    }
 
     // 清除相关缓存
     this.clearRelatedCache(fullPath);

--- a/packages/filesystem/googledrive/googledrive.test.ts
+++ b/packages/filesystem/googledrive/googledrive.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import GoogleDriveFileSystem from "./googledrive";
+
+describe("GoogleDriveFileSystem", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("delete should be idempotent when file id is missing", async () => {
+    const fs = new GoogleDriveFileSystem("/", "token");
+    vi.spyOn(fs, "getFileId").mockResolvedValue(null);
+    const requestSpy = vi.spyOn(fs, "request");
+
+    await expect(fs.delete("missing.txt")).resolves.toBeUndefined();
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+
+  it("delete should be idempotent on 404 response", async () => {
+    const fs = new GoogleDriveFileSystem("/", "token");
+    vi.spyOn(fs, "getFileId").mockResolvedValue("file-1");
+    vi.spyOn(fs, "request").mockResolvedValue({
+      status: 404,
+      text: vi.fn().mockResolvedValue("not found"),
+    } as unknown as Response);
+
+    await expect(fs.delete("missing.txt")).resolves.toBeUndefined();
+  });
+});

--- a/packages/filesystem/googledrive/googledrive.ts
+++ b/packages/filesystem/googledrive/googledrive.ts
@@ -110,23 +110,44 @@ export default class GoogleDriveFileSystem implements FileSystem {
   request(url: string, config?: RequestInit, nothen?: boolean) {
     config = config || {};
     const headers = <Headers>config.headers || new Headers();
-    headers.append(`Authorization`, `Bearer ${this.accessToken}`);
+    headers.set(`Authorization`, `Bearer ${this.accessToken}`);
     config.headers = headers;
-    const ret = fetch(url, config);
+    const doFetch = () => fetch(url, config);
+    const retryWithFreshToken = async () => {
+      const token = await AuthVerify("googledrive", true);
+      this.accessToken = token;
+      headers.set(`Authorization`, `Bearer ${this.accessToken}`);
+      return doFetch();
+    };
     if (nothen) {
-      return <Promise<Response>>ret;
+      return doFetch().then(async (resp) => {
+        if (resp.status === 401) {
+          return retryWithFreshToken();
+        }
+        return resp;
+      });
     }
-    return ret
-      .then((data) => data.json())
+    return doFetch()
+      .then(async (resp) => {
+        if (resp.status === 401) {
+          resp = await retryWithFreshToken();
+        }
+        if (!resp.ok) {
+          throw new Error(await resp.text());
+        }
+        return resp.json();
+      })
       .then(async (data) => {
         if (data.error) {
           if (data.error.code === 401) {
             // Token可能过期，尝试刷新
-            const token = await AuthVerify("googledrive", true);
-            this.accessToken = token;
-            headers.set(`Authorization`, `Bearer ${this.accessToken}`);
-            return fetch(url, config)
-              .then((retryData) => retryData.json())
+            return retryWithFreshToken()
+              .then(async (retryResp) => {
+                if (!retryResp.ok) {
+                  throw new Error(await retryResp.text());
+                }
+                return retryResp.json();
+              })
               .then((retryData) => {
                 if (retryData.error) {
                   throw new Error(JSON.stringify(retryData));
@@ -145,7 +166,7 @@ export default class GoogleDriveFileSystem implements FileSystem {
     // 首先，找到要删除的文件或文件夹
     const fileId = await this.getFileId(fullPath);
     if (!fileId) {
-      throw new Error(`File or directory not found: ${fullPath}`);
+      return;
     }
 
     // 删除文件或文件夹
@@ -156,6 +177,9 @@ export default class GoogleDriveFileSystem implements FileSystem {
       },
       true
     ).then(async (resp) => {
+      if (resp.status === 404) {
+        return;
+      }
       if (resp.status !== 204 && resp.status !== 200) {
         throw new Error(await resp.text());
       }

--- a/packages/filesystem/onedrive/onedrive.test.ts
+++ b/packages/filesystem/onedrive/onedrive.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import OneDriveFileSystem from "./onedrive";
+import { LocalStorageDAO } from "@App/app/repo/localStorage";
+
+function createMockResponse(options: { ok?: boolean; status?: number; text?: string; json?: any }): Response {
+  const { ok = true, status = 200, text = "", json = {} } = options;
+  return {
+    ok,
+    status,
+    text: vi.fn().mockResolvedValue(text),
+    json: vi.fn().mockResolvedValue(json),
+    headers: new Headers(),
+  } as unknown as Response;
+}
+
+describe("OneDriveFileSystem", () => {
+  const localStorageDAO = new LocalStorageDAO();
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await chrome.storage.local.clear();
+  });
+
+  it("request should return retry result after token refresh", async () => {
+    await localStorageDAO.saveValue("netdisk:token:onedrive", {
+      accessToken: "expired-token",
+      refreshToken: "refresh-token",
+      createtime: Date.now(),
+    });
+
+    const fs = new OneDriveFileSystem("/", "expired-token");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createMockResponse({
+          ok: true,
+          status: 200,
+          json: {
+            error: {
+              code: "InvalidAuthenticationToken",
+            },
+          },
+        })
+      )
+      .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({
+          code: 0,
+          data: {
+            token: {
+              access_token: "fresh-token",
+              refresh_token: "fresh-refresh-token",
+            },
+          },
+        }),
+      } as unknown as Response)
+      .mockResolvedValueOnce(
+        createMockResponse({
+          ok: true,
+          status: 200,
+          json: {
+            value: [
+              {
+                name: "ok.txt",
+                size: 1,
+                eTag: "tag",
+                createdDateTime: new Date().toISOString(),
+                lastModifiedDateTime: new Date().toISOString(),
+              },
+            ],
+          },
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const data = await fs.request("https://graph.microsoft.com/v1.0/me/drive/special/approot/children");
+
+    expect(data.value).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("delete should be idempotent on 404", async () => {
+    const fs = new OneDriveFileSystem("/", "token");
+    vi.spyOn(fs, "request").mockResolvedValue({
+      status: 404,
+      text: vi.fn().mockResolvedValue("not found"),
+    } as unknown as Response);
+
+    await expect(fs.delete("missing.txt")).resolves.toBeUndefined();
+  });
+});

--- a/packages/filesystem/onedrive/onedrive.test.ts
+++ b/packages/filesystem/onedrive/onedrive.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import OneDriveFileSystem from "./onedrive";
 import { LocalStorageDAO } from "@App/app/repo/localStorage";
 
@@ -15,10 +15,16 @@ function createMockResponse(options: { ok?: boolean; status?: number; text?: str
 
 describe("OneDriveFileSystem", () => {
   const localStorageDAO = new LocalStorageDAO();
+  let originalFetch: typeof fetch;
 
   beforeEach(async () => {
     vi.clearAllMocks();
     await chrome.storage.local.clear();
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    vi.stubGlobal("fetch", originalFetch);
   });
 
   it("request should return retry result after token refresh", async () => {

--- a/packages/filesystem/onedrive/onedrive.ts
+++ b/packages/filesystem/onedrive/onedrive.ts
@@ -74,28 +74,51 @@ export default class OneDriveFileSystem implements FileSystem {
     config = config || {};
     const headers = <Headers>config.headers || new Headers();
     if (!url.includes("uploadSession")) {
-      headers.append(`Authorization`, `Bearer ${this.accessToken}`);
+      headers.set(`Authorization`, `Bearer ${this.accessToken}`);
     }
     config.headers = headers;
-    const ret = fetch(url, config);
+    const doFetch = () => fetch(url, config);
+    const retryWithFreshToken = async () => {
+      const token = await AuthVerify("onedrive", true);
+      this.accessToken = token;
+      if (!url.includes("uploadSession")) {
+        headers.set(`Authorization`, `Bearer ${this.accessToken}`);
+      }
+      return doFetch();
+    };
     if (nothen) {
-      return <Promise<Response>>ret;
+      return doFetch().then(async (resp) => {
+        if (resp.status === 401 && !url.includes("uploadSession")) {
+          return retryWithFreshToken();
+        }
+        return resp;
+      });
     }
-    return ret
-      .then((data) => data.json())
+    return doFetch()
+      .then(async (resp) => {
+        if (resp.status === 401 && !url.includes("uploadSession")) {
+          resp = await retryWithFreshToken();
+        }
+        if (!resp.ok) {
+          throw new Error(await resp.text());
+        }
+        return resp.json();
+      })
       .then(async (data) => {
         if (data.error) {
           if (data.error.code === "InvalidAuthenticationToken") {
-            const token = await AuthVerify("onedrive", true);
-            this.accessToken = token;
-            headers.set(`Authorization`, `Bearer ${this.accessToken}`);
-            return fetch(url, config)
-              .then((retryData) => retryData.json())
+            return retryWithFreshToken()
+              .then(async (retryResp) => {
+                if (!retryResp.ok) {
+                  throw new Error(await retryResp.text());
+                }
+                return retryResp.json();
+              })
               .then((retryData) => {
                 if (retryData.error) {
                   throw new Error(JSON.stringify(retryData));
                 }
-                return data;
+                return retryData;
               });
           }
           throw new Error(JSON.stringify(data));
@@ -112,6 +135,9 @@ export default class OneDriveFileSystem implements FileSystem {
       },
       true
     );
+    if (resp.status === 404) {
+      return;
+    }
     if (resp.status !== 204) {
       throw new Error(await resp.text());
     }

--- a/packages/filesystem/onedrive/onedrive.ts
+++ b/packages/filesystem/onedrive/onedrive.ts
@@ -141,7 +141,6 @@ export default class OneDriveFileSystem implements FileSystem {
     if (resp.status !== 204) {
       throw new Error(await resp.text());
     }
-    return resp;
   }
 
   async list(): Promise<FileInfo[]> {

--- a/packages/filesystem/webdav/webdav.test.ts
+++ b/packages/filesystem/webdav/webdav.test.ts
@@ -161,6 +161,16 @@ describe("WebDAVFileSystem", () => {
 
       expect(mockClient.deleteFile).toHaveBeenCalledWith("/test.txt");
     });
+
+    it("应当在 404 时静默成功（幂等删除）", async () => {
+      (mockClient.deleteFile as ReturnType<typeof vi.fn>).mockRejectedValue({
+        response: { status: 404 },
+        message: "404 Not Found",
+      });
+      const fs = createTestFS(mockClient);
+
+      await expect(fs.delete("missing.txt")).resolves.toBeUndefined();
+    });
   });
 
   describe("list", () => {

--- a/packages/filesystem/webdav/webdav.ts
+++ b/packages/filesystem/webdav/webdav.ts
@@ -88,7 +88,14 @@ export default class WebDAVFileSystem implements FileSystem {
   }
 
   async delete(path: string): Promise<void> {
-    return this.client.deleteFile(joinPath(this.basePath, path));
+    try {
+      await this.client.deleteFile(joinPath(this.basePath, path));
+    } catch (e: any) {
+      if (e.response?.status === 404 || e.message?.includes("404")) {
+        return;
+      }
+      throw e;
+    }
   }
 
   async list(): Promise<FileInfo[]> {


### PR DESCRIPTION
## 背景

云同步场景下，`packages/filesystem` 这层直接决定了“认证失效后是否能恢复”和“多设备重复删除是否会被误判成失败”。

这次修正聚焦两类高风险问题：

1. 认证已失效时，底层仍可能继续返回旧 token，导致后续请求反复 401/403
2. 文件已被其他设备删除时，重复删除会被当作异常，影响同步收敛

本次修改只处理高价值、低歧义、可验证的问题，不扩大到更大范围的重构。

---

## 修正重点

### 1. 修复 `AuthVerify()` 在 token 过期后错误回退旧 token 的问题

**修改文件**
- `packages/filesystem/auth.ts`

**问题**
- 旧逻辑中，token 已过期时如果 refresh 失败，会继续返回旧 token
- 这会让调用方误以为认证仍然有效，后续请求持续失败但根因被隐藏

**修正**
- 当 token 已过期或已被判定失效时，refresh 失败直接抛错
- 不再回退到旧 token

**意义**
- 避免“认证已经坏了，但系统还继续拿旧 token 硬跑”
- 让上层更早感知真实认证问题，而不是进入反复失败状态

---

### 2. 修复 OneDrive 请求层在 token 刷新后返回旧失败结果的问题

**修改文件**
- `packages/filesystem/onedrive/onedrive.ts`

**问题**
- OneDrive `request()` 在检测到 token 失效后会刷新 token 并重试
- 但原逻辑在重试成功后，返回的仍可能是第一次失败结果，而不是第二次成功结果
- 同时，`nothen` 原始响应路径不支持 token 刷新恢复

**修正**
- 统一抽出 token 刷新后的重试逻辑
- 刷新成功后返回重试结果，而不是旧失败结果
- `nothen` 路径也支持 401 后刷新并重试
- 补上基于 HTTP 状态的错误处理

**意义**
- 避免“认证已恢复，但调用方仍收到失败结果”
- 提高 OneDrive 在 token 过期场景下的自恢复能力

---

### 3. 为 Google Drive 请求层补充更稳定的认证恢复与 HTTP 错误处理

**修改文件**
- `packages/filesystem/googledrive/googledrive.ts`

**问题**
- 原逻辑默认直接解析 JSON，HTTP 层错误不够明确
- `nothen` 原始响应路径缺少 token 自动恢复
- 删除缺失文件时会直接报错

**修正**
- 统一先检查 HTTP 状态，再解析响应
- 401 时刷新 token 后重试
- `nothen` 路径支持 token 自动恢复
- `delete()` 对“目标不存在”改为幂等成功

**意义**
- 减少 HTTP 错误被包装成 JSON 解析异常
- 提高认证恢复一致性
- 让多设备重复删除符合幂等语义

---

### 4. 为 Dropbox 请求层补充 token 恢复，并将删除改为幂等

**修改文件**
- `packages/filesystem/dropbox/dropbox.ts`

**问题**
- 原始响应路径在 token 过期后无法自动恢复
- 删除不存在文件时会抛错
- 请求头使用 `append()`，重复设置时可读性较差

**修正**
- `nothen` 路径支持 401 后刷新 token 并重试
- 正常请求也统一支持 token 自动恢复
- `delete()` 对 `path_lookup/not_found` / `path/not_found` 视为成功
- 将 Authorization 设置改为 `set()`

**意义**
- 提高 Dropbox 认证恢复能力
- 避免多设备重复删除时产生假失败
- 让请求头设置语义更明确

---

### 5. 为 WebDAV 删除补充幂等语义

**修改文件**
- `packages/filesystem/webdav/webdav.ts`

**问题**
- 删除一个已经不存在的文件会抛错
- 在云同步、多设备收敛场景下，这不应该算异常

**修正**
- `delete()` 遇到 404 时静默成功

**意义**
- 让 WebDAV 删除语义和同步场景更匹配
- 避免“文件其实已经删掉，但同步却被记成失败”

---

### 6. 为 OneDrive 删除补充幂等语义

**修改文件**
- `packages/filesystem/onedrive/onedrive.ts`

**修正**
- `delete()` 遇到 404 时静默成功

**意义**
- 和其他云盘保持一致
- 避免重复删除误报异常

---

## 测试

### 新增测试
- `packages/filesystem/auth.test.ts`
- `packages/filesystem/onedrive/onedrive.test.ts`
- `packages/filesystem/googledrive/googledrive.test.ts`
- `packages/filesystem/dropbox/dropbox.test.ts`

### 补充测试
- `packages/filesystem/webdav/webdav.test.ts`

### 覆盖内容
- token 过期时 refresh 失败不再回退旧 token
- OneDrive 刷新 token 后返回真正的重试结果
- Google Drive / Dropbox / OneDrive / WebDAV 删除不存在文件时保持幂等成功

### 验证结果
- 相关 `vitest` 测试通过
- `tsc --noEmit` 通过

---

## 影响范围

本次改动主要影响：
- token 过期/失效后的恢复路径
- 删除不存在文件时的行为
- OneDrive / Google Drive / Dropbox 的请求层错误处理一致性

不影响：
- 文件内容格式
- 上层同步协议
- 现有 `packages/filesystem` 公开接口签名

---

## 总结

这次修正的核心不是增加新能力，而是修正两类会放大同步问题的底层误判：

- **认证已失效，却继续返回旧 token**
- **文件已不存在，却把重复删除当成错误**

修完后，`packages/filesystem` 在以下场景下会更稳定：

- token 过期
- 网络波动
- 多设备重复删除
- 同步收敛过程中出现“目标已不存在”的正常状态
```