### PR TITLE
(Codex) 移除 Baidu filesystem 对全局 DNR 规则的依赖，改为请求级禁用 cookie

### DIFF
--- a/packages/filesystem/baidu/baidu.test.ts
+++ b/packages/filesystem/baidu/baidu.test.ts
@@ -3,6 +3,7 @@ import BaiduFileSystem from "./baidu";
 
 describe("BaiduFileSystem", () => {
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -11,6 +12,11 @@ describe("BaiduFileSystem", () => {
       json: async () => ({ errno: 0 }),
     });
     vi.stubGlobal("fetch", fetchMock);
+
+    // 监视 updateDynamicRules，确保不再依赖全局 DNR 规则
+    const updateDynamicRulesMock = vi.fn();
+    (chrome as any).declarativeNetRequest.updateDynamicRules = updateDynamicRulesMock;
+
     const fs = new BaiduFileSystem("/apps", "token");
 
     await expect(fs.request("https://pan.baidu.com/rest/2.0/xpan/file?method=list")).resolves.toEqual({
@@ -24,5 +30,6 @@ describe("BaiduFileSystem", () => {
         credentials: "omit",
       })
     );
+    expect(updateDynamicRulesMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/filesystem/baidu/baidu.test.ts
+++ b/packages/filesystem/baidu/baidu.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import BaiduFileSystem from "./baidu";
+
+describe("BaiduFileSystem", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("request should omit credentials without using global DNR rules", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ errno: 0 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const fs = new BaiduFileSystem("/apps", "token");
+
+    await expect(fs.request("https://pan.baidu.com/rest/2.0/xpan/file?method=list")).resolves.toEqual({
+      errno: 0,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://pan.baidu.com/rest/2.0/xpan/file?method=list",
+      expect.objectContaining({
+        credentials: "omit",
+      })
+    );
+  });
+});

--- a/packages/filesystem/baidu/baidu.ts
+++ b/packages/filesystem/baidu/baidu.ts
@@ -59,29 +59,9 @@ export default class BaiduFileSystem implements FileSystem {
   async request(url: string, config?: RequestInit) {
     config = config || {};
     const headers = <Headers>config.headers || new Headers();
-    // 处理请求匿名不发送cookie
-    await chrome.declarativeNetRequest.updateDynamicRules({
-      removeRuleIds: [100],
-      addRules: [
-        {
-          id: 100,
-          action: {
-            type: "modifyHeaders",
-            responseHeaders: [
-              {
-                operation: "remove",
-                header: "cookie",
-              },
-            ],
-          },
-          condition: {
-            urlFilter: url,
-            resourceTypes: ["xmlhttprequest"],
-          },
-        },
-      ],
-    });
     config.headers = headers;
+    // 对百度网盘请求显式禁用 cookie，避免依赖全局 DNR 规则造成并发竞态
+    config.credentials = "omit";
     return fetch(url, config)
       .then((data) => data.json())
       .then(async (data) => {
@@ -99,11 +79,6 @@ export default class BaiduFileSystem implements FileSystem {
             });
         }
         return data;
-      })
-      .finally(() => {
-        chrome.declarativeNetRequest.updateDynamicRules({
-          removeRuleIds: [100],
-        });
       });
   }
 


### PR DESCRIPTION
## 背景

`packages/filesystem/baidu/baidu.ts` 里原本为了让百度网盘请求“不带 cookie”，使用了 `chrome.declarativeNetRequest.updateDynamicRules()` 动态增删一条全局规则。

这套做法有两个核心问题：

1. 它依赖浏览器全局共享状态，而不是请求自身配置
2. 它使用固定 rule id，在并发请求下会产生竞态

在同步场景里，这意味着：
- 一个请求还没结束，另一个请求可能已经覆盖或移除了规则
- 请求是否真的不带 cookie，会变成时序相关行为
- 分页列目录、连续上传、并发同步时更容易出现偶发异常

这类问题不一定每次都复现，但一旦出现，会非常难排查。

---

## 本次修改

### 修改文件
- `packages/filesystem/baidu/baidu.ts`

### 修改内容
- 删除请求前的 `chrome.declarativeNetRequest.updateDynamicRules(...)`
- 删除请求完成后的动态规则清理逻辑
- 改为在 Baidu 请求中直接设置：
  - `credentials: "omit"`

---

## 修改意图

这次不是改变 Baidu 请求的业务语义，而是把“不要带 cookie”从**全局副作用**改成**请求内显式行为**。

核心意图：

1. 保留原始目标  
   - 仍然是不带 cookie 访问百度网盘接口

2. 去掉全局共享状态  
   - 不再依赖动态 DNR 规则
   - 不再依赖固定 rule id

3. 消除并发竞态  
   - 每个请求自己决定是否带 cookie
   - 请求之间互不影响

---

## 为什么这样改

原实现的问题，不是“是否禁用 cookie”，而是“禁用 cookie 的方式不安全”。

用全局 DNR 规则做这件事，会把一个本该属于单请求配置的问题，扩大成浏览器层面的共享状态问题。

这在以下场景中尤其危险：
- 多个 Baidu API 请求并发
- 同步过程中连续分页请求
- 上传、删除、列目录交错发生
- 网络不稳定导致请求耗时拉长

改成 `credentials: "omit"` 后：
- 行为更直接
- 作用域更小
- 并发更安全
- 也更符合 fetch 本身的语义

---

## 测试

### 新增测试
- `packages/filesystem/baidu/baidu.test.ts`

### 覆盖内容
- Baidu 请求会显式使用 `credentials: "omit"`
- 不再依赖全局 DNR 规则来实现“不带 cookie”

### 验证结果
- `vitest` 通过
- `tsc --noEmit` 通过

---

## 影响范围

本次改动只影响 Baidu filesystem 请求层的 cookie 处理方式。

不影响：
- Baidu 文件读写协议
- token 刷新逻辑
- 上层同步协议
- 现有 filesystem 接口签名

---

## 预期收益

这次修正后，Baidu filesystem 在同步场景下会更稳定：

- 请求行为不再依赖全局动态规则
- 并发请求之间不会互相覆盖或互相清理规则
- 能减少百度网盘同步中的偶发认证/请求异常
- 更适合多请求并发和网络抖动场景

---

## 总结

这次修的重点不是“新增功能”，而是去掉一个高风险实现方式：

- 以前：用全局 DNR 规则间接控制请求是否带 cookie
- 现在：用请求自身的 `credentials: "omit"` 明确控制

也就是把一个容易竞态、难排查的问题，收敛成单请求内可预期的行为。
