### PR TITLE
安装页的 loadingStatus 改用 monospace 避免跳动

### DIFF
--- a/src/pages/install/App.tsx
+++ b/src/pages/install/App.tsx
@@ -732,7 +732,7 @@ function App() {
             <>
               <Typography.Title heading={3}>{t("install_page_loading")}</Typography.Title>
               <div className="downloading">
-                <Typography.Text>{fetchingState.loadingStatus}</Typography.Text>
+                <Typography.Text style={{ fontFamily: "monospace" }}>{fetchingState.loadingStatus}</Typography.Text>
                 <div className="loader"></div>
               </div>
             </>


### PR DESCRIPTION
<img width="374" height="112" alt="Screenshot 2026-04-27 at 0 22 18" src="https://github.com/user-attachments/assets/3966b622-0edb-4591-8b89-9f7937b6ddf5" />

字体不使用 monospace 的话，数字跳动会同时改变字阔
monospace 则不会