### PR TITLE
🐛 修复 脚本管理页面的tooltip提示被遮挡问题 (#1386)

### DIFF
--- a/src/pages/components/layout/Sider.tsx
+++ b/src/pages/components/layout/Sider.tsx
@@ -169,7 +169,7 @@ const Sider: React.FC = () => {
       <Layout.Content
         style={{
           borderLeft: "1px solid var(--color-bg-5)",
-          overflow: "hidden",
+          // overflow: "hidden", //fix: 避免 tooltip 被遮挡
           padding: 0,
           height: "auto",
           boxSizing: "border-box",


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

## Screenshots / 截图

<!-- Screenshots / 截图-->
<img width="769" height="263" alt="PixPin_2026-04-30_14-32-02" src="https://github.com/user-attachments/assets/428f5ab8-429c-4982-bec5-0e5cf7b8378b" />

<img width="1280" height="137" alt="PixPin_2026-04-30_14-32-34" src="https://github.com/user-attachments/assets/6e20babc-30d0-4736-aa3e-c6699323ba7b" />
