### PR TITLE
fix(sync): (Codex) OneDrive createDir recursion

### DIFF
--- a/packages/filesystem/onedrive/onedrive.test.ts
+++ b/packages/filesystem/onedrive/onedrive.test.ts
@@ -93,4 +93,38 @@ describe("OneDriveFileSystem", () => {
 
     await expect(fs.delete("missing.txt")).resolves.toBeUndefined();
   });
+
+  it("createDir should create nested directories from root", async () => {
+    const fs = new OneDriveFileSystem("/", "token");
+    const requestSpy = vi.spyOn(fs, "request").mockResolvedValue({});
+
+    await expect(fs.createDir("A/B/C")).resolves.toBeUndefined();
+
+    expect(requestSpy).toHaveBeenCalledTimes(3);
+    expect(requestSpy.mock.calls[0][0]).toBe("https://graph.microsoft.com/v1.0/me/drive/special/approot/children");
+    expect(requestSpy.mock.calls[1][0]).toBe("https://graph.microsoft.com/v1.0/me/drive/special/approot:/A:/children");
+    expect(requestSpy.mock.calls[2][0]).toBe(
+      "https://graph.microsoft.com/v1.0/me/drive/special/approot:/A/B:/children"
+    );
+    expect(JSON.parse((requestSpy.mock.calls[2][1] as RequestInit).body as string)).toMatchObject({
+      name: "C",
+      folder: {},
+      "@microsoft.graph.conflictBehavior": "fail",
+    });
+  });
+
+  it("createDir should continue when an intermediate directory already exists", async () => {
+    const fs = new OneDriveFileSystem("/", "token");
+    const requestSpy = vi
+      .spyOn(fs, "request")
+      .mockRejectedValueOnce(new Error('{"error":{"code":"nameAlreadyExists"}}'))
+      .mockResolvedValueOnce({});
+
+    await expect(fs.createDir("A/B")).resolves.toBeUndefined();
+
+    expect(requestSpy).toHaveBeenCalledTimes(2);
+    expect(JSON.parse((requestSpy.mock.calls[1][1] as RequestInit).body as string)).toMatchObject({
+      name: "B",
+    });
+  });
 });

--- a/packages/filesystem/onedrive/onedrive.ts
+++ b/packages/filesystem/onedrive/onedrive.ts
@@ -45,29 +45,35 @@ export default class OneDriveFileSystem implements FileSystem {
     if (!dir) {
       return;
     }
-    dir = joinPath(this.path, dir);
-    const dirs = dir.split("/");
-    let parent = "";
-    if (dirs.length > 2) {
-      parent = dirs.slice(0, dirs.length - 1).join("/");
-    }
+    const dirs = joinPath(this.path, dir).split("/").filter(Boolean);
     const myHeaders = new Headers();
     myHeaders.append("Content-Type", "application/json");
-    if (parent !== "") {
-      parent = `:${parent}:`;
+
+    for (let i = 0; i < dirs.length; i++) {
+      const parentPath = dirs.slice(0, i).join("/");
+      const parent = parentPath ? `:/${parentPath}:` : "";
+      try {
+        await this.request(`https://graph.microsoft.com/v1.0/me/drive/special/approot${parent}/children`, {
+          method: "POST",
+          headers: myHeaders,
+          body: JSON.stringify({
+            name: dirs[i],
+            folder: {},
+            "@microsoft.graph.conflictBehavior": "fail",
+          }),
+        });
+      } catch (error) {
+        if (this.isDirectoryAlreadyExistsError(error)) {
+          continue;
+        }
+        throw error;
+      }
     }
-    const data = await this.request(`https://graph.microsoft.com/v1.0/me/drive/special/approot${parent}/children`, {
-      method: "POST",
-      headers: myHeaders,
-      body: JSON.stringify({
-        name: dirs[dirs.length - 1],
-        folder: {},
-        "@microsoft.graph.conflictBehavior": "replace",
-      }),
-    });
-    if (data.errno) {
-      throw new Error(JSON.stringify(data));
-    }
+  }
+
+  private isDirectoryAlreadyExistsError(error: unknown): boolean {
+    const msg = String(error);
+    return msg.includes("nameAlreadyExists") || msg.includes("itemAlreadyExists");
   }
 
   request(url: string, config?: RequestInit, nothen?: boolean): Promise<Response | any> {


### PR DESCRIPTION
`createDir("A/B/C")` 现在会从 OneDrive app root 开始逐层创建 `A`、`B`、`C`，而不是直接尝试在尚未存在的 `A/B` 下创建 `C`。同时保留原有 `ScriptCat` 前缀兼容逻辑，并把 OneDrive 返回的目录已存在冲突视为成功，以符合 `mkdir -p` 语义；其它错误仍会抛出。

补了两个测试：验证嵌套目录会按层级发请求，以及中间目录已存在时会继续创建子目录。