### PR TITLE
fix(sync): (Codex) Google Drive `ensureDirExists()` 接口语义不一致

### DIFF
--- a/packages/filesystem/googledrive/googledrive.test.ts
+++ b/packages/filesystem/googledrive/googledrive.test.ts
@@ -25,4 +25,38 @@ describe("GoogleDriveFileSystem", () => {
 
     await expect(fs.delete("missing.txt")).resolves.toBeUndefined();
   });
+
+  it("ensureDirExists should create missing nested directories and return final id", async () => {
+    const fs = new GoogleDriveFileSystem("/", "token");
+    const findSpy = vi.spyOn(fs, "findFolderByName").mockResolvedValue(null);
+    const createSpy = vi
+      .spyOn(fs, "createFolder")
+      .mockResolvedValueOnce({ id: "id-A", name: "A" })
+      .mockResolvedValueOnce({ id: "id-B", name: "B" });
+
+    await expect(fs.ensureDirExists("/A/B")).resolves.toBe("id-B");
+
+    expect(findSpy.mock.calls).toEqual([
+      ["A", "appDataFolder"],
+      ["B", "id-A"],
+    ]);
+    expect(createSpy.mock.calls).toEqual([
+      ["A", "appDataFolder"],
+      ["B", "id-A"],
+    ]);
+  });
+
+  it("writer should ensure directory from root when filesystem is opened in subdir", async () => {
+    const fs = new GoogleDriveFileSystem("/Base", "token");
+    const writer = await fs.create("file.txt");
+    const ensureSpy = vi.spyOn(fs, "ensureDirExists").mockResolvedValue("base-id");
+    const findSpy = vi.spyOn(fs, "findFileInDirectory").mockResolvedValue(null);
+    const requestSpy = vi.spyOn(fs, "request").mockResolvedValue({});
+
+    await expect(writer.write("content")).resolves.toBeUndefined();
+
+    expect(ensureSpy).toHaveBeenCalledWith("/Base");
+    expect(findSpy).toHaveBeenCalledWith("file.txt", "base-id");
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/filesystem/googledrive/googledrive.ts
+++ b/packages/filesystem/googledrive/googledrive.ts
@@ -40,6 +40,14 @@ export default class GoogleDriveFileSystem implements FileSystem {
     }
 
     const fullPath = joinPath(this.path, dir);
+    await this.ensureDirPath(fullPath);
+  }
+
+  private async ensureDirPath(fullPath: string): Promise<string> {
+    if (fullPath === "/" || fullPath === "") {
+      return "appDataFolder";
+    }
+
     const dirs = fullPath.split("/").filter(Boolean);
 
     // 从根目录开始逐级创建目录
@@ -69,7 +77,7 @@ export default class GoogleDriveFileSystem implements FileSystem {
       parentId = folderId;
     }
 
-    return Promise.resolve();
+    return parentId;
   }
   async findFolderByName(name: string, parentId: string): Promise<{ id: string; name: string } | null> {
     const query = `name='${name}' and mimeType='application/vnd.google-apps.folder' and '${parentId}' in parents and trashed=false`;
@@ -315,24 +323,6 @@ export default class GoogleDriveFileSystem implements FileSystem {
 
   // 确保目录存在并返回目录ID，优化Writer避免重复获取
   async ensureDirExists(dirPath: string): Promise<string> {
-    if (dirPath === "/" || dirPath === "") {
-      return "appDataFolder";
-    }
-
-    // 先检查缓存
-    const cachedId = this.pathToIdCache.get(dirPath);
-    if (cachedId) {
-      return cachedId;
-    }
-
-    // 如果没有缓存，使用getFileId方法
-    const foundId = await this.getFileId(dirPath);
-    if (!foundId) {
-      throw new Error(`Failed to create or find directory: ${dirPath}`);
-    }
-
-    // 缓存结果
-    this.pathToIdCache.set(dirPath, foundId);
-    return foundId;
+    return this.ensureDirPath(dirPath);
   }
 }


### PR DESCRIPTION
原本 `ensureDirExists(dirPath)` 名字表示“确保目录存在”，但实际只做查找；目录不存在就抛错。现在改成真正逐级确保目录存在，并返回最终目录 ID。

- `createDir()` 和 `ensureDirExists()` 现在共用同一套内部逻辑 `ensureDirPath()`
- `ensureDirPath()` 从 Google Drive `appDataFolder` 根目录开始逐级查找目录
- 找到就复用并缓存 ID
- 找不到就调用 `createFolder()` 创建，再缓存 ID
- `ensureDirExists("/A/B")` 现在会真的确保 `/A/B` 存在，并返回 `B` 的 folder id

这个修正主要解决 writer 路径问题。`GoogleDriveFileWriter.write()` 原本依赖 `ensureDirExists()`，但如果上层没先建目录，写入会失败。现在 writer 自己调用 `ensureDirExists()` 时，目录缺失也能正确创建。

同时避免了一个陷阱：没有让 `ensureDirExists()` 直接调用 `createDir()`，因为在 `openDir("/Base")` 后写文件时，直接调用 `createDir("/Base")` 可能被拼成重复路径 `/Base/Base`。所以这次抽了 root-based 的内部 helper。

测试补在 googledrive.test.ts

- 验证 `ensureDirExists("/A/B")` 会创建缺失的嵌套目录并返回最终 ID
- 验证在子目录 filesystem 里写文件时，writer 使用的是 `/Base`，不会变成重复路径
