### PR TITLE
fix(sync): (Codex) OAuth refresh token race

### DIFF
--- a/packages/filesystem/auth.test.ts
+++ b/packages/filesystem/auth.test.ts
@@ -42,4 +42,30 @@ describe("AuthVerify", () => {
     await expect(AuthVerify("onedrive")).resolves.toBe("cached-access");
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("concurrent expired token verification should share one refresh request", async () => {
+    await localStorageDAO.saveValue(key, {
+      accessToken: "old-access",
+      refreshToken: "old-refresh",
+      createtime: Date.now() - 3600000 - 1000,
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        code: 0,
+        data: {
+          token: {
+            access_token: "new-access",
+            refresh_token: "new-refresh",
+          },
+        },
+      }),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      Promise.all([AuthVerify("onedrive"), AuthVerify("onedrive"), AuthVerify("onedrive")])
+    ).resolves.toEqual(["new-access", "new-access", "new-access"]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/filesystem/auth.ts
+++ b/packages/filesystem/auth.ts
@@ -73,6 +73,47 @@ export type Token = {
   refreshToken: string;
   createtime: number;
 };
+const refreshTokenPromises: Partial<Record<NetDiskType, Promise<string>>> = {};
+
+function refreshAccessToken(
+  netDiskType: NetDiskType,
+  token: Token,
+  invalid: boolean | undefined,
+  key: string,
+  localStorageDAO: LocalStorageDAO
+) {
+  if (refreshTokenPromises[netDiskType]) {
+    return refreshTokenPromises[netDiskType];
+  }
+
+  const refreshPromiseFn = async () => {
+    const resp = await RefreshToken(netDiskType, token.refreshToken);
+    if (resp.code !== 0) {
+      await localStorageDAO.delete(key);
+      // 刷新失败,并且标记失效,尝试重新获取token
+      if (invalid) {
+        return await AuthVerify(netDiskType);
+      }
+      throw new WarpTokenError(new Error(resp.msg));
+    }
+    const newToken = {
+      accessToken: resp.data.token.access_token,
+      refreshToken: resp.data.token.refresh_token,
+      createtime: Date.now(),
+    };
+    // 更新token
+    await localStorageDAO.saveValue(key, newToken);
+    return newToken.accessToken;
+  };
+  const refreshPromise: Promise<string> = refreshPromiseFn().finally(() => {
+    if (refreshTokenPromises[netDiskType] === refreshPromise) {
+      delete refreshTokenPromises[netDiskType];
+    }
+  });
+
+  refreshTokenPromises[netDiskType] = refreshPromise;
+  return refreshPromise;
+}
 
 export async function AuthVerify(netDiskType: NetDiskType, invalid?: boolean) {
   let token: Token | undefined = undefined;
@@ -99,36 +140,16 @@ export async function AuthVerify(netDiskType: NetDiskType, invalid?: boolean) {
     invalid = false;
     await localStorageDAO.saveValue(key, token);
   }
-  // token过期或者失效
+  // token过期(大于一小时)或者失效 -> 刷新token
   const expired = Date.now() >= token.createtime + 3600000;
-  if (expired || invalid) {
-    // 大于一小时刷新token
-    try {
-      const resp = await RefreshToken(netDiskType, token.refreshToken);
-      if (resp.code !== 0) {
-        await localStorageDAO.delete(key);
-        // 刷新失败,并且标记失效,尝试重新获取token
-        if (invalid) {
-          return await AuthVerify(netDiskType);
-        }
-        throw new WarpTokenError(new Error(resp.msg));
-      }
-      token = {
-        accessToken: resp.data.token.access_token,
-        refreshToken: resp.data.token.refresh_token,
-        createtime: Date.now(),
-      };
-      // 更新token
-      await localStorageDAO.saveValue(key, token);
-    } catch (e) {
-      // 已过期或已被服务端判定失效的 token 不能继续回退使用
-      console.warn(e);
-      throw e;
-    }
-  } else {
-    return token.accessToken;
+  if (!expired && !invalid) return token.accessToken;
+  try {
+    return await refreshAccessToken(netDiskType, token, invalid, key, localStorageDAO);
+  } catch (e) {
+    // 已过期或已被服务端判定失效的 token 不能继续回退使用
+    console.warn(e);
+    throw e;
   }
-  return token.accessToken;
 }
 
 export const netDiskTypeMap: Partial<Record<FileSystemType, NetDiskType>> = {

--- a/packages/filesystem/auth.ts
+++ b/packages/filesystem/auth.ts
@@ -140,9 +140,9 @@ export async function AuthVerify(netDiskType: NetDiskType, invalid?: boolean) {
     invalid = false;
     await localStorageDAO.saveValue(key, token);
   }
-  // token过期(大于一小时)或者失效 -> 刷新token
-  const expired = Date.now() >= token.createtime + 3600000;
-  if (!expired && !invalid) return token.accessToken;
+  // token未过期(一小时内)及有效则保留，不用刷新token
+  const unexpired = Date.now() < token.createtime + 3600000;
+  if (unexpired && !invalid) return token.accessToken;
   try {
     return await refreshAccessToken(netDiskType, token, invalid, key, localStorageDAO);
   } catch (e) {


### PR DESCRIPTION
在 auth.ts 加入以 NetDiskType 为 key 的 refreshTokenPromises。同一个云端 provider 的多个并行 AuthVerify() 如果同时遇到过期或失效 token，现在会共用同一个 refresh promise；第一个请求负责刷新并写回新 token，其余请求等待同一结果，避免用已被旋转失效的 refresh token 重复刷新。

同时在 auth.test.ts 加了回归测试：三个并行 AuthVerify("onedrive") 只会触发一次 fetch refresh，并全部拿到新的 access token。

