### PR TITLE
fix(sync): (Codex) Dropbox exists swallows auth errors

### DIFF
--- a/packages/filesystem/dropbox/dropbox.test.ts
+++ b/packages/filesystem/dropbox/dropbox.test.ts
@@ -14,4 +14,20 @@ describe("DropboxFileSystem", () => {
 
     await expect(fs.delete("missing.txt")).resolves.toBeUndefined();
   });
+
+  it("exists should return false on path not found", async () => {
+    const fs = new DropboxFileSystem("/", "token");
+    vi.spyOn(fs, "request").mockRejectedValue(
+      new Error('Dropbox API Error: 409 - {"error_summary":"path/not_found/..."}')
+    );
+
+    await expect(fs.exists("/missing.txt")).resolves.toBe(false);
+  });
+
+  it("exists should rethrow auth and network errors", async () => {
+    const fs = new DropboxFileSystem("/", "token");
+    vi.spyOn(fs, "request").mockRejectedValue(new Error("Dropbox API Error: 401 - invalid_access_token"));
+
+    await expect(fs.exists("/test.txt")).rejects.toThrow("invalid_access_token");
+  });
 });

--- a/packages/filesystem/dropbox/dropbox.ts
+++ b/packages/filesystem/dropbox/dropbox.ts
@@ -4,6 +4,11 @@ import type { FileInfo, FileCreateOptions, FileReader, FileWriter } from "../fil
 import { joinPath } from "../utils";
 import { DropboxFileReader, DropboxFileWriter } from "./rw";
 
+function isDropboxPathNotFound(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("path_lookup/not_found") || message.includes("path/not_found");
+}
+
 export default class DropboxFileSystem implements FileSystem {
   accessToken?: string;
 
@@ -149,7 +154,7 @@ export default class DropboxFileSystem implements FileSystem {
         }),
       });
     } catch (e: any) {
-      if (e.message?.includes("path_lookup/not_found") || e.message?.includes("path/not_found")) {
+      if (isDropboxPathNotFound(e)) {
         return;
       }
       throw e;
@@ -241,8 +246,11 @@ export default class DropboxFileSystem implements FileSystem {
         }),
       });
       return true;
-    } catch (_) {
-      return false;
+    } catch (e) {
+      if (isDropboxPathNotFound(e)) {
+        return false;
+      }
+      throw e;
     }
   }
 


### PR DESCRIPTION
`exists()` 现在只把 Dropbox 明确返回的「路径不存在」视为 `false`；如果是认证失败、网络错误、服务端错误等异常，会继续抛出，不再被误判成文件不存在。这样 `DropboxFileWriter.write()` 不会在 token 失效或网络异常时错误地走“创建新文件”逻辑。

- 新增 `isDropboxPathNotFound()`，统一判断 Dropbox 的 `path/not_found` / `path_lookup/not_found`。
- 新增 `exists()` 的路径不存在与 auth error 回归测试。
