### PR TITLE
fix(sync): (Codex) WebDAV `verify()` 过弱

### DIFF
--- a/packages/filesystem/webdav/webdav.test.ts
+++ b/packages/filesystem/webdav/webdav.test.ts
@@ -70,14 +70,24 @@ describe("WebDAVFileSystem", () => {
   });
 
   describe("verify", () => {
-    it("应当成功验证", async () => {
+    it("应当通过列目录、写入探针文件和清理探针完成验证", async () => {
       const fs = createTestFS(mockClient);
 
       await expect(fs.verify()).resolves.toBeUndefined();
       expect(mockClient.getQuota).toHaveBeenCalled();
+      expect(mockClient.getDirectoryContents).toHaveBeenCalledWith("/");
+      expect(mockClient.createDirectory).toHaveBeenCalledWith(expect.stringMatching(/^\/\.scriptcat-verify-/));
+      expect(mockClient.putFileContents).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/\.scriptcat-verify-.+\/probe\.txt$/),
+        ""
+      );
+      expect(mockClient.deleteFile).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/\.scriptcat-verify-.+\/probe\.txt$/)
+      );
+      expect(mockClient.deleteFile).toHaveBeenCalledWith(expect.stringMatching(/^\/\.scriptcat-verify-/));
     });
 
-    it("应当在 401 时抛出 WarpTokenError", async () => {
+    it("应当在 401 时抛出 WarpTokenError 1", async () => {
       (mockClient.getQuota as ReturnType<typeof vi.fn>).mockRejectedValue({
         response: { status: 401 },
         message: "Unauthorized",
@@ -87,13 +97,47 @@ describe("WebDAVFileSystem", () => {
       await expect(fs.verify()).rejects.toBeInstanceOf(WarpTokenError);
     });
 
-    it("应当在其他错误时抛出包含原始信息的 Error", async () => {
+    it("应当在 401 时抛出 WarpTokenError 2", async () => {
+      (mockClient.getDirectoryContents as ReturnType<typeof vi.fn>).mockRejectedValue({
+        response: { status: 401 },
+        message: "Unauthorized",
+      });
+      const fs = createTestFS(mockClient);
+
+      await expect(fs.verify()).rejects.toBeInstanceOf(WarpTokenError);
+    });
+
+    it("应当在其他错误时抛出包含原始信息的 Error 1", async () => {
       (mockClient.getQuota as ReturnType<typeof vi.fn>).mockRejectedValue({
         message: "Network error",
       });
       const fs = createTestFS(mockClient);
 
       await expect(fs.verify()).rejects.toThrow("WebDAV verify failed: Network error");
+    });
+
+    it("应当在其他错误时抛出包含原始信息的 Error 2", async () => {
+      (mockClient.getDirectoryContents as ReturnType<typeof vi.fn>).mockRejectedValue({
+        message: "Network error",
+      });
+      const fs = createTestFS(mockClient);
+
+      await expect(fs.verify()).rejects.toThrow("WebDAV verify failed: Network error");
+    });
+
+    it("应当在无法写入探针文件时验证失败并清理探针目录", async () => {
+      (mockClient.putFileContents as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+      const fs = createTestFS(mockClient);
+
+      await expect(fs.verify()).rejects.toThrow("WebDAV verify failed: probe file write returned false");
+      expect(mockClient.deleteFile).toHaveBeenCalledWith(expect.stringMatching(/^\/\.scriptcat-verify-/));
+    });
+
+    it("应当在删除探针文件失败时验证失败", async () => {
+      (mockClient.deleteFile as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("Delete denied"));
+      const fs = createTestFS(mockClient);
+
+      await expect(fs.verify()).rejects.toThrow("WebDAV verify failed: Delete denied");
     });
   });
 

--- a/packages/filesystem/webdav/webdav.ts
+++ b/packages/filesystem/webdav/webdav.ts
@@ -53,13 +53,40 @@ export default class WebDAVFileSystem implements FileSystem {
   }
 
   async verify(): Promise<void> {
+    const verifyDir = joinPath(this.basePath, `.scriptcat-verify-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const verifyFile = joinPath(verifyDir, "probe.txt");
+    let dirCreated = false;
+    let fileCreated = false;
+
     try {
       await this.client.getQuota();
+      await this.client.getDirectoryContents(this.basePath);
+      await this.client.createDirectory(verifyDir);
+      dirCreated = true;
+      const written = await this.client.putFileContents(verifyFile, "");
+      if (!written) {
+        throw new Error("probe file write returned false");
+      }
+      fileCreated = true;
+      await this.client.deleteFile(verifyFile);
+      fileCreated = false;
+      await this.client.deleteFile(verifyDir);
+      dirCreated = false;
     } catch (e: any) {
+      await this.cleanupVerifyProbe(verifyFile, verifyDir, fileCreated, dirCreated);
       if (e.response?.status === 401) {
         throw new WarpTokenError(e);
       }
       throw new Error(`WebDAV verify failed: ${e.message}`); // 保留原始信息
+    }
+  }
+
+  private async cleanupVerifyProbe(verifyFile: string, verifyDir: string, fileCreated: boolean, dirCreated: boolean) {
+    if (fileCreated) {
+      await this.client.deleteFile(verifyFile).catch(() => undefined);
+    }
+    if (dirCreated) {
+      await this.client.deleteFile(verifyDir).catch(() => undefined);
     }
   }
 


### PR DESCRIPTION
`verify()` 不再只检查 `getQuota()`，而是验证 WebDAV 同步实际需要的能力：能列出目录、能创建临时目录、能写入探针文件、能删除探针文件和临时目录。这样能提前发现“账号能连上但没有写入/删除权限”的配置问题。401 仍会转换为 `WarpTokenError`，其他失败会保留为 `WebDAV verify failed: ...`。