### PR TITLE
fix: create_context 的空物件改为 Object.create(null)

### DIFF
--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -8,6 +8,8 @@ import { isEarlyStartScript } from "./utils";
 import { ListenerManager } from "./listener_manager";
 import { createGMBase } from "./gm_api/gm_api";
 
+// 不要使用 {}, 改使用 Object.create(null) - 避免在页面生成沙盒时，受到 Object.prototype 被注入的影响
+
 // 构建沙盒上下文
 export const createContext = (
   scriptRes: TScriptInfo,
@@ -62,7 +64,7 @@ export const createContext = (
       return invalid;
     },
   });
-  const grantedAPIs: { [key: string]: any } = {};
+  const grantedAPIs: { [key: string]: any } = Object.create(null);
   const __methodInject__ = (grant: string): boolean => {
     const grantSet: Set<string> = context.grantSet;
     const s = GMContextApiGet(grant);
@@ -98,7 +100,7 @@ export const createContext = (
     for (let i = 0; i < m; i++) {
       const part = fnKeyArray[i];
       s += `${i ? "." : ""}${part}`;
-      g = g[part] || (g[part] = grantedAPIs[s] || {});
+      g = g[part] || (g[part] = grantedAPIs[s] || Object.create(null));
     }
   }
   context.unsafeWindow = window;
@@ -166,10 +168,10 @@ const initOwnDescs = Object.getOwnPropertyDescriptors(global);
 
 // overridedDescs将以物件OwnPropertyDescriptor方式进行物件属性修改
 // 覆盖原有的 OwnPropertyDescriptor定义 或 父类的PropertyDescriptor定义
-const overridedDescs: Record<string, PropertyDescriptor> = {};
+const overridedDescs: Record<string, PropertyDescriptor> = Object.create(null);
 
 // 记录原生 onxxxxx 的 PropertyDescriptor
-const eventDescs: Record<string, PropertyDescriptor> = {};
+const eventDescs: Record<string, PropertyDescriptor> = Object.create(null);
 
 // 包含物件本身及所有父类(不包含Object)的PropertyDescriptor
 // 主要是找出哪些 function值， setter/getter 需要替换 global window

--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -31,6 +31,8 @@ export const createContext = (
     });
   }
   let invalid = false;
+  const GM = Object.create(null);
+  GM.info = GMInfo;
   const context = createGMBase({
     prefix: envPrefix,
     message,
@@ -40,11 +42,9 @@ export const createContext = (
     EE,
     runFlag: uuidv4(),
     eventId: 10000,
-    GM: { info: GMInfo },
+    GM: GM,
     GM_info: GMInfo,
-    window: {
-      // onurlchange: null,
-    },
+    window: Object.create(null),
     grantSet: new Set(),
     loadScriptPromise,
     loadScriptResolve,

--- a/src/app/service/content/exec_script.ts
+++ b/src/app/service/content/exec_script.ts
@@ -55,7 +55,7 @@ export default class ExecScript {
       // 在不改变 Context 的情况下，以 named 传入多个全域变量
       const GM = Object.create(null);
       GM.info = GM_info;
-      this.named = { GM: { info: GM_info }, GM_info };
+      this.named = { GM, GM_info };
     } else {
       // 构建脚本GM上下文
       this.sandboxContext = createContext(scriptRes, GM_info, envPrefix, message, contentMsg, grantSet);

--- a/src/app/service/content/exec_script.ts
+++ b/src/app/service/content/exec_script.ts
@@ -53,6 +53,8 @@ export default class ExecScript {
       // 不注入任何GM api
       // ScriptCat行为：GM.info 和 GM_info 同时注入
       // 在不改变 Context 的情况下，以 named 传入多个全域变量
+      const GM = Object.create(null);
+      GM.info = GM_info;
       this.named = { GM: { info: GM_info }, GM_info };
     } else {
       // 构建脚本GM上下文


### PR DESCRIPTION
## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

有点难重视。但我确实遇到了这个问题
当其他脚本先注入到环境，例如用了 `@unwrap`，又或者是其他 userscript manager, 又或者是其他 浏览器扩充直接插入 page script

当它们进行以下的 `Object.prototype` 骑劫后，

```js
Object.defineProperty(Object.prototype, "test", {
    set(_newValue) {
        if (!this.testComplete) {
            // do Something
            this.testComplete = true;
        }
    },
    get() {
        return 1;
    }
});
```

这样的话，如果直接用 `const desc = {}`, 然后

```js
desc["test"] = {
    enumerable: true,
    configurable: true,
    value: 123
    writeable: true,
};
```

这样就会在 desc 里生成一个 `testComplete: true`

最终 `Object.create` 就会失败然后完全崩溃

解決方法是把 `{}` 改成 `Object.create(null)`

## Screenshots / 截图

<!-- Screenshots / 截图-->
