### PR TITLE
fix: 修复 ScriptCat 长时间运行时可能出现的内存泄漏问题

### DIFF
--- a/src/app/service/content/gm_api/gm_xhr.ts
+++ b/src/app/service/content/gm_api/gm_xhr.ts
@@ -290,6 +290,7 @@ export function GM_xmlhttpRequest(
       onMessageHandler = null;
       doAbort = null;
       refCleanup = null;
+      connect?.disconnect(); // 确保 connect 断开
       connect = null;
     };
 
@@ -529,14 +530,22 @@ export function GM_xmlhttpRequest(
         };
         if (msgData.code === -1) {
           // 处理错误
+          const message = msgData.message || "unknown";
+          const code = msgData.code;
           LoggerCore.logger().error("GM_xmlhttpRequest error", {
-            code: msgData.code,
-            message: msgData.message,
+            code: code,
+            message,
           });
-          details.onerror?.({
-            readyState: ReadyStateCode.DONE,
-            error: msgData.message || "unknown",
-          });
+          if (!reqDone) {
+            errorOccur = message;
+            details.onerror?.({
+              readyState: ReadyStateCode.DONE,
+              error: message,
+            });
+            reqDone = true;
+            retPromiseReject?.(message);
+            refCleanup?.();
+          }
           return;
         }
         // 处理返回

--- a/src/app/service/service_worker/gm_api/gm_api.ts
+++ b/src/app/service/service_worker/gm_api/gm_api.ts
@@ -109,6 +109,7 @@ const cleanupOnAPIError = (requestId: string) => {
   if (!markerID) return;
   redirectedUrls.delete(markerID);
   nwErrorResults.delete(markerID);
+  nwErrorResultPromises.delete(markerID);
   scXhrRequests.delete(markerID);
   headersReceivedMap.delete(markerID);
   headersSettled(markerID); // 处理完毕
@@ -891,6 +892,7 @@ export default class GMApi {
       const loadendCleanUp = () => {
         redirectedUrls.delete(markerID);
         nwErrorResults.delete(markerID);
+        nwErrorResultPromises.delete(markerID);
         const reqId = scXhrRequests.get(markerID);
         if (reqId) scXhrRequests.delete(reqId);
         scXhrRequests.delete(markerID);

--- a/src/app/service/service_worker/gm_api/gm_xhr.ts
+++ b/src/app/service/service_worker/gm_api/gm_xhr.ts
@@ -110,6 +110,7 @@ export class GMXhrFetchStrategy implements GMXhrStrategy {
           }),
           new Promise((r) => setTimeout(r, 800)),
         ]);
+        nwErrorResultPromises.delete(this.resultParam.markerID);
         nwErr = nwErrorResults.get(this.resultParam.markerID);
       }
       if (nwErr) {

--- a/src/pkg/utils/match.test.ts
+++ b/src/pkg/utils/match.test.ts
@@ -42,6 +42,20 @@ describe.concurrent("UrlMatch-internal1", () => {
   });
 });
 
+describe.concurrent("UrlMatch-cache", () => {
+  it.concurrent("limits cached URL entries and refreshes recently used entries", () => {
+    const url = new UrlMatch<string>(2);
+    url.addMatch("*://*/*", "ok");
+
+    expect(url.urlMatch("https://a.example/")).toEqual(["ok"]);
+    expect(url.urlMatch("https://b.example/")).toEqual(["ok"]);
+    expect(url.urlMatch("https://a.example/")).toEqual(["ok"]);
+    expect(url.urlMatch("https://c.example/")).toEqual(["ok"]);
+
+    expect([...url.cacheMap.keys()]).toEqual(["https://a.example/", "https://c.example/"]);
+  });
+});
+
 describe.concurrent("UrlMatch-internal2", () => {
   const url = new UrlMatch<string>();
   url.addInclude("*gro???***???.com*", "ok1");

--- a/src/pkg/utils/match.ts
+++ b/src/pkg/utils/match.ts
@@ -6,6 +6,10 @@ export class UrlMatch<T> {
   public readonly cacheMap = new Map<string, T[]>();
   private sorter: Partial<Record<string, number>> | null = null;
 
+  constructor(private readonly maxCacheEntries: number = 4096) {
+    if (this.maxCacheEntries <= 0) throw new Error(`maxCacheEntries ${this.maxCacheEntries} <= 0`);
+  }
+
   public addRules(uuid: T, rules: URLRuleEntry[]) {
     this.cacheMap.clear();
     let map = this.rulesMap.get(uuid);
@@ -15,7 +19,12 @@ export class UrlMatch<T> {
 
   public urlMatch(url: string): T[] {
     const cacheMap = this.cacheMap;
-    if (cacheMap.has(url)) return cacheMap.get(url) as T[];
+    if (cacheMap.has(url)) {
+      const cached = cacheMap.get(url) as T[];
+      cacheMap.delete(url);
+      cacheMap.set(url, cached);
+      return cached;
+    }
     const res: T[] = [];
     for (const [uuid, rules] of this.rulesMap) {
       try {
@@ -38,6 +47,10 @@ export class UrlMatch<T> {
       });
     }
     cacheMap.set(url, res);
+    if (cacheMap.size > this.maxCacheEntries) {
+      const oldest = cacheMap.keys().next().value;
+      if (oldest !== undefined) cacheMap.delete(oldest);
+    }
     return res;
   }
 


### PR DESCRIPTION
## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

### 变更内容

* 为 UrlMatch URL 匹配缓存增加 4096 条 LRU 上限，避免浏览大量不同 URL 后缓存无限增长。
* 增加 UrlMatch 缓存上限回归测试。
* 修复 GM_xmlhttpRequest 完成或失败后未断开消息连接的问题，避免周期性请求长期累积无效监听器。
* 清理 GM_xmlhttpRequest 网络错误等待 map，避免异常/超时路径残留 promise 引用。

## Screenshots / 截图

<!-- Screenshots / 截图-->
