### PR TITLE
perf: (Codex) 优化 RuntimeService.getScriptsForTab

### DIFF
--- a/src/app/service/service_worker/popup.ts
+++ b/src/app/service/service_worker/popup.ts
@@ -342,7 +342,7 @@ export class PopupService {
   async getPopupData(req: GetPopupDataReq): Promise<GetPopupDataRes> {
     const { url, tabId } = req;
     const [matchingResult, runScripts, backScriptList] = await Promise.all([
-      this.runtime.getPageScriptMatchingResultByUrl(url, true, true),
+      this.runtime.getPopupPageScriptMatchingResultByUrl(url),
       this.getScriptMenu(tabId),
       this.getScriptMenu(-1),
     ]);

--- a/src/app/service/service_worker/resource.test.ts
+++ b/src/app/service/service_worker/resource.test.ts
@@ -3,6 +3,7 @@ import { ResourceService } from "./resource";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import type { Group } from "@Packages/message/server";
 import type { IMessageQueue } from "@Packages/message/message_queue";
+import type { Resource } from "@App/app/repo/resource";
 
 initTestEnv();
 
@@ -94,5 +95,55 @@ describe("ResourceService - loadByUrl", () => {
     const res = await service.loadByUrl("https://example.com/noct", "resource");
 
     expect(res.contentType).toBe("application/octet-stream");
+  });
+});
+
+describe("ResourceService - getScriptResources", () => {
+  let service: ResourceService;
+
+  const createResource = (url: string): Resource => ({
+    url,
+    content: "local content",
+    contentType: "text/plain",
+    hash: {
+      md5: "",
+      sha1: "",
+      sha256: "",
+      sha384: "",
+      sha512: "sha512",
+    },
+    base64: "",
+    link: {},
+    type: "resource",
+    createtime: 1,
+    updatetime: 1,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const mockGroup = {} as Group;
+    const mockMQ = {} as IMessageQueue;
+    service = new ResourceService(mockGroup, mockMQ);
+  });
+
+  it("命名 @resource 使用 file:/// 时应立即刷新本地文件", async () => {
+    const url = "file:///tmp/local.txt";
+    const resource = createResource(url);
+    const updateResource = vi.spyOn(service, "updateResource").mockResolvedValue(resource);
+    const getResource = vi.spyOn(service, "getResource");
+
+    const result = await service.getScriptResources(
+      {
+        uuid: "script-uuid",
+        metadata: {
+          resource: [`asset ${url}`],
+        },
+      } as any,
+      false
+    );
+
+    expect(updateResource).toHaveBeenCalledWith("script-uuid", url, "resource");
+    expect(getResource).not.toHaveBeenCalled();
+    expect(result.asset).toBe(resource);
   });
 });

--- a/src/app/service/service_worker/resource.ts
+++ b/src/app/service/service_worker/resource.ts
@@ -98,7 +98,7 @@ export class ResourceService {
           }
         }
         if (path) {
-          if (uri.startsWith("file:///")) {
+          if (path.startsWith("file:///")) {
             // 如果是file://协议，则每次请求更新一下文件
             const res = await this.updateResource(script.uuid, path, type);
             ret[resourceKey] = res;

--- a/src/app/service/service_worker/runtime.test.ts
+++ b/src/app/service/service_worker/runtime.test.ts
@@ -3,7 +3,12 @@ import { RuntimeService } from "./runtime";
 import { vi, describe, it, expect, beforeEach, type MockedFunction } from "vitest";
 import { randomUUID } from "crypto";
 import type { Script, ScriptRunResource } from "@App/app/repo/scripts";
-import { SCRIPT_STATUS_DISABLE, SCRIPT_STATUS_ENABLE, SCRIPT_TYPE_NORMAL } from "@App/app/repo/scripts";
+import {
+  SCRIPT_STATUS_DISABLE,
+  SCRIPT_STATUS_ENABLE,
+  SCRIPT_TYPE_BACKGROUND,
+  SCRIPT_TYPE_NORMAL,
+} from "@App/app/repo/scripts";
 import { getCombinedMeta } from "./utils";
 import type { SystemConfig } from "@App/pkg/config/config";
 import type { Group } from "@Packages/message/server";
@@ -16,16 +21,36 @@ import type { ScriptDAO } from "@App/app/repo/scripts";
 import { LocalStorageDAO } from "@App/app/repo/localStorage";
 import type { MessageConnect, TMessage } from "@Packages/message/types";
 import { obtainBlackList } from "@App/pkg/utils/utils";
+import type { CompiledResource, Resource } from "@App/app/repo/resource";
 
 initTestEnv();
 
-describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹配", () => {
+describe("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹配", () => {
   let runtime: RuntimeService;
   let mockSystemConfig: {
     getBlacklist: MockedFunction<() => string>;
   };
   let mockScriptService: {
     buildScriptRunResource: MockedFunction<(script: Script, scriptFlag?: string) => ScriptRunResource>;
+  };
+  let mockValueService: {
+    getScriptValue: MockedFunction<(script: Script) => Promise<Record<string, any>>>;
+  };
+  let mockResourceService: {
+    getScriptResources: MockedFunction<(script: Script, load: boolean) => Promise<Record<string, any>>>;
+    updateResource: MockedFunction<(uuid: string, url: string, type: any) => Promise<any>>;
+  };
+  let mockScriptDAO: {
+    all: MockedFunction<() => Promise<Script[]>>;
+    gets: MockedFunction<(uuids: string[]) => Promise<(Script | undefined)[]>>;
+    scriptCodeDAO: {
+      get: MockedFunction<(uuid: string) => Promise<{ uuid: string; code: string } | undefined>>;
+    };
+  };
+
+  const updateMockScripts = async (scripts: Script[]) => {
+    mockScriptDAO.all.mockResolvedValue(scripts);
+    runtime.scriptMatchDisable = await runtime.createPopupDisabledScriptMatch();
   };
 
   // 测试数据创建工具函数
@@ -63,6 +88,59 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
     };
   };
 
+  const createUserScriptCode = (script: Script, body = "console.log('test');") =>
+    [
+      "// ==UserScript==",
+      `// @name ${script.name}`,
+      `// @namespace ${script.namespace}`,
+      ...(script.metadata.match || []).map((item) => `// @match ${item}`),
+      ...(script.metadata.include || []).map((item) => `// @include ${item}`),
+      "// ==/UserScript==",
+      body,
+    ].join("\n");
+
+  const createCompiledResourceAsync = async (
+    script: Script,
+    scriptRunResource: ScriptRunResource
+  ): Promise<CompiledResource> => {
+    const matchInfo = await runtime.applyScriptMatchInfo(scriptRunResource);
+    expect(matchInfo).toBeDefined();
+    return {
+      name: script.name,
+      flag: scriptRunResource.flag,
+      uuid: script.uuid,
+      require: [],
+      matches: script.metadata.match || ["https://www.example.com/*"],
+      includeGlobs: [],
+      excludeMatches: [],
+      excludeGlobs: [],
+      allFrames: !script.metadata.noframes,
+      world: script.metadata["inject-into"]?.[0] === "content" ? "USER_SCRIPT" : "MAIN",
+      runAt: "",
+      scriptUrlPatterns: matchInfo!.scriptUrlPatterns,
+      originalUrlPatterns:
+        matchInfo!.originalUrlPatterns === matchInfo!.scriptUrlPatterns ? null : matchInfo!.originalUrlPatterns,
+    };
+  };
+
+  const createTextResource = (url: string, content: string, sha512: string): Resource => ({
+    url,
+    content,
+    base64: "base64",
+    hash: {
+      md5: "",
+      sha1: "",
+      sha256: "",
+      sha384: "",
+      sha512,
+    },
+    type: "require",
+    link: {},
+    contentType: "text/javascript",
+    createtime: 1,
+    updatetime: 1,
+  });
+
   beforeEach(() => {
     // 创建所有必需的mock对象
     mockSystemConfig = {
@@ -71,6 +149,20 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
 
     mockScriptService = {
       buildScriptRunResource: vi.fn(),
+    };
+    mockValueService = {
+      getScriptValue: vi.fn(),
+    };
+    mockResourceService = {
+      getScriptResources: vi.fn(),
+      updateResource: vi.fn(),
+    };
+    mockScriptDAO = {
+      all: vi.fn().mockResolvedValue([]),
+      gets: vi.fn().mockResolvedValue([]),
+      scriptCodeDAO: {
+        get: vi.fn(),
+      },
     };
 
     const mockGroup = {
@@ -89,11 +181,6 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
     const mockMessageQueue = {
       group: vi.fn().mockReturnValue(mockGroup),
     } as unknown as IMessageQueue;
-    const mockValueService = {} as ValueService;
-    const mockResourceService = {} as ResourceService;
-    const mockScriptDAO = {
-      all: vi.fn().mockResolvedValue([]),
-    } as unknown as ScriptDAO;
     const mockLocalStorageDAO = new LocalStorageDAO();
 
     runtime = new RuntimeService(
@@ -101,10 +188,10 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
       mockGroup,
       mockSender,
       mockMessageQueue,
-      mockValueService,
+      mockValueService as unknown as ValueService,
       mockScriptService as unknown as ScriptService,
-      mockResourceService,
-      mockScriptDAO,
+      mockResourceService as unknown as ResourceService,
+      mockScriptDAO as unknown as ScriptDAO,
       mockLocalStorageDAO
     );
   });
@@ -124,7 +211,7 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
       // Act
       const scriptMatchInfo = await runtime.applyScriptMatchInfo(scriptRunResource);
       expect(scriptMatchInfo).toBeDefined();
-      const result = runtime.getPageScriptMatchingResultByUrl("https://www.example.com/path");
+      const result = runtime.getPageScriptMatchingResultByUrlInternal("https://www.example.com/path");
 
       // Assert
       // expect(mockScriptService.buildScriptRunResource).toHaveBeenCalledWith(script);
@@ -146,6 +233,8 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
         },
       });
 
+      await updateMockScripts([script]);
+
       const scriptRunResource = createScriptRunResource(script);
       mockScriptService.buildScriptRunResource.mockReturnValue(scriptRunResource);
 
@@ -154,10 +243,10 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
       expect(scriptMatchInfo).toBeDefined();
 
       // 测试默认查询（不包含无效匹配）
-      const defaultResult = runtime.getPageScriptMatchingResultByUrl("https://www.example.com/path");
+      const defaultResult = runtime.getPageScriptMatchingResultByUrlInternal("https://www.example.com/path");
 
       // 测试包含无效匹配的查询
-      const allResult = runtime.getPageScriptMatchingResultByUrl("https://www.example.com/path", true, true);
+      const allResult = runtime.getPageScriptMatchingResultByUrlInternal("https://www.example.com/path", true, true);
 
       // Assert
       // expect(mockScriptService.buildScriptRunResource).toHaveBeenCalledWith(script);
@@ -182,6 +271,7 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
           include: ["*://*/api/*"],
         },
       });
+      await updateMockScripts([script]);
 
       const scriptRunResource = createScriptRunResource(script);
       mockScriptService.buildScriptRunResource.mockReturnValue(scriptRunResource);
@@ -191,13 +281,13 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
       expect(scriptMatchInfo).toBeDefined();
 
       // 测试匹配第一个规则
-      const result1 = runtime.getPageScriptMatchingResultByUrl("https://www.example.com/path");
+      const result1 = runtime.getPageScriptMatchingResultByUrlInternal("https://www.example.com/path");
       // 测试匹配第二个规则
-      const result2 = runtime.getPageScriptMatchingResultByUrl("https://www.test.com/page");
+      const result2 = runtime.getPageScriptMatchingResultByUrlInternal("https://www.test.com/page");
       // 测试匹配include规则
-      const result3 = runtime.getPageScriptMatchingResultByUrl("https://example.org/api/users");
+      const result3 = runtime.getPageScriptMatchingResultByUrlInternal("https://example.org/api/users");
       // 测试不匹配的URL
-      const result4 = runtime.getPageScriptMatchingResultByUrl("https://other.com/page");
+      const result4 = runtime.getPageScriptMatchingResultByUrlInternal("https://other.com/page");
 
       // Assert
       expect(result1.has(script.uuid)).toBe(true);
@@ -222,6 +312,7 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
           exclude: ["*://www.example.com/admin/*"],
         },
       });
+      await updateMockScripts([script]);
 
       const scriptRunResource = createScriptRunResource(script);
       mockScriptService.buildScriptRunResource.mockReturnValue(scriptRunResource);
@@ -231,11 +322,11 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
       expect(scriptMatchInfo).toBeDefined();
 
       // 测试被include但不被exclude的URL
-      const includeResult = runtime.getPageScriptMatchingResultByUrl("https://www.example.com/user");
+      const includeResult = runtime.getPageScriptMatchingResultByUrlInternal("https://www.example.com/user");
       // 测试被include但也被exclude的URL
-      const excludeResult = runtime.getPageScriptMatchingResultByUrl("https://www.example.com/admin/panel");
+      const excludeResult = runtime.getPageScriptMatchingResultByUrlInternal("https://www.example.com/admin/panel");
       // 测试被include但也被exclude的URL（包含无效匹配）
-      const excludeAllResult = runtime.getPageScriptMatchingResultByUrl(
+      const excludeAllResult = runtime.getPageScriptMatchingResultByUrlInternal(
         "https://www.example.com/admin/panel",
         true,
         true
@@ -269,6 +360,7 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
       const script = createMockScript({
         metadata: {},
       });
+      await updateMockScripts([script]);
 
       const scriptRunResource = createScriptRunResource(script);
       mockScriptService.buildScriptRunResource.mockReturnValue(scriptRunResource);
@@ -276,7 +368,7 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
       // Act
       const scriptMatchInfo = await runtime.applyScriptMatchInfo(scriptRunResource);
       expect(scriptMatchInfo).toBeUndefined();
-      const result = runtime.getPageScriptMatchingResultByUrl("https://www.example.com/path");
+      const result = runtime.getPageScriptMatchingResultByUrlInternal("https://www.example.com/path");
 
       // Assert
       expect(result.has(script.uuid)).toBe(false);
@@ -302,6 +394,9 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
         status: SCRIPT_STATUS_DISABLE,
       });
 
+      await updateMockScripts([disabledScript, disabledScript]);
+      runtime.scriptMatchDisable = await runtime.createPopupDisabledScriptMatch();
+
       const enabledRunResource = createScriptRunResource(enabledScript);
       const disabledRunResource = createScriptRunResource(disabledScript);
 
@@ -318,9 +413,9 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
       expect(disabledMatchInfo).toBeDefined();
 
       // 默认查询（不包含禁用）
-      const defaultResult = runtime.getPageScriptMatchingResultByUrl("https://www.example.com/path");
+      const defaultResult = runtime.getPageScriptMatchingResultByUrlInternal("https://www.example.com/path");
       // 包含禁用脚本的查询
-      const withDisabledResult = runtime.getPageScriptMatchingResultByUrl("https://www.example.com/path", true);
+      const withDisabledResult = runtime.getPageScriptMatchingResultByUrlInternal("https://www.example.com/path", true);
 
       // Assert
       // 默认不包含禁用脚本
@@ -338,12 +433,525 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
     });
   });
 
-  describe.concurrent("黑名單測試", async () => {
-    it.concurrent("黑名單測試 A", async () => {
+  describe("getScriptsForTab cache", () => {
+    it("应该复用静态脚本信息，只在每次页面加载时刷新 value", async () => {
+      const script = createMockScript({
+        uuid: "cache-script",
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+        updatetime: 100,
+      });
+      await updateMockScripts([script]);
+      const scriptRunResource = createScriptRunResource(script);
+      const matchInfo = await runtime.applyScriptMatchInfo(scriptRunResource);
+      expect(matchInfo).toBeDefined();
+
+      const compiledResource = {
+        name: script.name,
+        flag: scriptRunResource.flag,
+        uuid: script.uuid,
+        require: [],
+        matches: ["https://www.example.com/*"],
+        includeGlobs: [],
+        excludeMatches: [],
+        excludeGlobs: [],
+        allFrames: true,
+        world: "MAIN",
+        runAt: "",
+        scriptUrlPatterns: matchInfo!.scriptUrlPatterns,
+        originalUrlPatterns: null,
+      };
+      const compiledResourceDAO = {
+        gets: vi.fn().mockResolvedValue([compiledResource]),
+      };
+      runtime.compiledResourceDAO = compiledResourceDAO as any;
+
+      mockScriptDAO.gets.mockResolvedValue([script]);
+      mockScriptDAO.scriptCodeDAO.get.mockResolvedValue({
+        uuid: script.uuid,
+        code: [
+          "// ==UserScript==",
+          "// @name test-script",
+          "// @namespace test-namespace",
+          "// @match https://www.example.com/*",
+          "// ==/UserScript==",
+          "console.log('cached');",
+        ].join("\n"),
+      });
+      mockResourceService.getScriptResources.mockResolvedValue({});
+      mockValueService.getScriptValue.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 2 });
+
+      const first = await runtime.getScriptsForTab({
+        url: "https://www.example.com/path",
+        tabId: 1,
+        frameId: 0,
+      });
+      const second = await runtime.getScriptsForTab({
+        url: "https://www.example.com/path",
+        tabId: 1,
+        frameId: 0,
+      });
+
+      expect(first?.injectScriptList[0].value).toEqual({ count: 1 });
+      expect(second?.injectScriptList[0].value).toEqual({ count: 2 });
+      expect(second?.injectScriptList[0].metadataStr).toContain("@name test-script");
+      expect(runtime.pageLoadCaches.has(script.uuid)).toBe(true);
+      expect(compiledResourceDAO.gets).toHaveBeenCalledTimes(1);
+      expect(mockResourceService.getScriptResources).toHaveBeenCalledTimes(1);
+      expect(mockScriptDAO.scriptCodeDAO.get).toHaveBeenCalledTimes(1);
+      expect(mockValueService.getScriptValue).toHaveBeenCalledTimes(2);
+    });
+
+    it("应该在全局停用、黑名单、没有匹配脚本时直接返回 null", async () => {
+      runtime.isLoadScripts = false;
+      expect(
+        await runtime.getScriptsForTab({
+          url: "https://www.example.com/path",
+          tabId: 1,
+          frameId: 0,
+        })
+      ).toBeNull();
+
+      runtime.isLoadScripts = true;
+      runtime.blacklist = obtainBlackList("*://www.example.com/*");
+      runtime.loadBlacklist();
+      expect(
+        await runtime.getScriptsForTab({
+          url: "https://www.example.com/path",
+          tabId: 1,
+          frameId: 0,
+        })
+      ).toBeNull();
+
+      runtime.blacklist = [];
+      runtime.loadBlacklist();
+      expect(
+        await runtime.getScriptsForTab({
+          url: "https://not-matched.example/path",
+          tabId: 1,
+          frameId: 0,
+        })
+      ).toBeNull();
+      expect(mockScriptDAO.gets).not.toHaveBeenCalled();
+    });
+
+    it("应该按运行条件过滤脚本，并按 inject-into 拆分 inject/content 列表且保留顺序", async () => {
+      const injectScript = createMockScript({
+        uuid: "script-inject",
+        sort: 1,
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+      });
+      const contentScript = createMockScript({
+        uuid: "script-content",
+        sort: 2,
+        metadata: {
+          match: ["https://www.example.com/*"],
+          "inject-into": ["content"],
+        },
+      });
+      const noframesScript = createMockScript({
+        uuid: "script-noframes",
+        sort: 3,
+        metadata: {
+          match: ["https://www.example.com/*"],
+          noframes: [""],
+        },
+      });
+      const incognitoOnlyScript = createMockScript({
+        uuid: "script-incognito",
+        sort: 4,
+        metadata: {
+          match: ["https://www.example.com/*"],
+          "run-in": ["incognito-tabs"],
+        },
+      });
+
+      const scripts = [injectScript, contentScript, noframesScript, incognitoOnlyScript];
+      await updateMockScripts(scripts);
+      const runResources = scripts.map(createScriptRunResource);
+      const compiledResources = await Promise.all(
+        scripts.map((script, index) => createCompiledResourceAsync(script, runResources[index]))
+      );
+      runtime.compiledResourceDAO = {
+        gets: vi.fn().mockResolvedValue(compiledResources),
+      } as any;
+      mockScriptDAO.gets.mockResolvedValue(scripts);
+      mockScriptDAO.scriptCodeDAO.get.mockImplementation(async (uuid) => {
+        const script = scripts.find((item) => item.uuid === uuid);
+        return script ? { uuid, code: createUserScriptCode(script) } : undefined;
+      });
+      mockResourceService.getScriptResources.mockResolvedValue({});
+      mockValueService.getScriptValue.mockResolvedValue({});
+
+      const result = await runtime.getScriptsForTab({
+        url: "https://www.example.com/path",
+        tabId: 1,
+        frameId: 1,
+      });
+
+      expect(result?.injectScriptList.map((script) => script.uuid)).toEqual(["script-inject"]);
+      expect(result?.contentScriptList.map((script) => script.uuid)).toEqual(["script-content"]);
+      expect(result?.scriptmenus.map((script) => script.uuid)).toEqual(["script-inject", "script-content"]);
+    });
+
+    it("应该在脚本更新时间变化后丢弃旧 page-load cache 并重建静态信息", async () => {
+      const oldScript = createMockScript({
+        uuid: "cache-invalidated",
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+        updatetime: 100,
+      });
+      await updateMockScripts([oldScript]);
+      const newScript = {
+        ...oldScript,
+        updatetime: 200,
+      };
+      const oldRunResource = createScriptRunResource(oldScript);
+      const _newRunResource = createScriptRunResource(newScript);
+      const oldCompiled = await createCompiledResourceAsync(oldScript, oldRunResource);
+      const newCompiled = {
+        ...oldCompiled,
+        name: newScript.name,
+      };
+      const compiledResourceDAO = {
+        gets: vi.fn().mockResolvedValueOnce([oldCompiled]).mockResolvedValueOnce([newCompiled]),
+      };
+      runtime.compiledResourceDAO = compiledResourceDAO as any;
+      mockScriptDAO.gets.mockResolvedValueOnce([oldScript]).mockResolvedValueOnce([newScript]);
+      mockScriptDAO.scriptCodeDAO.get
+        .mockResolvedValueOnce({
+          uuid: oldScript.uuid,
+          code: createUserScriptCode(oldScript, "console.log('old');"),
+        })
+        .mockResolvedValueOnce({
+          uuid: newScript.uuid,
+          code: createUserScriptCode(newScript, "console.log('new');"),
+        });
+      mockResourceService.getScriptResources.mockResolvedValue({});
+      mockValueService.getScriptValue.mockResolvedValue({});
+
+      await runtime.getScriptsForTab({
+        url: "https://www.example.com/path",
+        tabId: 1,
+        frameId: 0,
+      });
+      await runtime.getScriptsForTab({
+        url: "https://www.example.com/path",
+        tabId: 1,
+        frameId: 0,
+      });
+
+      expect(compiledResourceDAO.gets).toHaveBeenCalledTimes(2);
+      expect(mockResourceService.getScriptResources).toHaveBeenCalledTimes(2);
+      expect(mockScriptDAO.scriptCodeDAO.get).toHaveBeenCalledTimes(2);
+      expect(runtime.pageLoadCaches.get(oldScript.uuid)?.code).toContain("console.log('new');");
+    });
+
+    it("应该在本地 file resource 改变时更新缓存资源并刷新已注册 userScript", async () => {
+      const resourceUrl = "file:///tmp/local.js";
+      const script = createMockScript({
+        uuid: "local-resource-script",
+        metadata: {
+          match: ["https://www.example.com/*"],
+          require: [resourceUrl],
+        },
+        updatetime: 100,
+      });
+      await updateMockScripts([script]);
+      const scriptRunResource = createScriptRunResource(script);
+      const compiledResource = await createCompiledResourceAsync(script, scriptRunResource);
+      runtime.compiledResourceDAO = {
+        gets: vi.fn().mockResolvedValue([compiledResource]),
+      } as any;
+      mockScriptDAO.gets.mockResolvedValue([script]);
+      mockScriptDAO.scriptCodeDAO.get.mockResolvedValue({
+        uuid: script.uuid,
+        code: createUserScriptCode(script, "console.log('with local resource');"),
+      });
+      mockResourceService.getScriptResources.mockResolvedValue({
+        [resourceUrl]: createTextResource(resourceUrl, "console.log('old resource');", "old-sha"),
+      });
+      mockResourceService.updateResource.mockResolvedValue(
+        createTextResource(resourceUrl, "console.log('new resource');", "new-sha")
+      );
+      mockValueService.getScriptValue.mockResolvedValue({});
+
+      const getScripts = vi.fn().mockResolvedValue([{ id: script.uuid, js: [{ code: "old registered code" }] }]);
+      const update = vi.fn().mockResolvedValue(undefined);
+      vi.spyOn(chrome.userScripts, "getScripts").mockImplementation(getScripts as any);
+      vi.spyOn(chrome.userScripts, "update").mockImplementation(update as any);
+
+      const result = await runtime.getScriptsForTab({
+        url: "https://www.example.com/path",
+        tabId: 1,
+        frameId: 0,
+      });
+
+      expect(result?.injectScriptList[0].resource[resourceUrl].content).toBe("console.log('new resource');");
+      expect(result?.injectScriptList[0].resource[resourceUrl].base64).toBeUndefined();
+      expect(update).toHaveBeenCalledTimes(1);
+      expect(update.mock.calls[0][0][0].id).toBe(script.uuid);
+      const updatedCode = update.mock.calls[0][0][0].js[0].code;
+      expect(updatedCode).toContain("console.log('new resource');");
+      expect(updatedCode).not.toContain("console.log('old resource');");
+      expect(runtime.pageLoadCaches.get(script.uuid)?.localResources[0].sha512).toBe("new-sha");
+    });
+
+    it("应该支持命名 @resource file:/// 改变时更新缓存资源", async () => {
+      const resourceUrl = "file:///tmp/local.txt";
+      const script = createMockScript({
+        uuid: "local-named-resource-script",
+        metadata: {
+          match: ["https://www.example.com/*"],
+          resource: [`asset ${resourceUrl}`],
+        },
+        updatetime: 100,
+      });
+      await updateMockScripts([script]);
+      const scriptRunResource = createScriptRunResource(script);
+      const compiledResource = await createCompiledResourceAsync(script, scriptRunResource);
+      runtime.compiledResourceDAO = {
+        gets: vi.fn().mockResolvedValue([compiledResource]),
+      } as any;
+      mockScriptDAO.gets.mockResolvedValue([script]);
+      mockScriptDAO.scriptCodeDAO.get.mockResolvedValue({
+        uuid: script.uuid,
+        code: createUserScriptCode(script, "console.log('with named local resource');"),
+      });
+      mockResourceService.getScriptResources.mockResolvedValue({
+        asset: { ...createTextResource(resourceUrl, "old text", "old-sha"), type: "resource" },
+      });
+      mockResourceService.updateResource.mockResolvedValue({
+        ...createTextResource(resourceUrl, "new text", "new-sha"),
+        type: "resource",
+      });
+      mockValueService.getScriptValue.mockResolvedValue({});
+
+      vi.spyOn(chrome.userScripts, "getScripts").mockResolvedValue([{ id: script.uuid, js: [{ code: "old" }] }] as any);
+      const update = vi.spyOn(chrome.userScripts, "update").mockResolvedValue(undefined);
+      update.mockClear();
+
+      const result = await runtime.getScriptsForTab({
+        url: "https://www.example.com/path",
+        tabId: 1,
+        frameId: 0,
+      });
+
+      expect(result?.injectScriptList[0].resource.asset.content).toBe("new text");
+      expect(runtime.pageLoadCaches.get(script.uuid)?.localResources[0]).toMatchObject({
+        resourceKey: "asset",
+        url: resourceUrl,
+        type: "resource",
+        sha512: "new-sha",
+      });
+      expect(update).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("getPopupPageScriptMatchingResultByUrl", () => {
+    it("应该按需匹配 disabled 脚本，且不写入 runtime disabled matcher 或 page-load cache", async () => {
+      const disabledScript = createMockScript({
+        uuid: "disabled-effective",
+        status: SCRIPT_STATUS_DISABLE,
+        sort: 1,
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+      });
+      const disabledExcludedScript = createMockScript({
+        uuid: "disabled-excluded",
+        status: SCRIPT_STATUS_DISABLE,
+        sort: 2,
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+        selfMetadata: {
+          exclude: ["https://www.example.com/*"],
+        },
+      });
+
+      await updateMockScripts([disabledScript, disabledExcludedScript]);
+      expect(runtime.getPageScriptMatchingResultByUrlInternal("https://www.example.com/path", true, true).size).toBe(2);
+
+      const result = await runtime.getPopupPageScriptMatchingResultByUrl("https://www.example.com/path");
+
+      expect(result.get(disabledScript.uuid)).toEqual({
+        uuid: disabledScript.uuid,
+        effective: true,
+      });
+      expect(result.get(disabledExcludedScript.uuid)).toEqual({
+        uuid: disabledExcludedScript.uuid,
+        effective: false,
+      });
+      expect(runtime.getPageScriptMatchingResultByUrlInternal("https://www.example.com/path", true, true).size).toBe(2);
+      expect(runtime.pageLoadCaches.size).toBe(0);
+    });
+
+    it("应该缓存 Popup disabled matcher，重复打开 Popup 时不重复扫描全部脚本", async () => {
+      const disabledScript = createMockScript({
+        uuid: "disabled-cached",
+        status: SCRIPT_STATUS_DISABLE,
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+      });
+
+      await updateMockScripts([disabledScript]);
+
+      const first = await runtime.getPopupPageScriptMatchingResultByUrl("https://www.example.com/path");
+      const second = await runtime.getPopupPageScriptMatchingResultByUrl("https://www.example.com/other");
+
+      expect(first.get(disabledScript.uuid)?.effective).toBe(true);
+      expect(second.get(disabledScript.uuid)?.effective).toBe(true);
+      expect(mockScriptDAO.all).toHaveBeenCalledTimes(1);
+    });
+
+    it("应该在 runtime cache 被清理后重建 Popup disabled matcher", async () => {
+      const oldDisabledScript = createMockScript({
+        uuid: "disabled-old",
+        status: SCRIPT_STATUS_DISABLE,
+        metadata: {
+          match: ["https://old.example.com/*"],
+        },
+      });
+
+      await updateMockScripts([oldDisabledScript]);
+      const result1 = await runtime.getPopupPageScriptMatchingResultByUrl("https://old.example.com/path");
+      expect(result1.has("disabled-old")).toBe(true);
+      expect(result1.has("disabled-new")).toBe(false);
+      expect(mockScriptDAO.all).toHaveBeenCalledTimes(1);
+
+      runtime.deleteScriptRuntimeCache(oldDisabledScript.uuid);
+
+      const newDisabledScript = createMockScript({
+        uuid: "disabled-new",
+        status: SCRIPT_STATUS_DISABLE,
+        metadata: {
+          match: ["https://new.example.com/*"],
+        },
+      });
+
+      await updateMockScripts([newDisabledScript]);
+      const result2 = await runtime.getPopupPageScriptMatchingResultByUrl("https://new.example.com/path");
+
+      expect(result2.has("disabled-old")).toBe(false);
+      expect(result2.has("disabled-new")).toBe(true);
+      expect(result2.get("disabled-new")?.effective).toBe(true);
+      expect(mockScriptDAO.all).toHaveBeenCalledTimes(2);
+    });
+
+    it("应该合并 enabled matcher 与按需 disabled 匹配，并保留 effective / non-effective 状态", async () => {
+      const enabledScript = createMockScript({
+        uuid: "enabled-effective",
+        sort: 1,
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+      });
+      const enabledExcludedScript = createMockScript({
+        uuid: "enabled-excluded",
+        sort: 2,
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+        selfMetadata: {
+          exclude: ["https://www.example.com/*"],
+        },
+      });
+      const disabledScript = createMockScript({
+        uuid: "disabled-effective",
+        status: SCRIPT_STATUS_DISABLE,
+        sort: 3,
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+      });
+
+      await runtime.applyScriptMatchInfo(createScriptRunResource(enabledScript));
+      await runtime.applyScriptMatchInfo(createScriptRunResource(enabledExcludedScript));
+      await updateMockScripts([enabledScript, enabledExcludedScript, disabledScript]);
+
+      const result = await runtime.getPopupPageScriptMatchingResultByUrl("https://www.example.com/path");
+
+      expect([...result.keys()]).toEqual(["enabled-effective", "enabled-excluded", "disabled-effective"]);
+      expect(result.get(enabledScript.uuid)?.effective).toBe(true);
+      expect(result.get(enabledExcludedScript.uuid)?.effective).toBe(false);
+      expect(result.get(disabledScript.uuid)?.effective).toBe(true);
+    });
+
+    it("应该忽略非普通脚本、enabled 脚本和没有匹配规则的 disabled 脚本按需扫描", async () => {
+      const backgroundScript = createMockScript({
+        uuid: "background-disabled",
+        type: SCRIPT_TYPE_BACKGROUND,
+        status: SCRIPT_STATUS_DISABLE,
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+      });
+      const enabledScriptNotInMatcher = createMockScript({
+        uuid: "enabled-not-in-runtime-matcher",
+        status: SCRIPT_STATUS_ENABLE,
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+      });
+      const disabledWithoutRules = createMockScript({
+        uuid: "disabled-without-rules",
+        status: SCRIPT_STATUS_DISABLE,
+        metadata: {},
+      });
+      const disabledMatched = createMockScript({
+        uuid: "disabled-matched",
+        status: SCRIPT_STATUS_DISABLE,
+        metadata: {
+          include: ["*://www.example.com/*"],
+        },
+      });
+
+      await updateMockScripts([backgroundScript, enabledScriptNotInMatcher, disabledWithoutRules, disabledMatched]);
+
+      const result = await runtime.getPopupPageScriptMatchingResultByUrl("https://www.example.com/path");
+
+      expect([...result.keys()]).toEqual(["disabled-matched"]);
+      expect(mockScriptDAO.all).toHaveBeenCalledTimes(1);
+    });
+
+    it("应该按 disabled 脚本 sort 顺序返回按需匹配结果", async () => {
+      const laterScript = createMockScript({
+        uuid: "sort-later",
+        status: SCRIPT_STATUS_DISABLE,
+        sort: 20,
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+      });
+      const earlierScript = createMockScript({
+        uuid: "sort-earlier",
+        status: SCRIPT_STATUS_DISABLE,
+        sort: 10,
+        metadata: {
+          match: ["https://www.example.com/*"],
+        },
+      });
+
+      await updateMockScripts([laterScript, earlierScript]);
+
+      const result = await runtime.getPopupPageScriptMatchingResultByUrl("https://www.example.com/path");
+
+      expect([...result.keys()]).toEqual(["sort-earlier", "sort-later"]);
+    });
+  });
+
+  describe.concurrent("黑名单测试", async () => {
+    it.concurrent("黑名单测试 A", async () => {
       // Arrange
       const blacklistString = "*://www.blacklisted.com/*";
       mockSystemConfig.getBlacklist.mockReturnValue(blacklistString);
-      runtime.blacklist = obtainBlackList(blacklistString); //  this.systemConfig.addListener("blacklist", ... ) 裡自動更新 blacklist
+      runtime.blacklist = obtainBlackList(blacklistString); //  this.systemConfig.addListener("blacklist", ... ) 里自动更新 blacklist
       runtime.loadBlacklist();
       expect(runtime.blackMatch?.rulesMap?.size || 0).toBe(1);
       expect(runtime.blackMatch?.rulesMap.get("BK")?.length || 0).toBe(1);
@@ -361,11 +969,11 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
       expect(blacklistResult).toBe(true);
     });
 
-    it.concurrent("黑名單測試 B", async () => {
+    it.concurrent("黑名单测试 B", async () => {
       // Arrange
       const blacklistString = "*://www.blacklisted.com/*\nhttps://*.google.com/*";
       mockSystemConfig.getBlacklist.mockReturnValue(blacklistString);
-      runtime.blacklist = obtainBlackList(blacklistString); //  this.systemConfig.addListener("blacklist", ... ) 裡自動更新 blacklist
+      runtime.blacklist = obtainBlackList(blacklistString); //  this.systemConfig.addListener("blacklist", ... ) 里自动更新 blacklist
       runtime.loadBlacklist();
       expect(runtime.blackMatch?.rulesMap?.size || 0).toBe(1);
       expect(runtime.blackMatch?.rulesMap.get("BK")?.length || 0).toBe(2);

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -3,7 +3,7 @@ import type { IMessageQueue } from "@Packages/message/message_queue";
 import type { Group, IGetSender } from "@Packages/message/server";
 import type { ExtMessageSender, MessageSend } from "@Packages/message/types";
 import type { TClientPageLoadInfo } from "@App/app/repo/scripts";
-import type { Script, ScriptDAO, ScriptRunResource, ScriptSite, TScriptInfo } from "@App/app/repo/scripts";
+import type { Script, ScriptDAO, ScriptRunResource, ScriptSite, TScriptInfo, UserConfig } from "@App/app/repo/scripts";
 import { SCRIPT_STATUS_DISABLE, SCRIPT_STATUS_ENABLE, SCRIPT_TYPE_NORMAL } from "@App/app/repo/scripts";
 import { type ValueService } from "./value";
 import GMApi, { GMExternalDependencies } from "./gm_api/gm_api";
@@ -48,12 +48,13 @@ import { initLocalesPromise, localePath } from "@App/locales/locales";
 import { DocumentationSite } from "@App/app/const";
 import { extractUrlPatterns, RuleType, type URLRuleEntry } from "@App/pkg/utils/url_matcher";
 import { parseUserConfig } from "@App/pkg/utils/yaml";
-import type { CompiledResource, ResourceType } from "@App/app/repo/resource";
-import { CompiledResourceDAO } from "@App/app/repo/resource";
+import type { CompiledResource, Resource, ResourceType } from "@App/app/repo/resource";
+import { CompiledResourceDAO, CompiledResourceNamespace } from "@App/app/repo/resource";
 import { setOnTabURLChanged } from "./url_monitor";
 import { scriptToMenu, type TPopupPageLoadInfo } from "./popup_scriptmenu";
 
 const ORIGINAL_URLMATCH_SUFFIX = "{ORIGINAL}"; // 用于标记原始URLPatterns的后缀
+let commonSorter: Record<string, number> = {};
 
 const RuntimeRegisterCode = {
   UNSET: 0,
@@ -62,6 +63,37 @@ const RuntimeRegisterCode = {
 } as const;
 
 type RuntimeRegisterCode = ValueOf<typeof RuntimeRegisterCode>;
+
+type RegisteredUserScriptWithJsCode = any;
+
+type TCodeCache = {
+  code: string;
+  metadataStr: string;
+  userConfigStr: string;
+  userConfig: UserConfig | null;
+  scriptCacheKey: string;
+};
+
+type TLocalResourceCache = {
+  resourceKey: string;
+  url: string;
+  type: ResourceType;
+  sha512: string;
+};
+
+type TRuntimeResource = { base64?: string } & Omit<Resource, "base64">;
+
+type TPageLoadScriptCache = {
+  scriptCacheKey: string;
+  scriptUrlPatterns: URLRuleEntry[];
+  originalUrlPatterns: URLRuleEntry[] | null;
+  code: string;
+  metadataStr: string;
+  userConfigStr: string;
+  userConfig: UserConfig | null;
+  resource: Record<string, TRuntimeResource>;
+  localResources: TLocalResourceCache[];
+};
 
 const runtimeGlobal = {
   registerState: RuntimeRegisterCode.UNSET,
@@ -93,8 +125,17 @@ const deliveryStorage = chrome.storage.local; // 日后再处理
 
 export class RuntimeService {
   scriptMatchEnable: UrlMatch<string> = new UrlMatch<string>();
-  scriptMatchDisable: UrlMatch<string> = new UrlMatch<string>();
+  scriptMatchDisable: UrlMatch<string> | null = null;
   blackMatch: UrlMatch<string> = new UrlMatch<string>();
+  private readonly codeCacheMap = new Map<string, TCodeCache>();
+  public readonly pageLoadCaches = new Map<string, TPageLoadScriptCache>();
+  private readonly cachedPatterns = new Map<
+    string,
+    {
+      scriptUrlPatterns: URLRuleEntry[];
+      originalUrlPatterns: URLRuleEntry[];
+    }
+  >();
 
   logger: Logger;
 
@@ -254,7 +295,10 @@ export class RuntimeService {
 
   createMatchInfoEntry(
     scriptRes: ScriptRunResource,
-    o: { scriptUrlPatterns: URLRuleEntry[]; originalUrlPatterns: URLRuleEntry[] | null }
+    o: {
+      scriptUrlPatterns: URLRuleEntry[];
+      originalUrlPatterns: URLRuleEntry[] | null;
+    }
   ) {
     // 优化性能，将不需要的信息去掉
     // 而且可能会超过缓存的存储限制
@@ -270,16 +314,26 @@ export class RuntimeService {
   }
 
   async waitInit() {
-    const [cRuntimeStartFlag, compiledResources, allScripts] = await Promise.all([
+    const [cRuntimeStartFlag, compiledResourceNamespace, allScripts] = await Promise.all([
       cacheInstance.get<boolean>("runtimeStartFlag"),
-      this.compiledResourceDAO.all(),
+      cacheInstance.get<string>("compiledResourceNamespace"),
       this.scriptDAO.all(),
     ]);
 
     const unregisterScriptIds = [] as string[];
-    // 没有 CompiledResources 表示这是 没有启用脚本 或 代码有改变需要重新安装。
-    // 这个情况会把所有有效脚本跟Inject&Content脚本先取消注册。后续载入时会重新以新代码注册。
-    const cleanUpPreviousRegister = !compiledResources.length;
+    const uuidSort = { ...commonSorter };
+    allScripts.map((script) => {
+      const { uuid, sort } = script;
+      const uuidOri = `${uuid}${ORIGINAL_URLMATCH_SUFFIX}`;
+      uuidSort[uuid] = sort;
+      uuidSort[uuidOri] = sort;
+    });
+    commonSorter = uuidSort;
+    this.scriptMatchEnable.setupSorter(commonSorter);
+    this.scriptMatchDisable?.setupSorter(commonSorter);
+    // CompiledResourceNamespace 改变表示注册资料结构或注入代码可能已变。
+    // 这个情况会把有效脚本跟 Inject/Content 脚本先取消注册，后续载入时再重新注册。
+    const shouldCleanUpPreviousRegister = compiledResourceNamespace !== CompiledResourceNamespace;
     this.initialCompiledResourcePromise = Promise.all(
       allScripts.map(async (script) => {
         const uuid = script.uuid;
@@ -289,12 +343,12 @@ export class RuntimeService {
         if (!isNormalScript || !enable) {
           // 确保浏览器没有残留 PageScripts
           if (uuid) unregisterScriptIds.push(uuid);
-        } else if (cleanUpPreviousRegister) {
+        } else if (shouldCleanUpPreviousRegister) {
           // CompiledResourceNamespace 修改后先反注册残留脚本，之后再重新加载 PageScripts
           if (uuid) unregisterScriptIds.push(uuid);
         }
 
-        if (isNormalScript) {
+        if (isNormalScript && enable) {
           let compiledResource = await this.compiledResourceDAO.get(uuid);
           if (!compiledResource) {
             const ret = await this.buildAndSaveCompiledResourceFromScript(script, false);
@@ -308,8 +362,9 @@ export class RuntimeService {
 
           const { scriptUrlPatterns, originalUrlPatterns } = compiledResource;
           const uuidOri = `${uuid}${ORIGINAL_URLMATCH_SUFFIX}`;
+
           // 添加新的数据
-          const scriptMatch = enable ? this.scriptMatchEnable : this.scriptMatchDisable;
+          const scriptMatch = this.scriptMatchEnable;
           scriptMatch.addRules(uuid, scriptUrlPatterns);
           if (originalUrlPatterns !== null && originalUrlPatterns !== scriptUrlPatterns) {
             scriptMatch.addRules(uuidOri, originalUrlPatterns);
@@ -317,7 +372,7 @@ export class RuntimeService {
         }
       })
     );
-    if (cleanUpPreviousRegister) {
+    if (shouldCleanUpPreviousRegister) {
       // 先反注册残留脚本
       unregisterScriptIds.push(
         // 兼容旧的注册ID，过渡期后可移除
@@ -332,6 +387,9 @@ export class RuntimeService {
     }
     if (!cRuntimeStartFlag) {
       await cacheInstance.set<boolean>("runtimeStartFlag", true);
+    }
+    if (shouldCleanUpPreviousRegister) {
+      await cacheInstance.set<string>("compiledResourceNamespace", CompiledResourceNamespace);
     }
 
     let count = 0;
@@ -355,6 +413,12 @@ export class RuntimeService {
     if (!ret) return;
     const { apiScript } = ret;
     await this.loadPageScript(script, apiScript!);
+  }
+
+  deleteScriptRuntimeCache(uuid: string) {
+    this.pageLoadCaches.delete(uuid);
+    this.codeCacheMap.delete(uuid);
+    this.cachedPatterns.delete(uuid);
   }
 
   public async pushValueUpdate(script: Script, sendData: ValueUpdateDataEncoded) {
@@ -420,7 +484,9 @@ export class RuntimeService {
     // 监听脚本开启
     this.mq.subscribe<TEnableScript[]>("enableScripts", async (data) => {
       const unregisteyUuids = [] as string[];
+      this.scriptMatchDisable = null;
       for (const { uuid, enable } of data) {
+        this.deleteScriptRuntimeCache(uuid);
         const script = await this.scriptDAO.get(uuid);
         if (!script) {
           this.logger.error("script enable failed, script not found", {
@@ -452,6 +518,8 @@ export class RuntimeService {
 
     // 监听脚本安装
     this.mq.subscribe<TInstallScript>("installScript", async (data) => {
+      this.scriptMatchDisable = null;
+      this.deleteScriptRuntimeCache(data.script.uuid);
       const script = await this.scriptDAO.get(data.script.uuid);
       if (!script) {
         this.logger.error("script install failed, script not found", {
@@ -459,14 +527,17 @@ export class RuntimeService {
         });
         return;
       }
+
+      const { uuid, sort } = script;
+      const uuidOri = `${uuid}${ORIGINAL_URLMATCH_SUFFIX}`;
+      commonSorter[uuid] = sort;
+      commonSorter[uuidOri] = sort;
+
       // 代码更新时脚本类别不会更改
       if (script.type === SCRIPT_TYPE_NORMAL) {
         const enable = script.status === SCRIPT_STATUS_ENABLE;
         if (enable) {
           await this.updateResourceOnScriptChange(script);
-        } else {
-          // 还是要建立 CompiledResoure, 否则 Popup 看不到 Script
-          await this.buildAndSaveCompiledResourceFromScript(script, false);
         }
       } else {
         bgScriptStorageNames.add(getStorageName(script));
@@ -478,19 +549,30 @@ export class RuntimeService {
       const unregisteyUuids = [] as string[];
       for (const { uuid } of data) {
         unregisteyUuids.push(uuid);
+        this.deleteScriptRuntimeCache(uuid);
+        const uuidOri = `${uuid}${ORIGINAL_URLMATCH_SUFFIX}`;
+        delete commonSorter[uuid];
+        delete commonSorter[uuidOri];
         this.scriptMatchEnable.clearRules(uuid);
-        this.scriptMatchEnable.clearRules(`${uuid}${ORIGINAL_URLMATCH_SUFFIX}`);
-        this.scriptMatchDisable.clearRules(uuid);
-        this.scriptMatchDisable.clearRules(`${uuid}${ORIGINAL_URLMATCH_SUFFIX}`);
+        this.scriptMatchEnable.clearRules(uuidOri);
+        this.scriptMatchDisable?.clearRules(uuid);
+        this.scriptMatchDisable?.clearRules(uuidOri);
       }
       await this.unregistryPageScripts(unregisteyUuids);
     });
 
     // 监听脚本排序
     this.mq.subscribe<TSortedScript[]>("sortedScripts", async (scripts) => {
-      const uuidSort = Object.fromEntries(scripts.map(({ uuid, sort }) => [uuid, sort]));
-      this.scriptMatchEnable.setupSorter(uuidSort);
-      this.scriptMatchDisable.setupSorter(uuidSort);
+      const uuidSort: Record<string, number> = {};
+      for (const script of scripts) {
+        const { uuid, sort } = script;
+        const uuidOri = `${uuid}${ORIGINAL_URLMATCH_SUFFIX}`;
+        uuidSort[uuid] = sort;
+        uuidSort[uuidOri] = sort;
+      }
+      commonSorter = { ...commonSorter, ...uuidSort };
+      this.scriptMatchEnable.setupSorter(commonSorter);
+      this.scriptMatchDisable?.setupSorter(commonSorter);
     });
 
     // 监听offscreen环境初始化, 初始化完成后, 再将后台脚本运行起来
@@ -845,7 +927,7 @@ export class RuntimeService {
           excludeGlobs: [...result.excludeGlobs, ...excludeGlobs],
           allFrames: result.allFrames,
           world: result.world,
-        } as chrome.userScripts.RegisteredUserScript;
+        } as RegisteredUserScriptWithJsCode;
         if (result.runAt) {
           registerScript.runAt = result.runAt as chrome.extensionTypes.RunAt;
         }
@@ -853,7 +935,7 @@ export class RuntimeService {
       })
     ).then(async (res) => {
       // 过滤掉undefined和未开启的
-      return res.filter((item) => item) as chrome.userScripts.RegisteredUserScript[];
+      return res.filter((item) => item) as RegisteredUserScriptWithJsCode[];
     });
     return registerScripts;
   }
@@ -886,7 +968,7 @@ export class RuntimeService {
     }
 
     let retContent: chrome.scripting.RegisteredContentScript[] = [];
-    const retInject: chrome.userScripts.RegisteredUserScript[] = [];
+    const retInject: RegisteredUserScriptWithJsCode[] = [];
 
     // ------ scripting.js ------
     // Note: Chrome does not support file.js?query
@@ -918,7 +1000,7 @@ export class RuntimeService {
         excludeMatches: excludeMatches,
         excludeGlobs: excludeGlobs,
         world: "MAIN",
-      } satisfies chrome.userScripts.RegisteredUserScript;
+      } satisfies RegisteredUserScriptWithJsCode;
       retInject.push(script);
     }
     const contentJs = await this.getContentJsCode();
@@ -935,7 +1017,7 @@ export class RuntimeService {
         excludeMatches,
         excludeGlobs,
         world: "USER_SCRIPT",
-      } satisfies chrome.userScripts.RegisteredUserScript;
+      } satisfies RegisteredUserScriptWithJsCode;
       retInject.push(script);
     }
 
@@ -979,7 +1061,7 @@ export class RuntimeService {
     // 需要等getParticularScriptList完成后再执行
     const { inject: injectScriptList, content: contentScriptList } = await this.getContentAndInjectScript(options);
 
-    const list: chrome.userScripts.RegisteredUserScript[] = [...particularScriptList, ...injectScriptList];
+    const list: RegisteredUserScriptWithJsCode[] = [...particularScriptList, ...injectScriptList];
 
     let failed = false;
     try {
@@ -1032,7 +1114,26 @@ export class RuntimeService {
     );
   }
 
-  getPageScriptMatchingResultByUrl(
+  private processScriptMatchingRet(
+    ret: Map<string, { uuid: string; effective: boolean }>,
+    matchedUuids: string[],
+    includeNonEffective: boolean = false
+  ) {
+    for (const e of matchedUuids) {
+      const isEffective = !e.endsWith(ORIGINAL_URLMATCH_SUFFIX);
+      const uuid = isEffective ? e : e.slice(0, -ORIGINAL_URLMATCH_SUFFIX.length);
+      if (!includeNonEffective && !isEffective) continue;
+      const o = ret.get(uuid) || { uuid, effective: false };
+      // 只包含 uuid{Ori} 而不包含 uuid 的情况，effective = false
+      if (isEffective) {
+        o.effective = true;
+      }
+      // ret 只包含 uuid 为键的 matchingResult
+      ret.set(uuid, o);
+    }
+  }
+
+  getPageScriptMatchingResultByUrlInternal(
     url: string,
     includeDisabled: boolean = false,
     includeNonEffective: boolean = false
@@ -1042,21 +1143,57 @@ export class RuntimeService {
     // 因此基于自定义排除页面被排除的情况下，结果只包含 uuid{Ori} 而不包含 uuid
     let matchedUuids = this.scriptMatchEnable.urlMatch(url!);
     if (includeDisabled) {
-      matchedUuids = [...matchedUuids, ...this.scriptMatchDisable.urlMatch(url!)];
-    }
-    const ret = new Map<string, { uuid: string; effective: boolean }>();
-    for (const e of matchedUuids) {
-      const uuid = e.endsWith(ORIGINAL_URLMATCH_SUFFIX) ? e.slice(0, -ORIGINAL_URLMATCH_SUFFIX.length) : e;
-      if (!includeNonEffective && uuid !== e) continue;
-      const o = ret.get(uuid) || { uuid, effective: false };
-      // 只包含 uuid{Ori} 而不包含 uuid 的情况，effective = false
-      if (e === uuid) {
-        o.effective = true;
+      if (this.scriptMatchDisable) {
+        matchedUuids = [...matchedUuids, ...this.scriptMatchDisable.urlMatch(url!)];
+      } else {
+        // 正常不会出现
+        console.error("Unexpected Error in getPageScriptMatchingResultByUrlInternal");
       }
-      ret.set(uuid, o);
     }
-    // ret 只包含 uuid 为键的 matchingResult
+
+    const ret = new Map<string, { uuid: string; effective: boolean }>();
+    this.processScriptMatchingRet(ret, matchedUuids, includeNonEffective);
     return ret;
+  }
+
+  async getPopupPageScriptMatchingResultByUrl(url: string) {
+    if (!this.scriptMatchDisable) {
+      this.scriptMatchDisable = await this.createPopupDisabledScriptMatch();
+    }
+    const ret = this.getPageScriptMatchingResultByUrlInternal(url, true, true);
+    return ret;
+  }
+
+  async createPopupDisabledScriptMatch(): Promise<UrlMatch<string>> {
+    const disabledMatch = new UrlMatch<string>();
+    disabledMatch.setupSorter(commonSorter);
+    const uuidSort: Record<string, number> = {};
+    const scripts = await this.scriptDAO.all();
+    for (const script of scripts) {
+      if (script.type !== SCRIPT_TYPE_NORMAL || script.status !== SCRIPT_STATUS_DISABLE) {
+        continue;
+      }
+      // 前台 UserScript 腳本 並 已停用
+
+      let patterns = this.cachedPatterns.get(script.uuid);
+      if (!patterns) {
+        const scriptRes = buildScriptRunResourceBasic(script);
+        const p = scriptURLPatternResults(scriptRes);
+        if (!p) continue;
+        this.cachedPatterns.set(script.uuid, p);
+        patterns = p;
+      }
+
+      const { uuid, sort } = script;
+      const uuidOri = `${uuid}${ORIGINAL_URLMATCH_SUFFIX}`;
+      uuidSort[uuid] = sort;
+      uuidSort[uuidOri] = sort;
+      disabledMatch.addRules(uuid, patterns.scriptUrlPatterns);
+      if (patterns.originalUrlPatterns !== patterns.scriptUrlPatterns) {
+        disabledMatch.addRules(uuidOri, patterns.originalUrlPatterns);
+      }
+    }
+    return disabledMatch;
   }
 
   async updateSites() {
@@ -1125,163 +1262,76 @@ export class RuntimeService {
     }
 
     // 匹配当前页面的脚本（只包含有效脚本。自定义排除了的不包含）
-    const matchingResult = this.getPageScriptMatchingResultByUrl(url, false, false);
+    const matchingResult = this.getPageScriptMatchingResultByUrlInternal(url, false, false);
 
     // 该网址没有任何脚本匹配，包括排除匹配
     if (!matchingResult.size) return null;
 
-    const enableScriptList = [] as (ScriptLoadInfo & { scriptUrlPatterns: URLRuleEntry[] })[];
+    const matchingUuids = [...matchingResult.keys()];
+    const enableScriptListByIndex = new Array<(ScriptLoadInfo & { scriptUrlPatterns: URLRuleEntry[] }) | undefined>(
+      matchingUuids.length
+    );
+    const cacheMisses = [] as {
+      index: number;
+      script: Script;
+      scriptRes: ScriptRunResource;
+      scriptCacheKey: string;
+    }[];
 
-    const uuids = [...matchingResult.keys()];
+    const matchingScripts = await this.scriptDAO.gets(matchingUuids);
 
-    const [scripts, compiledResources] = await Promise.all([
-      this.scriptDAO.gets(uuids),
-      this.compiledResourceDAO.gets(uuids),
-    ]);
+    for (let idx = 0, l = matchingUuids.length; idx < l; idx++) {
+      const matchingScript = matchingScripts[idx];
+      if (!matchingScript) continue;
 
-    const resourceChecks = {} as { [uuid: string]: Record<string, [string, ResourceType]> };
-
-    for (let idx = 0, l = uuids.length; idx < l; idx++) {
-      const uuid = uuids[idx];
-      const script = scripts[idx];
-      const compiledResource = compiledResources[idx];
-
-      if (!script || !compiledResource) continue;
-      const scriptRes_ = buildScriptRunResourceBasic(script);
-      const { scriptUrlPatterns, originalUrlPatterns } = compiledResource;
-
-      for (const [_key, res] of Object.entries(scriptRes_.resource)) {
-        if (res.url.startsWith("file:///")) {
-          const resourceCheck =
-            resourceChecks[uuid] || (resourceChecks[uuid] = {} as Record<string, [string, ResourceType]>);
-          resourceCheck[res.url] = [res.hash.sha512, res.type];
-        }
-      }
-
-      // 物件部份内容预设为空
-      const scriptRes = {
-        ...scriptRes_,
-        scriptUrlPatterns: scriptUrlPatterns,
-        originalUrlPatterns: originalUrlPatterns === null ? scriptUrlPatterns : originalUrlPatterns,
-        code: "",
-        value: {},
-        resource: {},
-        metadataStr: "",
-        userConfigStr: "",
-      };
-
-      // 判断脚本是否开启
-      if (scriptRes.status === SCRIPT_STATUS_DISABLE) {
+      const scriptRes = buildScriptRunResourceBasic(matchingScript);
+      if (this.shouldSkipPageLoadScript(scriptRes, frameId)) {
         continue;
       }
-      // 判断注入页面类型
-      if (scriptRes.metadata["run-in"]) {
-        const runIn = scriptRes.metadata["run-in"][0];
-        if (runIn !== "all") {
-          // 判断插件运行环境
-          const contextType = chrome.extension.inIncognitoContext ? "incognito-tabs" : "normal-tabs";
-          if (runIn !== contextType) {
-            continue;
-          }
-        }
+
+      const scriptCacheKey = this.getPageLoadScriptCacheKey(scriptRes);
+      const cache = this.getPageLoadScriptCache(matchingScript.uuid, scriptCacheKey);
+      if (cache) {
+        enableScriptListByIndex[idx] = this.createPageLoadScriptInfo(scriptRes, cache);
+      } else {
+        cacheMisses.push({ index: idx, script: matchingScript, scriptRes, scriptCacheKey });
       }
-      // 如果是iframe,判断是否允许在iframe里运行
-      if (frameId) {
-        if (scriptRes.metadata.noframes) {
-          continue;
-        }
-      }
-      enableScriptList.push(scriptRes);
     }
+
+    if (cacheMisses.length) {
+      const compiledResources = await this.compiledResourceDAO.gets(cacheMisses.map(({ script }) => script.uuid));
+      for (let idx = 0, l = cacheMisses.length; idx < l; idx++) {
+        const { index, script, scriptRes, scriptCacheKey } = cacheMisses[idx];
+        let compiledResource = compiledResources[idx];
+        if (!compiledResource || !compiledResource.scriptUrlPatterns?.length) {
+          const ret = await this.buildAndSaveCompiledResourceFromScript(script, false);
+          compiledResource = ret?.compiledResource;
+        }
+        if (!compiledResource?.scriptUrlPatterns?.length) continue;
+
+        const cache = await this.buildPageLoadScriptCache(scriptRes, compiledResource, scriptCacheKey);
+        this.pageLoadCaches.set(script.uuid, cache);
+        enableScriptListByIndex[index] = this.createPageLoadScriptInfo(scriptRes, cache);
+      }
+    }
+
+    const enableScriptList = enableScriptListByIndex.filter((script) => !!script) as (ScriptLoadInfo & {
+      scriptUrlPatterns: URLRuleEntry[];
+    })[];
 
     // 没有任何启用脚本
     if (!enableScriptList.length) return null;
 
     const scriptCodes = {} as Record<string, string>;
-    // 更新资源使用了file协议的脚本
-    const scriptsWithUpdatedResources = new Map<string, ScriptLoadInfo>();
-    for (const scriptRes of enableScriptList) {
-      const uuid = scriptRes.uuid;
-      const resourceCheck = resourceChecks[uuid];
-      if (resourceCheck) {
-        let resourceUpdated = false;
-        for (const [url, [sha512, type]] of Object.entries(resourceCheck)) {
-          const resourceList = scriptRes.metadata[type];
-          if (!resourceList) continue;
-          const updatedResource = await this.resource.updateResource(scriptRes.uuid, url, type);
-          if (updatedResource.hash?.sha512 !== sha512) {
-            for (const uri of resourceList) {
-              /** 资源键名 */
-              let resourceKey = uri;
-              /** 文件路径 */
-              let path: string | null = uri;
-              if (type === "resource") {
-                // @resource xxx https://...
-                const split = uri.split(/\s+/);
-                if (split.length === 2) {
-                  resourceKey = split[0];
-                  path = split[1].trim();
-                } else {
-                  path = null;
-                }
-              }
-              if (path === url) {
-                const r = scriptRes.resource[resourceKey];
-                if (r) {
-                  resourceUpdated = true;
-                  r.content = updatedResource.content;
-                  r.contentType = updatedResource.contentType;
-                  r.createtime = updatedResource.createtime;
-                  r.hash = updatedResource.hash;
-                  r.link = updatedResource.link;
-                  r.type = updatedResource.type;
-                  r.updatetime = updatedResource.updatetime;
-                }
-              }
-            }
-          }
-        }
-        if (resourceUpdated) {
-          scriptsWithUpdatedResources.set(scriptRes.uuid, scriptRes);
-          scriptCodes[scriptRes.uuid] = scriptRes.code || "";
-        }
-      }
-    }
+    const scriptsWithUpdatedResources = await this.refreshLocalResourcesForPageLoad(enableScriptList, scriptCodes);
 
-    const { value, resource, scriptDAO } = this;
     await Promise.all(
-      enableScriptList.flatMap((script) => [
-        // 加载value
-        value.getScriptValue(script!).then((value) => {
+      enableScriptList.map((script) =>
+        // 加载value；value 不进入 page-load cache，每次都取最新值
+        this.value.getScriptValue(script).then((value) => {
           script.value = value;
-        }),
-        // 加载resource
-        resource.getScriptResources(script, false).then((resource) => {
-          script.resource = resource;
-          for (const name of Object.keys(resource)) {
-            const res = script.resource[name];
-            // 删除base64以节省资源
-            // 如果有content就删除base64
-            if (res.content) {
-              res.base64 = undefined;
-            }
-          }
-        }),
-        // 加载code相关的信息
-        scriptDAO.scriptCodeDAO.get(script.uuid).then((code) => {
-          if (code) {
-            const metadataStr = getMetadataStr(code.code) || "";
-            const userConfigStr = getUserConfigStr(code.code) || "";
-            const userConfig = parseUserConfig(userConfigStr);
-            script.metadataStr = metadataStr;
-            script.userConfigStr = userConfigStr;
-            script.userConfig = userConfig;
-            if (scriptCodes[script.uuid] === "") {
-              scriptCodes[script.uuid] = code.code;
-            }
-          }
-        }),
-      ])
+        })
+      )
     );
 
     if (scriptsWithUpdatedResources.size) {
@@ -1353,6 +1403,203 @@ export class RuntimeService {
     } satisfies TScriptsForTab;
   }
 
+  private shouldSkipPageLoadScript(scriptRes: ScriptRunResource, frameId: number | undefined) {
+    // 判断脚本是否开启
+    if (scriptRes.status === SCRIPT_STATUS_DISABLE) {
+      return true;
+    }
+    // 判断注入页面类型
+    if (scriptRes.metadata["run-in"]) {
+      const runIn = scriptRes.metadata["run-in"][0];
+      if (runIn !== "all") {
+        // 判断插件运行环境
+        const contextType = chrome.extension.inIncognitoContext ? "incognito-tabs" : "normal-tabs";
+        if (runIn !== contextType) {
+          return true;
+        }
+      }
+    }
+    // 如果是iframe,判断是否允许在iframe里运行
+    if (frameId && scriptRes.metadata.noframes) {
+      return true;
+    }
+    return false;
+  }
+
+  private getPageLoadScriptCacheKey(scriptRes: ScriptRunResource) {
+    const { status, type, updatetime, metadata, originalMetadata, selfMetadata } = scriptRes;
+    const objectKeys = {
+      metadata: metadata,
+      originalMetadata: originalMetadata,
+      selfMetadata: selfMetadata || {},
+    };
+    return `${status}:${type}:${updatetime || 0}~${JSON.stringify(objectKeys)}`;
+  }
+
+  private getScriptCodeCacheKey(script: Script) {
+    return `${script.createtime || 0}:${script.updatetime || 0}`;
+  }
+
+  private getPageLoadScriptCache(uuid: string, scriptCacheKey: string) {
+    const cache = this.pageLoadCaches.get(uuid);
+    if (!cache) return undefined;
+    if (cache.scriptCacheKey !== scriptCacheKey || !cache.scriptUrlPatterns?.length) {
+      this.pageLoadCaches.delete(uuid);
+      return undefined;
+    }
+    return cache;
+  }
+
+  private createPageLoadScriptInfo(scriptRes: ScriptRunResource, cache: TPageLoadScriptCache) {
+    return {
+      ...scriptRes,
+      scriptUrlPatterns: cache.scriptUrlPatterns,
+      originalUrlPatterns: cache.originalUrlPatterns === null ? cache.scriptUrlPatterns : cache.originalUrlPatterns,
+      code: "",
+      value: {},
+      resource: this.cloneRuntimeResources(cache.resource),
+      metadataStr: cache.metadataStr,
+      userConfigStr: cache.userConfigStr,
+      userConfig: cache.userConfig || undefined,
+    } as ScriptLoadInfo & { scriptUrlPatterns: URLRuleEntry[] };
+  }
+
+  private cloneRuntimeResource(resource: Resource | TRuntimeResource) {
+    const ret = { ...resource } as TRuntimeResource;
+    // 删除base64以节省资源；如果有content就删除base64
+    if (ret.content) {
+      ret.base64 = undefined;
+    }
+    return ret;
+  }
+
+  private cloneRuntimeResources(resources: Record<string, Resource | TRuntimeResource>) {
+    const ret = {} as Record<string, TRuntimeResource>;
+    for (const [name, resource] of Object.entries(resources)) {
+      ret[name] = this.cloneRuntimeResource(resource);
+    }
+    return ret;
+  }
+
+  private getLocalResourceCacheList(scriptRes: ScriptRunResource, resources: Record<string, TRuntimeResource>) {
+    const ret: TLocalResourceCache[] = [];
+    const collect = (type: ResourceType) => {
+      for (const uri of scriptRes.metadata[type] || []) {
+        let resourceKey = uri;
+        let path: string | null = uri;
+        if (type === "resource") {
+          // @resource xxx file:///...
+          const split = uri.split(/\s+/);
+          if (split.length === 2) {
+            resourceKey = split[0];
+            path = split[1].trim();
+          } else {
+            path = null;
+          }
+        }
+        if (path?.startsWith("file:///")) {
+          ret.push({
+            resourceKey,
+            url: path,
+            type,
+            sha512: resources[resourceKey]?.hash?.sha512 || "",
+          });
+        }
+      }
+    };
+    collect("require");
+    collect("require-css");
+    collect("resource");
+    return ret;
+  }
+
+  private async buildPageLoadScriptCache(
+    scriptRes: ScriptRunResource,
+    compiledResource: CompiledResource,
+    scriptCacheKey: string
+  ): Promise<TPageLoadScriptCache> {
+    const [resources, codeInfo] = await Promise.all([
+      this.resource.getScriptResources(scriptRes, false).then((resources) => this.cloneRuntimeResources(resources)),
+      this.getScriptInfoForCode(scriptRes),
+    ]);
+    return {
+      scriptCacheKey,
+      scriptUrlPatterns: compiledResource.scriptUrlPatterns,
+      originalUrlPatterns: compiledResource.originalUrlPatterns,
+      code: codeInfo.code,
+      metadataStr: codeInfo.metadataStr,
+      userConfigStr: codeInfo.userConfigStr,
+      userConfig: codeInfo.userConfig,
+      resource: resources,
+      localResources: this.getLocalResourceCacheList(scriptRes, resources),
+    };
+  }
+
+  private async refreshLocalResourcesForPageLoad(
+    enableScriptList: (ScriptLoadInfo & {
+      scriptUrlPatterns: URLRuleEntry[];
+    })[],
+    scriptCodes: Record<string, string>
+  ) {
+    const scriptsWithUpdatedResources = new Map<string, ScriptLoadInfo>();
+    for (const scriptRes of enableScriptList) {
+      const cache = this.pageLoadCaches.get(scriptRes.uuid);
+      if (!cache?.localResources.length) continue;
+
+      let resourceUpdated = false;
+      for (const localResource of cache.localResources) {
+        let updatedResource: Resource;
+        try {
+          updatedResource = await this.resource.updateResource(scriptRes.uuid, localResource.url, localResource.type);
+        } catch (e) {
+          this.logger.error(
+            "update local resource on page load failed",
+            { uuid: scriptRes.uuid, url: localResource.url },
+            Logger.E(e)
+          );
+          continue;
+        }
+        const nextSha512 = updatedResource.hash?.sha512 || "";
+        if (nextSha512 === localResource.sha512) continue;
+
+        localResource.sha512 = nextSha512;
+        const runtimeResource = this.cloneRuntimeResource(updatedResource);
+        cache.resource[localResource.resourceKey] = runtimeResource;
+        scriptRes.resource[localResource.resourceKey] = runtimeResource;
+        resourceUpdated = true;
+      }
+
+      if (resourceUpdated) {
+        scriptsWithUpdatedResources.set(scriptRes.uuid, scriptRes);
+        scriptCodes[scriptRes.uuid] = cache.code;
+      }
+    }
+    return scriptsWithUpdatedResources;
+  }
+
+  private async getScriptInfoForCode(script: Script): Promise<TCodeCache> {
+    const scriptCacheKey = this.getScriptCodeCacheKey(script);
+    const cached = this.codeCacheMap.get(script.uuid);
+    if (cached?.scriptCacheKey === scriptCacheKey) {
+      return cached;
+    }
+
+    const code = await this.scriptDAO.scriptCodeDAO.get(script.uuid);
+    const codeText = code?.code || "";
+    const metadataStr = code ? getMetadataStr(codeText) || "" : "";
+    const userConfigStr = code ? getUserConfigStr(codeText) || "" : "";
+    const userConfig = userConfigStr ? parseUserConfig(userConfigStr) || null : null;
+    const ret = {
+      scriptCacheKey,
+      code: codeText,
+      metadataStr,
+      userConfigStr,
+      userConfig,
+    };
+    this.codeCacheMap.set(script.uuid, ret);
+    return ret;
+  }
+
   // 停止脚本
   async stopScript(uuid: string) {
     return await stopScript(this.msgSender, uuid);
@@ -1385,13 +1632,13 @@ export class RuntimeService {
     // 清理一下老数据
     this.scriptMatchEnable.clearRules(uuid);
     this.scriptMatchEnable.clearRules(uuidOri);
-    this.scriptMatchDisable.clearRules(uuid);
-    this.scriptMatchDisable.clearRules(uuidOri);
+    this.scriptMatchDisable?.clearRules(uuid);
+    this.scriptMatchDisable?.clearRules(uuidOri);
     const scriptMatch = scriptRes.status === SCRIPT_STATUS_ENABLE ? this.scriptMatchEnable : this.scriptMatchDisable;
     // 添加新的数据
-    scriptMatch.addRules(uuid, scriptUrlPatterns);
+    scriptMatch?.addRules(uuid, scriptUrlPatterns);
     if (originalUrlPatterns && originalUrlPatterns !== scriptUrlPatterns) {
-      scriptMatch.addRules(uuidOri, originalUrlPatterns);
+      scriptMatch?.addRules(uuidOri, originalUrlPatterns);
     }
     return matchInfoEntry;
   }
@@ -1404,6 +1651,7 @@ export class RuntimeService {
     if (!o) {
       return undefined;
     }
+    this.cachedPatterns.set(scriptRes.uuid, o);
     // 构建脚本匹配信息
     return this.scriptMatchEntry(scriptRes, o);
   }

--- a/src/app/service/service_worker/utils.ts
+++ b/src/app/service/service_worker/utils.ts
@@ -19,6 +19,8 @@ import {
 } from "@App/pkg/utils/url_matcher";
 import { cacheInstance } from "@App/app/cache";
 
+type RegisteredUserScriptWithJsCode = RequireField<chrome.userScripts.RegisteredUserScript, "js">;
+
 export function getRunAt(runAts: string[]): chrome.extensionTypes.RunAt {
   // 没有 run-at 时为 undefined. Fallback 至 document_idle
   const runAt = runAts[0] as string | undefined;
@@ -196,7 +198,7 @@ export function getUserScriptRegister(scriptMatchInfo: ScriptMatchInfo) {
     scriptMatchInfo.scriptUrlPatterns.filter((e) => e.ruleType === RuleType.GLOB_EXCLUDE)
   );
 
-  const registerScript: chrome.userScripts.RegisteredUserScript = {
+  const registerScript: RegisteredUserScriptWithJsCode = {
     id: scriptMatchInfo.uuid,
     js: [{ code: "" }],
     matches: matches, // primary

--- a/src/types/main.d.ts
+++ b/src/types/main.d.ts
@@ -7,6 +7,7 @@ declare module "@App/app/types.d.ts";
 type Override<T, U> = Omit<T, keyof U> & U;
 type ValueOf<T> = T[keyof T];
 type ReactStateSetter<T> = (value: T | ((prev: T) => T)) => void;
+type RequireField<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>;
 
 declare const sandbox: Window;
 


### PR DESCRIPTION
## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

本 PR 优化 `RuntimeService.getScriptsForTab` 的页面加载路径，并调整 Popup 对 disabled 脚本的匹配方式，减少 service worker 初始化和页面加载时的重复计算。同时修复了命名 `@resource` 使用 `file:///` 本地资源时未按解析后的路径刷新资源的问题。

### 背景

原来的 `getScriptsForTab` 在每次页面加载时都会重新读取或解析脚本运行所需的多项静态资料，例如 compiled resource、resource、脚本代码、metadata、userConfig 和 URL match 规则。实际页面加载时经常只有脚本 value 需要保持最新，脚本代码、metadata、match 规则和 resource 等静态资料通常不会变化。

另外，service worker 初始化阶段原本会处理全部普通脚本，包括 disabled 脚本。对于安装脚本较多、但实际启用脚本较少的场景，这会带来不必要的启动成本。

### 修改内容

#### 1. 为页面加载增加 service worker 内存缓存

新增 page-load cache，用于缓存单个脚本在页面加载时需要复用的静态资料：

- `scriptUrlPatterns` / `originalUrlPatterns`
- `resource`
- `code`
- `metadataStr`
- `userConfigStr`
- `userConfig`
- 本地 `file:///` resource 的 hash 快照

这些缓存只存在于当前 service worker 生命周期内，不写入持久化存储，也不改变 `getScriptsForTab` 的输入输出结构。

#### 2. `getScriptsForTab` 复用静态资料，只刷新动态 value

新的页面加载流程会先通过 matcher 找到当前 URL 匹配的 enabled 脚本，再按脚本缓存 key 判断 page-load cache 是否可复用。

- cache 命中时，复用 metadata、userConfig、resource、URL patterns 和 code 等静态资料；
- 每次页面加载仍然重新读取脚本 value，保证 `GM_setValue` 等 value 更新可以及时反映；
- cache 未命中时才重新构建 compiled resource、读取 resource、读取脚本代码并解析 metadata / userConfig。

cache key 覆盖会影响运行静态资料的字段，包括 `metadata`、`originalMetadata`、`selfMetadata`、`status`、`type` 和 `updatetime`。

#### 3. 保持脚本执行顺序稳定

`getScriptsForTab` 现在会先按 matcher 返回顺序建立结果槽位，再将 cache hit 和 cache miss 的脚本回填到对应位置，避免异步处理 cache miss 时改变脚本执行顺序。

#### 4. 更完整的 runtime cache 清理

新增统一的 runtime cache 清理逻辑，在脚本安装、更新、删除、启用或停用等场景中清理相关缓存，避免复用旧的 page-load cache、code cache 或 matcher pattern cache。

#### 5. 保留 `file:///` 本地资源热更新能力

page-load cache 会记录本地 `file:///` resource 的 hash。页面加载时如果发现本地资源内容变化，会更新：

- page-load cache 中的 resource；
- 当前返回给 content / inject 的 resource；
- 已注册 userScript 使用的注入代码。

同时修复 `ResourceService.getScriptResources` 中命名 `@resource` 的本地资源判断逻辑：现在使用解析后的 `path` 判断 `file:///`，而不是原始 `uri`，保证 `@resource name file:///...` 能正确触发本地文件刷新。

#### 6. service worker 初始化只预热 enabled 普通脚本

`waitInit()` 改为：

- 不再通过 `compiledResourceDAO.all()` 读取全部 compiled resource；
- 使用 `CompiledResourceNamespace` 标记判断是否需要清理旧注册；
- 只为 `SCRIPT_TYPE_NORMAL && SCRIPT_STATUS_ENABLE` 的脚本建立 matcher / compiled resource；
- disabled 普通脚本不再在 service worker 启动阶段预热。

这样可以减少“安装大量脚本但只启用少量脚本”时的 service worker 启动开销。

#### 7. Popup disabled 脚本匹配改为按需构建

Popup 获取当前页面脚本匹配结果时，改为调用专用入口：

```ts
getPopupPageScriptMatchingResultByUrl(url)
````

该入口会在 Popup 首次请求时按需构建 disabled matcher，后续 Popup 请求复用该 matcher。普通页面加载路径只维护 enabled matcher，不再被 disabled 脚本拖慢。

当脚本安装、更新、删除、启用、停用或排序变化时，会同步清理或更新相关 matcher / sorter 缓存，保证 Popup 结果仍能按 sort 顺序返回，并正确保留 effective / non-effective 状态。

#### 8. 类型收紧

新增 `RequireField<T, K>` 工具类型，并将部分 userScripts 注册结构收紧为必须包含 `js` 字段，避免内部构造注册脚本时出现类型约束不明确的问题。

### 测试覆盖

本 PR 补充和调整了 runtime / resource 单元测试，覆盖：

* page-load cache 命中时复用静态资料；
* 每次页面加载仍然刷新 script value；
* 全局停用、黑名单、无匹配脚本时直接返回 `null`；
* `run-in`、`noframes`、`inject-into` 等过滤和拆分逻辑；
* cache hit / miss 混合时保持脚本顺序；
* 脚本更新时间变化后重建 page-load cache；
* `file:///` resource 变化后更新缓存、返回结果和已注册 userScript；
* 命名 `@resource name file:///...` 会立即刷新本地文件；
* Popup 按需匹配 disabled 脚本，并复用 disabled matcher；
* runtime cache 清理后 Popup disabled matcher 会重建；
* Popup 合并 enabled / disabled 匹配结果，并保留 effective / non-effective 状态；
* disabled 脚本按 sort 顺序返回；
* 非普通脚本、enabled 脚本、无匹配规则的 disabled 脚本不会进入 disabled 扫描结果。

### 兼容性

* 不改变 `getScriptsForTab` 的输入输出结构；
* 不改变 content / inject 接收到的数据格式；
* 不改变持久化数据结构；
* 新增缓存均为 service worker 内存缓存，service worker 重启后会按现有流程重新建立。

## Screenshots / 截图

<!-- Screenshots / 截图-->

