### PR TITLE
fix(sync): (Codex) OneDrive zero-byte upload fix

### DIFF
--- a/packages/filesystem/onedrive/onedrive.test.ts
+++ b/packages/filesystem/onedrive/onedrive.test.ts
@@ -127,4 +127,55 @@ describe("OneDriveFileSystem", () => {
       name: "B",
     });
   });
+
+  it("writer should upload empty string with simple PUT", async () => {
+    const fs = new OneDriveFileSystem("/", "token");
+    const requestSpy = vi.spyOn(fs, "request").mockResolvedValue({});
+
+    const writer = await fs.create("empty.txt");
+    await writer.write("");
+
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    expect(requestSpy.mock.calls[0][0]).toBe(
+      "https://graph.microsoft.com/v1.0/me/drive/special/approot:/empty.txt:/content"
+    );
+    expect(requestSpy.mock.calls[0][1]).toMatchObject({
+      method: "PUT",
+      body: "",
+    });
+  });
+
+  it("writer should upload empty Blob with simple PUT", async () => {
+    const fs = new OneDriveFileSystem("/", "token");
+    const requestSpy = vi.spyOn(fs, "request").mockResolvedValue({});
+    const emptyBlob = new Blob([]);
+
+    const writer = await fs.create("empty.bin");
+    await writer.write(emptyBlob);
+
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    expect(requestSpy.mock.calls[0][0]).toBe(
+      "https://graph.microsoft.com/v1.0/me/drive/special/approot:/empty.bin:/content"
+    );
+    expect((requestSpy.mock.calls[0][1] as RequestInit).body).toBe(emptyBlob);
+  });
+
+  it("writer should keep upload session for non-empty content", async () => {
+    const fs = new OneDriveFileSystem("/", "token");
+    const requestSpy = vi
+      .spyOn(fs, "request")
+      .mockResolvedValueOnce({ uploadUrl: "https://upload.example/session" })
+      .mockResolvedValueOnce({});
+
+    const writer = await fs.create("not-empty.txt");
+    await writer.write("abc");
+
+    expect(requestSpy).toHaveBeenCalledTimes(2);
+    expect(requestSpy.mock.calls[0][0]).toBe(
+      "https://graph.microsoft.com/v1.0/me/drive/special/approot:/not-empty.txt:/createUploadSession"
+    );
+    expect(requestSpy.mock.calls[1][0]).toBe("https://upload.example/session");
+    const headers = (requestSpy.mock.calls[1][1] as RequestInit).headers as Headers;
+    expect(headers.get("Content-Range")).toBe("bytes 0-2/3");
+  });
 });

--- a/packages/filesystem/onedrive/rw.ts
+++ b/packages/filesystem/onedrive/rw.ts
@@ -58,7 +58,14 @@ export class OneDriveFileWriter implements FileWriter {
 
   async write(content: string | Blob): Promise<void> {
     // 预上传获取id
-    const size = this.size(content).toString();
+    const size = this.size(content);
+    if (size === 0) {
+      return this.fs.request(`https://graph.microsoft.com/v1.0/me/drive/special/approot:${this.path}:/content`, {
+        method: "PUT",
+        body: content,
+      });
+    }
+
     let myHeaders = new Headers();
     myHeaders.append("Content-Type", "application/json");
     const uploadUrl = await this.fs
@@ -83,7 +90,7 @@ export class OneDriveFileWriter implements FileWriter {
         return data.uploadUrl;
       });
     myHeaders = new Headers();
-    myHeaders.append("Content-Range", `bytes 0-${parseInt(size, 10) - 1}/${size}`);
+    myHeaders.append("Content-Range", `bytes 0-${size - 1}/${size}`);
     return this.fs.request(uploadUrl, {
       method: "PUT",
       body: content,


### PR DESCRIPTION

**问题分析**
当前 `OneDriveFileWriter.write()` 对所有内容都走 `createUploadSession`，然后生成：

```text
Content-Range: bytes 0-${size - 1}/${size}
```

当内容为空时，`size = 0`，会变成非法 header：

```text
Content-Range: bytes 0--1/0
```

这会导致空脚本、空资源、空元数据上传到 OneDrive 失败。这个问题不依赖 typed error、同步冲突检测或缓存修复。

**本地改动**
改了 packages/filesystem/onedrive/rw.ts  ：
当 `size === 0` 时，改用 OneDrive simple upload：

```text
PUT /me/drive/special/approot:{path}:/content
```

非空内容继续使用原来的 upload session 路径，避免扩大行为变更。

补了测试在 packages/filesystem/onedrive/onedrive.test.ts：

- 空字符串走 simple PUT，不创建 upload session
- 空 Blob 走 simple PUT
- 非空内容仍走 upload session
- 非空 `Content-Range` 仍为正常值，例如 `bytes 0-2/3`

