### PR TITLE
fix(sync): (Codex) 为云同步上传补充 modifiedDate （写入 S3 自定义元数据）

### DIFF
--- a/packages/filesystem/s3/rw.ts
+++ b/packages/filesystem/s3/rw.ts
@@ -65,7 +65,7 @@ export class S3FileWriter implements FileWriter {
       "content-type": "application/octet-stream",
     };
     if (this.modifiedDate) {
-      // 通过自定义元数据保存创建时间（ISO 8601 格式）
+      // 历史兼容：S3 侧使用 createtime 元数据保存文件时间，实际来源是 FileCreateOptions.modifiedDate。
       headers["x-amz-meta-createtime"] = new Date(this.modifiedDate).toISOString();
     }
 

--- a/packages/filesystem/s3/s3.test.ts
+++ b/packages/filesystem/s3/s3.test.ts
@@ -184,6 +184,24 @@ describe("S3FileSystem", () => {
         })
       );
     });
+
+    it("S3FileWriter.write 应在传入 modifiedDate 时写入 createtime 元数据", async () => {
+      (mockClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(createMockResponse({ ok: true }));
+
+      const writer = await fs.create("output.txt", { modifiedDate: 1234 });
+      await writer.write("hello world");
+
+      expect(mockClient.request).toHaveBeenCalledWith(
+        "PUT",
+        "test-bucket",
+        "output.txt",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "x-amz-meta-createtime": new Date(1234).toISOString(),
+          }),
+        })
+      );
+    });
   });
 
   // ---- createDir ----

--- a/packages/filesystem/s3/s3.test.ts
+++ b/packages/filesystem/s3/s3.test.ts
@@ -185,7 +185,7 @@ describe("S3FileSystem", () => {
       );
     });
 
-    it("S3FileWriter.write 应在传入 modifiedDate 时写入 createtime 元数据", async () => {
+    it("S3FileWriter.write 应将 modifiedDate 写入兼容用的 createtime 元数据", async () => {
       (mockClient.request as ReturnType<typeof vi.fn>).mockResolvedValue(createMockResponse({ ok: true }));
 
       const writer = await fs.create("output.txt", { modifiedDate: 1234 });

--- a/src/app/service/service_worker/synchronize.test.ts
+++ b/src/app/service/service_worker/synchronize.test.ts
@@ -445,6 +445,112 @@ console.log("ok");`
     });
   });
 
+  it("passes script modifiedDate when pushing script and meta files", async () => {
+    const writeMock = vi.fn().mockResolvedValue(undefined);
+    const createMock = vi.fn().mockResolvedValue({ write: writeMock });
+    const fs = createFs({
+      create: createMock,
+    });
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        scriptCodeDAO: {
+          get: vi.fn().mockResolvedValue({ code: "// code" }),
+        },
+        all: vi.fn().mockResolvedValue([]),
+      } as any
+    );
+    const script = {
+      uuid: "push-uuid",
+      name: "push",
+      origin: "origin",
+      downloadUrl: "download-url",
+      checkUpdateUrl: "check-update-url",
+      updatetime: 1234,
+      createtime: 1000,
+      status: 1,
+      sort: 0,
+      metadata: {},
+    };
+
+    await service.pushScript(fs, script as any);
+
+    expect(createMock.mock.calls[0]).toEqual(["push-uuid.user.js", { modifiedDate: 1234 }]);
+    expect(createMock.mock.calls[1]).toEqual(["push-uuid.meta.json", { modifiedDate: 1234 }]);
+  });
+
+  it("uses Date.now as modifiedDate when writing scriptcat-sync.json", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(9876);
+    const createMock = vi.fn().mockResolvedValue({
+      write: vi.fn().mockResolvedValue(undefined),
+    });
+    const fs = createFs({
+      create: createMock,
+    });
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        scriptCodeDAO: {},
+        all: vi.fn().mockResolvedValue([]),
+      } as any
+    );
+
+    try {
+      await service.syncOnce(syncConfig, fs);
+
+      expect(createMock).toHaveBeenCalledWith("scriptcat-sync.json", {
+        modifiedDate: 9876,
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("uses Date.now as modifiedDate when writing delete tombstone meta", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(6789);
+    const createMock = vi.fn().mockResolvedValue({
+      write: vi.fn().mockResolvedValue(undefined),
+    });
+    const fs = createFs({
+      create: createMock,
+    });
+    const service = new SynchronizeService(
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {
+        scriptCodeDAO: {},
+        all: vi.fn().mockResolvedValue([]),
+      } as any
+    );
+
+    try {
+      await service.deleteCloudScript(fs, "delete-uuid", true);
+
+      expect(createMock).toHaveBeenCalledWith("delete-uuid.meta.json", {
+        modifiedDate: 6789,
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it("preserves cloud-native digest and does not overwrite with pushed md5", async () => {
     // 各后端 digest 格式不一致（webdav/onedrive 是 etag、dropbox 是 content_hash 等），
     // 上传后再次 list 已经能拿到原生 digest 时，必须保留它，不能被本地 md5 覆盖，

--- a/src/app/service/service_worker/synchronize.ts
+++ b/src/app/service/service_worker/synchronize.ts
@@ -66,7 +66,7 @@ type ScriptcatSyncStatus = {
   updatetime: number; // 更新时间
 };
 
-type PushScriptParam = TInstallScriptParams;
+type PushScriptParam = TInstallScriptParams & Partial<Pick<Script, "createtime" | "updatetime">>;
 
 type FileDigestMap = {
   [key: string]: string;
@@ -535,7 +535,9 @@ export class SynchronizeService {
         }
       });
       // 保存脚本猫同步状态
-      const syncFile = await fs.create("scriptcat-sync.json");
+      const syncFile = await fs.create("scriptcat-sync.json", {
+        modifiedDate: Date.now(),
+      });
       await syncFile.write(JSON.stringify(scriptcatSync, null, 2));
       this.logger.info("sync scriptcat-sync.json file success");
     }
@@ -575,7 +577,9 @@ export class SynchronizeService {
       await fs.delete(filename);
       if (syncDelete) {
         // 留下一个.meta.json删除标记
-        const meta = await fs.create(`${uuid}.meta.json`);
+        const meta = await fs.create(`${uuid}.meta.json`, {
+          modifiedDate: Date.now(),
+        });
         await meta.write(
           JSON.stringify(<SyncMeta>{
             uuid: uuid,
@@ -606,12 +610,13 @@ export class SynchronizeService {
       file: filename,
     });
     try {
-      const w = await fs.create(filename);
+      const modifiedDate = script.updatetime || script.createtime || Date.now();
+      const w = await fs.create(filename, { modifiedDate });
       // 获取脚本代码
       const code = await this.scriptCodeDAO.get(script.uuid);
       const scriptCode = code!.code;
       await w.write(scriptCode);
-      const meta = await fs.create(metaFilename);
+      const meta = await fs.create(metaFilename, { modifiedDate });
       const metaJson = JSON.stringify(<SyncMeta>{
         uuid: script.uuid,
         origin: script.origin,

--- a/src/app/service/service_worker/synchronize.ts
+++ b/src/app/service/service_worker/synchronize.ts
@@ -74,6 +74,10 @@ type FileDigestMap = {
 
 const SYNC_SERVICE_TASK_KEY = "cloud_sync_queue";
 
+function getScriptModifiedDate(script: PushScriptParam): number {
+  return script.updatetime || script.createtime || Date.now();
+}
+
 export class SynchronizeService {
   logger: Logger;
 
@@ -423,7 +427,9 @@ export class SynchronizeService {
                 await this.script.deleteScript(script.uuid, "sync");
                 InfoNotification(
                   i18n.t("notification.script_sync_delete"),
-                  i18n.t("notification.script_sync_delete_desc", { scriptName: i18nName(script) })
+                  i18n.t("notification.script_sync_delete_desc", {
+                    scriptName: i18nName(script),
+                  })
                 );
               } else {
                 // 否则认为是一个无效的.meta文件，进行删除，并进行同步
@@ -535,9 +541,8 @@ export class SynchronizeService {
         }
       });
       // 保存脚本猫同步状态
-      const syncFile = await fs.create("scriptcat-sync.json", {
-        modifiedDate: Date.now(),
-      });
+      const modifiedDate = Date.now();
+      const syncFile = await fs.create("scriptcat-sync.json", { modifiedDate });
       await syncFile.write(JSON.stringify(scriptcatSync, null, 2));
       this.logger.info("sync scriptcat-sync.json file success");
     }
@@ -577,9 +582,8 @@ export class SynchronizeService {
       await fs.delete(filename);
       if (syncDelete) {
         // 留下一个.meta.json删除标记
-        const meta = await fs.create(`${uuid}.meta.json`, {
-          modifiedDate: Date.now(),
-        });
+        const modifiedDate = Date.now();
+        const meta = await fs.create(`${uuid}.meta.json`, { modifiedDate });
         await meta.write(
           JSON.stringify(<SyncMeta>{
             uuid: uuid,
@@ -610,7 +614,7 @@ export class SynchronizeService {
       file: filename,
     });
     try {
-      const modifiedDate = script.updatetime || script.createtime || Date.now();
+      const modifiedDate = getScriptModifiedDate(script);
       const w = await fs.create(filename, { modifiedDate });
       // 获取脚本代码
       const code = await this.scriptCodeDAO.get(script.uuid);


### PR DESCRIPTION
## 背景

S3 writer 已经支持 `FileCreateOptions.modifiedDate`，并会将该时间写入 S3 自定义元数据。但 cloud sync 的上传路径此前没有传递 `modifiedDate`，导致脚本文件、meta 文件、同步状态文件以及删除 tombstone 在 S3 场景下无法写入对应的时间元数据。

本 PR 补齐 cloud sync 到 filesystem writer 的时间传递，让现有 S3 元数据写入能力在同步上传路径中生效。

## 改动内容

- 上传脚本 `.user.js` 时传入脚本文件时间。
- 上传脚本 `.meta.json` 时使用与 `.user.js` 相同的脚本文件时间。
- 写入 `scriptcat-sync.json` 时传入当前同步状态写入时间。
- 写入删除 tombstone `.meta.json` 时传入当前删除标记写入时间。
- 抽出 `getScriptModifiedDate()`，集中脚本文件时间选择逻辑：
  - 优先使用 `script.updatetime`
  - 其次使用 `script.createtime`
  - 最后 fallback 到 `Date.now()`
- 为 S3 writer 的 `x-amz-meta-createtime` 写入补充兼容性注释，说明该字段实际来源是 `FileCreateOptions.modifiedDate`。
- 补充同步层与 S3 writer 测试，验证 `modifiedDate` 会被正确传递和写入。

## 设计说明

`.user.js` 和 `.meta.json` 描述的是同一个脚本实体，同步比较也基于脚本更新时间，因此两者使用同一个 `modifiedDate` 更稳定。

`scriptcat-sync.json` 表示本次同步状态写入，删除 tombstone 表示本次删除标记写入，因此两者使用写入当下的时间。

S3 侧本次继续写入历史兼容字段 `x-amz-meta-createtime`，不改为 `x-amz-meta-modifiedtime`。直接改名可能影响已有对象或旧客户端；如果后续需要让 S3 metadata 参与同步判断，应另开 PR 设计读取策略、双写迁移和兼容逻辑。

## 非目标

- 不改变 cloud sync 的同步比较逻辑。
- 不引入 `x-amz-meta-modifiedtime`。
- 不设计 S3 metadata 的读取和迁移策略。
- 不改动其他 filesystem provider 的时间字段语义。