### PR TITLE
fix(UI): 不支持更新的就不要显示更新

### DIFF
--- a/src/pages/options/routes/ScriptList/components.tsx
+++ b/src/pages/options/routes/ScriptList/components.tsx
@@ -173,8 +173,11 @@ export const UpdateTimeCell = React.memo(({ className, script }: { className?: s
 
   return (
     <Space size={4}>
-      <Tooltip content={t("check_update")} position="tl">
-        <Typography.Text className={`tw-cursor-pointer ${className ?? ""}`} onClick={handleClick}>
+      <Tooltip content={t("check_update")} position="tl" disabled={!script.checkUpdateUrl}>
+        <Typography.Text
+          className={`${script.checkUpdateUrl ? "tw-cursor-pointer" : ""} ${className ?? ""}`}
+          onClick={script.checkUpdateUrl ? handleClick : undefined}
+        >
           {script.updatetime && semTime(new Date(script.updatetime))}
         </Typography.Text>
       </Tooltip>


### PR DESCRIPTION
## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

ScriptCat本身这个把鼠标移过去才知道可以更新的设计本身已经够蠢
如果在不能更新的都显示一个看似可以更新的「按钮」，然后点下去说不支持更新，就显得更蠢。

希望新UI不会再犯这些非人性化的UI/UX问题吧

## Screenshots / 截图

<!-- Screenshots / 截图-->

<img width="169" height="190" alt="Screenshot 2026-05-07 at 19 04 12" src="https://github.com/user-attachments/assets/4d5710b4-af5b-432e-a90e-6f3c2700eecb" />

