### PR TITLE
fix(encoding): (多AI) 重构 encoding.ts 以整合并改进检测机制

### DIFF
--- a/src/app/service/service_worker/resource.ts
+++ b/src/app/service/service_worker/resource.ts
@@ -13,7 +13,7 @@ import { calculateHashFromArrayBuffer } from "@App/pkg/utils/crypto";
 import { isBase64, parseUrlSRI } from "./utils";
 import { stackAsyncTask } from "@App/pkg/utils/async_queue";
 import { blobToUint8Array } from "@App/pkg/utils/datatype";
-import { readBlobContent } from "@App/pkg/utils/encoding";
+import { readRawContent } from "@App/pkg/utils/encoding";
 
 export class ResourceService {
   logger: Logger;
@@ -282,7 +282,7 @@ export class ResourceService {
     };
     if (isText(uint8Array)) {
       if (type === "require" || type === "require-css") {
-        resource.content = await readBlobContent(data, contentType); // @require和@require-css 是会转换成代码运行的，可以进行解码
+        resource.content = await readRawContent(data, contentType); // @require和@require-css 是会转换成代码运行的，可以进行解码
       } else {
         resource.content = await data.text(); // @resource 应该要保留原汁原味
       }

--- a/src/pages/install/App.tsx
+++ b/src/pages/install/App.tsx
@@ -33,7 +33,7 @@ import { CACHE_KEY_SCRIPT_INFO } from "@App/app/cache_key";
 import { cacheInstance } from "@App/app/cache";
 import { formatBytes } from "@App/pkg/utils/utils";
 import { ScriptIcons } from "../options/routes/utils";
-import { readBlobContent } from "@App/pkg/utils/encoding";
+import { readRawContent } from "@App/pkg/utils/encoding";
 import { prettyUrl } from "@App/pkg/utils/url-utils";
 
 const backgroundPromptShownKey = "background_prompt_shown";
@@ -108,10 +108,7 @@ const fetchScriptBody = async (url: string, { onProgress }: { [key: string]: any
   }
 
   const contentType = response.headers.get("content-type");
-  const code = await readBlobContent(
-    new Blob([chunksAll], { type: contentType || "application/octet-stream" }),
-    contentType
-  );
+  const code = await readRawContent(chunksAll, contentType);
 
   const metadata = parseMetadata(code);
   if (!metadata) {

--- a/src/pages/install/App.tsx
+++ b/src/pages/install/App.tsx
@@ -33,7 +33,7 @@ import { CACHE_KEY_SCRIPT_INFO } from "@App/app/cache_key";
 import { cacheInstance } from "@App/app/cache";
 import { formatBytes } from "@App/pkg/utils/utils";
 import { ScriptIcons } from "../options/routes/utils";
-import { bytesDecode, detectEncoding } from "@App/pkg/utils/encoding";
+import { readBlobContent } from "@App/pkg/utils/encoding";
 import { prettyUrl } from "@App/pkg/utils/url-utils";
 
 const backgroundPromptShownKey = "background_prompt_shown";
@@ -107,19 +107,11 @@ const fetchScriptBody = async (url: string, { onProgress }: { [key: string]: any
     position += chunk.length;
   }
 
-  // 检测编码：优先使用 Content-Type，回退到 chardet（仅检测前16KB）
   const contentType = response.headers.get("content-type");
-  const encode = detectEncoding(chunksAll, contentType);
-
-  // 使用检测到的 charset 解码
-  let code;
-  try {
-    code = bytesDecode(encode, chunksAll);
-  } catch (e: any) {
-    console.warn(`Failed to decode response with charset ${encode}: ${e.message}`);
-    // 回退到 UTF-8
-    code = new TextDecoder("utf-8").decode(chunksAll);
-  }
+  const code = await readBlobContent(
+    new Blob([chunksAll], { type: contentType || "application/octet-stream" }),
+    contentType
+  );
 
   const metadata = parseMetadata(code);
   if (!metadata) {

--- a/src/pages/store/favicons.ts
+++ b/src/pages/store/favicons.ts
@@ -2,7 +2,7 @@ import { type Script, ScriptDAO } from "@App/app/repo/scripts";
 import { FaviconDAO, type FaviconFile, type FaviconRecord } from "@App/app/repo/favicon";
 import { v5 as uuidv5 } from "uuid";
 import { getFaviconRootFolder } from "@App/app/service/service_worker/utils";
-import { readBlobContent } from "@App/pkg/utils/encoding";
+import { readRawContent } from "@App/pkg/utils/encoding";
 
 let scriptDAO: ScriptDAO | null = null;
 let faviconDAO: FaviconDAO | null = null;
@@ -149,7 +149,7 @@ export async function fetchIconByDomain(domain: string): Promise<string[]> {
 
   // 获取页面HTML
   const response = await fetch(url, { signal: timeoutAbortSignal(timeout) });
-  const html = await readBlobContent(response, response.headers.get("content-type"));
+  const html = await readRawContent(response, response.headers.get("content-type"));
   const resolvedPageUrl = response.url;
   const resolvedUrl = new URL(resolvedPageUrl);
   const resolvedOrigin = resolvedUrl.origin;

--- a/src/pkg/utils/encoding.test.ts
+++ b/src/pkg/utils/encoding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { bytesDecode, decodeUTF32, parseCharsetFromContentType, readBlobContent } from "./encoding";
+import { bytesDecode, decodeUTF32, parseCharsetFromContentType, readRawContent } from "./encoding";
 
 const blobFromBytes = (bytes: Uint8Array) =>
   new Blob([bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer]);
@@ -9,7 +9,7 @@ const expectReadBlobContentDecodesAs = async (
   encoding: string,
   contentType: string | null = null
 ) => {
-  await expect(readBlobContent(blobFromBytes(bytes), contentType)).resolves.toBe(bytesDecode(encoding, bytes));
+  await expect(readRawContent(blobFromBytes(bytes), contentType)).resolves.toBe(bytesDecode(encoding, bytes));
 };
 
 describe.concurrent("encoding", () => {
@@ -127,14 +127,14 @@ describe.concurrent("encoding", () => {
 
   describe.concurrent("readBlobContent", () => {
     it.concurrent("returns empty string for empty Blob", async () => {
-      await expect(readBlobContent(new Blob([]), null)).resolves.toBe("");
+      await expect(readRawContent(new Blob([]), null)).resolves.toBe("");
     });
 
     it.concurrent("decodes short UTF-8 text without charset", async () => {
       const text = "Hello World";
       const blob = new Blob([text]);
 
-      await expect(readBlobContent(blob, null)).resolves.toBe(text);
+      await expect(readRawContent(blob, null)).resolves.toBe(text);
     });
 
     it.concurrent("uses charset from valid Content-Type header", async () => {
@@ -142,14 +142,14 @@ describe.concurrent("encoding", () => {
       const gbkBytes = new Uint8Array([0xc4, 0xe3, 0xba, 0xc3, 0xca, 0xc0, 0xbd, 0xe7]);
       const blob = new Blob([gbkBytes.buffer]);
 
-      await expect(readBlobContent(blob, "text/plain; charset=gbk")).resolves.toBe(text);
+      await expect(readRawContent(blob, "text/plain; charset=gbk")).resolves.toBe(text);
     });
 
     it.concurrent("falls back when Content-Type charset is invalid", async () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       const text = "Hello World";
 
-      await expect(readBlobContent(new Blob([text]), "text/plain; charset=invalid-charset")).resolves.toBe(text);
+      await expect(readRawContent(new Blob([text]), "text/plain; charset=invalid-charset")).resolves.toBe(text);
 
       warn.mockRestore();
     });
@@ -163,7 +163,7 @@ describe.concurrent("encoding", () => {
         0xa1, 0xa3,
       ]);
 
-      await expect(readBlobContent(blobFromBytes(gbkBytes), "text/plain; charset=bogus")).resolves.toBe(text);
+      await expect(readRawContent(blobFromBytes(gbkBytes), "text/plain; charset=bogus")).resolves.toBe(text);
 
       warn.mockRestore();
     });
@@ -172,30 +172,30 @@ describe.concurrent("encoding", () => {
       const bytes = new Uint8Array([0xef, 0xbb, 0xbf, 0x48, 0x65, 0x6c, 0x6c, 0x6f]);
       const blob = new Blob([bytes.buffer]);
 
-      await expect(readBlobContent(blob, "text/plain; charset=utf-8")).resolves.toBe("Hello");
+      await expect(readRawContent(blob, "text/plain; charset=utf-8")).resolves.toBe("Hello");
     });
 
     it.concurrent("detects UTF-8 BOM", async () => {
       const bytes = new Uint8Array([0xef, 0xbb, 0xbf, 0x48, 0x65, 0x6c, 0x6c, 0x6f]);
       const blob = new Blob([bytes.buffer]);
 
-      await expect(readBlobContent(blob, null)).resolves.toBe("Hello");
+      await expect(readRawContent(blob, null)).resolves.toBe("Hello");
     });
 
     it.concurrent("detects UTF-16 BOM", async () => {
       const utf16le = new Uint8Array([0xff, 0xfe, 0x48, 0x00, 0x69, 0x00]);
       const utf16be = new Uint8Array([0xfe, 0xff, 0x00, 0x48, 0x00, 0x69]);
 
-      await expect(readBlobContent(new Blob([utf16le.buffer]), null)).resolves.toBe("Hi");
-      await expect(readBlobContent(new Blob([utf16be.buffer]), null)).resolves.toBe("Hi");
+      await expect(readRawContent(new Blob([utf16le.buffer]), null)).resolves.toBe("Hi");
+      await expect(readRawContent(new Blob([utf16be.buffer]), null)).resolves.toBe("Hi");
     });
 
     it.concurrent("detects UTF-32 BOM", async () => {
       const utf32le = new Uint8Array([0xff, 0xfe, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x69, 0x00, 0x00, 0x00]);
       const utf32be = new Uint8Array([0x00, 0x00, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x69]);
 
-      await expect(readBlobContent(new Blob([utf32le.buffer]), null)).resolves.toBe("Hi");
-      await expect(readBlobContent(new Blob([utf32be.buffer]), null)).resolves.toBe("Hi");
+      await expect(readRawContent(new Blob([utf32le.buffer]), null)).resolves.toBe("Hi");
+      await expect(readRawContent(new Blob([utf32be.buffer]), null)).resolves.toBe("Hi");
     });
 
     it.concurrent("detects UTF-16 without BOM via null pattern", async () => {
@@ -209,8 +209,8 @@ describe.concurrent("encoding", () => {
         be[i * 2 + 1] = text.charCodeAt(i);
       }
 
-      await expect(readBlobContent(new Blob([le.buffer]), null)).resolves.toBe(text);
-      await expect(readBlobContent(new Blob([be.buffer]), null)).resolves.toBe(text);
+      await expect(readRawContent(new Blob([le.buffer]), null)).resolves.toBe(text);
+      await expect(readRawContent(new Blob([be.buffer]), null)).resolves.toBe(text);
     });
 
     it.concurrent("detects UTF-32 without BOM via null pattern", async () => {
@@ -228,8 +228,8 @@ describe.concurrent("encoding", () => {
         be[i * 4 + 3] = text.charCodeAt(i);
       }
 
-      await expect(readBlobContent(new Blob([le.buffer]), null)).resolves.toBe(text);
-      await expect(readBlobContent(new Blob([be.buffer]), null)).resolves.toBe(text);
+      await expect(readRawContent(new Blob([le.buffer]), null)).resolves.toBe(text);
+      await expect(readRawContent(new Blob([be.buffer]), null)).resolves.toBe(text);
     });
 
     it.concurrent("falls through on invalid UTF null-pattern guesses", async () => {
@@ -241,7 +241,7 @@ describe.concurrent("encoding", () => {
         if (i + 3 < bytes.length) bytes[i + 3] = 0x00;
       }
 
-      await expect(readBlobContent(blobFromBytes(bytes), null)).resolves.toBe(bytesDecode("utf-8", bytes));
+      await expect(readRawContent(blobFromBytes(bytes), null)).resolves.toBe(bytesDecode("utf-8", bytes));
     });
 
     it.concurrent("rejects binary-looking false positive UTF-16 null patterns", async () => {
@@ -250,7 +250,7 @@ describe.concurrent("encoding", () => {
         bytes[i] = i % 2 === 0 ? 0x01 : 0x00;
       }
 
-      const result = await readBlobContent(blobFromBytes(bytes), null);
+      const result = await readRawContent(blobFromBytes(bytes), null);
 
       expect(result).not.toBe(bytesDecode("utf-16le", bytes));
       expect(result).not.toBe(bytesDecode("utf-16be", bytes));
@@ -263,7 +263,7 @@ describe.concurrent("encoding", () => {
         bytes[i] = 0;
       }
 
-      await expect(readBlobContent(blobFromBytes(bytes), null)).resolves.toBe(bytesDecode("utf-8", bytes));
+      await expect(readRawContent(blobFromBytes(bytes), null)).resolves.toBe(bytesDecode("utf-8", bytes));
     });
 
     it.concurrent("does not misclassify even-length legacy CJK bytes as UTF-16 or UTF-32", async () => {
@@ -273,7 +273,7 @@ describe.concurrent("encoding", () => {
         0xa1, 0xa3,
       ]);
 
-      await expect(readBlobContent(blobFromBytes(gbkBytes), null)).resolves.toBe(
+      await expect(readRawContent(blobFromBytes(gbkBytes), null)).resolves.toBe(
         "这是一个GBK编码测试Sentence混合12345。"
       );
     });
@@ -282,7 +282,7 @@ describe.concurrent("encoding", () => {
       const text = "Hello 世界, UTF-8 测试";
       const blob = new Blob([text]);
 
-      await expect(readBlobContent(blob, null)).resolves.toBe(text);
+      await expect(readRawContent(blob, null)).resolves.toBe(text);
     });
 
     it.concurrent("keeps mostly valid UTF-8 with a small corrupt byte as UTF-8", async () => {
@@ -295,7 +295,7 @@ describe.concurrent("encoding", () => {
       bytes[prefixBytes.length] = 0xff;
       bytes.set(suffixBytes, prefixBytes.length + 1);
 
-      await expect(readBlobContent(blobFromBytes(bytes), null)).resolves.toBe(`${prefix}\ufffd${suffix}`);
+      await expect(readRawContent(blobFromBytes(bytes), null)).resolves.toBe(`${prefix}\ufffd${suffix}`);
     });
 
     it.concurrent("handles GitHub release-like UTF-8 text without charset", async () => {
@@ -316,7 +316,7 @@ describe.concurrent("encoding", () => {
       ].join("\n");
       const blob = new Blob([text], { type: "application/octet-stream" });
 
-      const result = await readBlobContent(blob, "application/octet-stream");
+      const result = await readRawContent(blob, "application/octet-stream");
 
       expect(result).toContain("Giảm tốc độ");
       expect(result).toContain("Đã lưu!");
@@ -403,7 +403,7 @@ describe.concurrent("encoding", () => {
           `const message = ${JSON.stringify(item.text)};`,
         ].join("\n");
 
-        const result = await readBlobContent(
+        const result = await readRawContent(
           new Blob([text], { type: "application/octet-stream" }),
           "application/octet-stream"
         );
@@ -418,13 +418,13 @@ describe.concurrent("encoding", () => {
     it.concurrent("correctly decodes UTF-8 content larger than the full validation limit", async () => {
       const text = "Hello 世界 Emoji 🚀\n".repeat(20 * 1024);
 
-      await expect(readBlobContent(new Blob([text]), null)).resolves.toBe(text);
+      await expect(readRawContent(new Blob([text]), null)).resolves.toBe(text);
     });
 
     it.concurrent("keeps a UTF-8 emoji crossing a sampled range boundary intact", async () => {
       const text = `${"a".repeat(16 * 1024 - 2)}🚀${"b".repeat(300 * 1024)}`;
 
-      await expect(readBlobContent(new Blob([text]), null)).resolves.toBe(text);
+      await expect(readRawContent(new Blob([text]), null)).resolves.toBe(text);
     });
 
     it.concurrent("keeps large mostly valid UTF-8 with late corruption as UTF-8", async () => {
@@ -436,7 +436,7 @@ describe.concurrent("encoding", () => {
       bytes[prefix.length] = 0xff;
       bytes.set(suffixBytes, prefix.length + 1);
 
-      const result = await readBlobContent(blobFromBytes(bytes), null);
+      const result = await readRawContent(blobFromBytes(bytes), null);
 
       expect(result).toBe(`${prefix}\ufffd${suffix}`);
       expect(result).toContain(suffix);
@@ -455,7 +455,7 @@ describe.concurrent("encoding", () => {
       bytes.set(gbkBlock, utf8Part.length);
       bytes.set(utf8Part, utf8Part.length + gbkBlock.length);
 
-      const result = await readBlobContent(blobFromBytes(bytes), null);
+      const result = await readRawContent(blobFromBytes(bytes), null);
 
       expect(result).toContain("这是一个GBK编码测试");
     });
@@ -474,8 +474,8 @@ describe.concurrent("encoding", () => {
         0x68, 0x31, 0x32, 0x33,
       ]);
 
-      await expect(readBlobContent(new Blob([gbkBytes.buffer]), null)).resolves.toBe(gbkText);
-      await expect(readBlobContent(new Blob([shiftJisBytes.buffer]), null)).resolves.toBe(shiftJisText);
+      await expect(readRawContent(new Blob([gbkBytes.buffer]), null)).resolves.toBe(gbkText);
+      await expect(readRawContent(new Blob([shiftJisBytes.buffer]), null)).resolves.toBe(shiftJisText);
     });
 
     it.concurrent("preserves legacy fallback fixture coverage through decoded output", async () => {
@@ -585,7 +585,7 @@ describe.concurrent("encoding", () => {
       bytes.set(gbkBytes);
       bytes.set(emojiBytes, gbkBytes.length);
 
-      const result = await readBlobContent(blobFromBytes(bytes), null);
+      const result = await readRawContent(blobFromBytes(bytes), null);
 
       expect(result).toContain("这是一个GBK编码测试Sentence");
     });
@@ -632,7 +632,7 @@ describe.concurrent("encoding", () => {
       bytes.fill(0x61);
       bytes.set(shiftJisBytes, 18 * 1024);
 
-      await expect(readBlobContent(blobFromBytes(bytes), null)).resolves.toBe(
+      await expect(readRawContent(blobFromBytes(bytes), null)).resolves.toBe(
         `${"a".repeat(18 * 1024)}${shiftJisText}${"a".repeat(bytes.length - 18 * 1024 - shiftJisBytes.length)}`
       );
     });
@@ -651,7 +651,7 @@ describe.concurrent("encoding", () => {
         bytes.fill(0x61);
         bytes.set(shiftJisBytes, prefixLength);
 
-        await expect(readBlobContent(blobFromBytes(bytes), null)).resolves.toBe(
+        await expect(readRawContent(blobFromBytes(bytes), null)).resolves.toBe(
           `${"a".repeat(prefixLength)}${shiftJisText}`
         );
       }
@@ -662,7 +662,7 @@ describe.concurrent("encoding", () => {
         0x50, 0x72, 0x69, 0x63, 0x65, 0x3a, 0x20, 0x31, 0x30, 0x80, 0x20, 0x96, 0x20, 0x93, 0x73, 0x70, 0x65, 0x63,
         0x69, 0x61, 0x6c, 0x94,
       ]);
-      const result = await readBlobContent(new Blob([bytes.buffer]), null);
+      const result = await readRawContent(new Blob([bytes.buffer]), null);
 
       expect(result).toBe("Price: 10€ – “special”");
     });
@@ -676,14 +676,20 @@ describe.concurrent("encoding", () => {
         },
       } as Response;
 
-      await expect(readBlobContent(response, "text/plain; charset=utf-8")).resolves.toBe(text);
+      await expect(readRawContent(response, "text/plain; charset=utf-8")).resolves.toBe(text);
+    });
+
+    it.concurrent("handles Uint8Array", async () => {
+      const text = "Uint8Array content";
+      const encoded = new TextEncoder().encode(text);
+      await expect(readRawContent(encoded, "text/plain; charset=utf-8")).resolves.toBe(text);
     });
 
     it.concurrent("handles content larger than 16KB", async () => {
       const text = "a".repeat(20 * 1024);
       const blob = new Blob([text]);
 
-      const result = await readBlobContent(blob, null);
+      const result = await readRawContent(blob, null);
 
       expect(result).toBe(text);
       expect(result.length).toBe(20 * 1024);

--- a/src/pkg/utils/encoding.test.ts
+++ b/src/pkg/utils/encoding.test.ts
@@ -681,7 +681,7 @@ describe.concurrent("encoding", () => {
 
     it.concurrent("handles Uint8Array", async () => {
       const text = "Uint8Array content";
-      const uint8 = new TextEncoder().encode(text);
+      const uint8 = new TextEncoder().encode(text) as Uint8Array<ArrayBuffer>;
       await expect(readRawContent(uint8, "text/plain; charset=utf-8")).resolves.toBe(text);
     });
 

--- a/src/pkg/utils/encoding.test.ts
+++ b/src/pkg/utils/encoding.test.ts
@@ -1,790 +1,691 @@
-import { describe, it, expect, vi } from "vitest";
-import { parseCharsetFromContentType, detectEncoding, bytesDecode, readBlobContent } from "./encoding";
-import { base64ToUint8 } from "./datatype";
-import iconv from "iconv-lite";
+import { describe, expect, it, vi } from "vitest";
+import { bytesDecode, decodeUTF32, parseCharsetFromContentType, readBlobContent } from "./encoding";
 
-describe("encoding detection", () => {
-  describe("parseCharsetFromContentType", () => {
-    it("should extract charset from valid Content-Type header", () => {
+const blobFromBytes = (bytes: Uint8Array) =>
+  new Blob([bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer]);
+
+const expectReadBlobContentDecodesAs = async (
+  bytes: Uint8Array,
+  encoding: string,
+  contentType: string | null = null
+) => {
+  await expect(readBlobContent(blobFromBytes(bytes), contentType)).resolves.toBe(bytesDecode(encoding, bytes));
+};
+
+describe.concurrent("encoding", () => {
+  describe.concurrent("parseCharsetFromContentType", () => {
+    it.concurrent("extracts charset from Content-Type header", () => {
       expect(parseCharsetFromContentType("text/javascript; charset=utf-8")).toBe("utf-8");
       expect(parseCharsetFromContentType("text/plain; charset=GBK")).toBe("gbk");
       expect(parseCharsetFromContentType("application/javascript; charset=ISO-8859-1")).toBe("iso-8859-1");
     });
 
-    it("should handle charset with quotes", () => {
+    it.concurrent("handles quotes and case-insensitive charset parameter", () => {
       expect(parseCharsetFromContentType('text/javascript; charset="utf-8"')).toBe("utf-8");
       expect(parseCharsetFromContentType("text/javascript; charset='gbk'")).toBe("gbk");
-    });
-
-    it("should handle case-insensitive charset parameter", () => {
       expect(parseCharsetFromContentType("text/javascript; CHARSET=UTF-8")).toBe("utf-8");
       expect(parseCharsetFromContentType("text/javascript; Charset=GBK")).toBe("gbk");
     });
 
-    it("should return empty string for missing charset", () => {
+    it.concurrent("returns empty string when charset is missing", () => {
       expect(parseCharsetFromContentType("text/javascript")).toBe("");
       expect(parseCharsetFromContentType("text/plain; boundary=something")).toBe("");
-    });
-
-    it("should return empty string for null or empty input", () => {
       expect(parseCharsetFromContentType(null)).toBe("");
       expect(parseCharsetFromContentType("")).toBe("");
     });
 
-    it("should handle charset with additional parameters", () => {
+    it.concurrent("handles charset with additional parameters", () => {
       expect(parseCharsetFromContentType("text/javascript; charset=utf-8; boundary=xxx")).toBe("utf-8");
+    });
+
+    it.concurrent("handles whitespace around charset assignment", () => {
+      expect(parseCharsetFromContentType("text/plain; charset = UTF-8")).toBe("utf-8");
+      expect(parseCharsetFromContentType("text/plain; charset = UTF-8 boundary=foo")).toBe("utf-8");
+      expect(parseCharsetFromContentType("text/html; charset =  UTF-8  ; next=param")).toBe("utf-8");
     });
   });
 
-  describe("detectEncoding", () => {
-    // Test Tool: https://r12a.github.io/app-encodings/
-    it("Basic Test", () => {
-      let utf8Data: Uint8Array;
-      utf8Data = new TextEncoder().encode("a");
-      expect(detectEncoding(utf8Data, null)).toBe("ascii");
-      utf8Data = new TextEncoder().encode("a1");
-      expect(detectEncoding(utf8Data, null)).toBe("ascii");
-      utf8Data = new TextEncoder().encode("a");
-      expect(detectEncoding(utf8Data, "text/javascript; charset=utf-8")).toBe("utf-8");
-      utf8Data = new TextEncoder().encode("a1");
-      expect(detectEncoding(utf8Data, "text/javascript; charset=big5")).toBe("big5");
-      utf8Data = new TextEncoder().encode("a1");
-      expect(detectEncoding(utf8Data, "text/javascript; charset=big4")).toBe("ascii");
-      utf8Data = new TextEncoder().encode("你");
-      expect(detectEncoding(utf8Data, "text/javascript; charset=big4")).toBe("utf-8");
+  describe.concurrent("bytesDecode", () => {
+    it.concurrent("decodes UTF-8 and strips UTF-8 BOM", () => {
+      const bytes = new Uint8Array([0xef, 0xbb, 0xbf, 0x48, 0x69]);
+      expect(bytesDecode("utf-8", bytes)).toBe("Hi");
     });
-    it("Charset Detection Test (1)", () => {
-      let utf8Data: Uint8Array;
-      utf8Data = new Uint8Array([
-        0xa7,
-        0xda, // 我
-        0xb7,
-        0x52, // 愛
-        0x20, // space
-        0x43, // C
-        0x20, // space
-        0xbb,
-        0x79, // 語
-        0xa8,
-        0xec, // 言
-      ]);
-      expect(detectEncoding(utf8Data, null)).toBe("big5");
 
-      // 這是一個Big5測試句子，包含English與中文123。
-      utf8Data = Uint8Array.from([
-        0xb3, 0x6f, 0xac, 0x4f, 0xa4, 0x40, 0xad, 0xd3, 0x42, 0x69, 0x67, 0x35, 0xb4, 0xfa, 0xb8, 0xd5, 0xa5, 0xdc,
-        0xa4, 0x40, 0xa5, 0x5f, 0xa6, 0x72, 0x45, 0x6e, 0x67, 0x6c, 0x69, 0x73, 0x68, 0xbb, 0x50, 0xa4, 0xa4, 0x31,
-        0x32, 0x33, 0xa1, 0x43,
-      ]);
-      expect(detectEncoding(utf8Data, null)).toBe("big5");
+    it.concurrent("normalizes charset labels before decoding", () => {
+      const bytes = new Uint8Array([0xff, 0xfe, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00]);
 
-      // 这是一个GBK编码测试Sentence混合12345。
-      utf8Data = Uint8Array.from([
+      expect(bytesDecode("UTF-32LE", bytes)).toBe("H");
+    });
+
+    it.concurrent("decodes UTF-16 and UTF-32 variants", () => {
+      const utf16le = new Uint8Array([0xff, 0xfe, 0x48, 0x00, 0x69, 0x00]);
+      const utf16be = new Uint8Array([0xfe, 0xff, 0x00, 0x48, 0x00, 0x69]);
+      const utf32le = new Uint8Array([0xff, 0xfe, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x69, 0x00, 0x00, 0x00]);
+      const utf32be = new Uint8Array([0x00, 0x00, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x69]);
+
+      expect(bytesDecode("utf-16le", utf16le)).toBe("Hi");
+      expect(bytesDecode("utf-16be", utf16be)).toBe("Hi");
+      expect(bytesDecode("utf-32le", utf32le)).toBe("Hi");
+      expect(bytesDecode("utf-32be", utf32be)).toBe("Hi");
+    });
+  });
+
+  describe.concurrent("decodeUTF32", () => {
+    it.concurrent("decodes UTF-32LE and UTF-32BE without BOM", () => {
+      const le = new Uint8Array([0x48, 0x00, 0x00, 0x00, 0x69, 0x00, 0x00, 0x00]);
+      const be = new Uint8Array([0x00, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x69]);
+
+      expect(decodeUTF32(le, true)).toBe("Hi");
+      expect(decodeUTF32(be, false)).toBe("Hi");
+    });
+
+    it.concurrent("strips UTF-32 BOM", () => {
+      const le = new Uint8Array([0xff, 0xfe, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00]);
+      const be = new Uint8Array([0x00, 0x00, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x48]);
+
+      expect(decodeUTF32(le, true)).toBe("H");
+      expect(decodeUTF32(be, false)).toBe("H");
+    });
+
+    it.concurrent("decodes astral code points", () => {
+      const le = new Uint8Array([0x80, 0xf6, 0x01, 0x00, 0x20, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x01, 0x00]);
+      const be = new Uint8Array([0x00, 0x01, 0xf6, 0x80, 0x00, 0x00, 0x00, 0x20, 0x00, 0x01, 0x00, 0x0d]);
+
+      expect(decodeUTF32(le, true)).toBe("🚀 𐀍");
+      expect(decodeUTF32(be, false)).toBe("🚀 𐀍");
+    });
+
+    it.concurrent("throws for non-Uint8Array input", () => {
+      expect(() => decodeUTF32([0, 0, 0, 0] as unknown as Uint8Array)).toThrow(TypeError);
+    });
+
+    it.concurrent("throws when byte length is not a multiple of 4", () => {
+      expect(() => decodeUTF32(new Uint8Array([0x48, 0x00, 0x00]))).toThrow(RangeError);
+    });
+
+    it.concurrent("decodes UTF-32LE from a subarray with non-zero byteOffset", () => {
+      const padded = new Uint8Array([0x00, 0x48, 0x00, 0x00, 0x00, 0x69, 0x00, 0x00, 0x00]);
+
+      expect(decodeUTF32(padded.subarray(1), true)).toBe("Hi");
+    });
+
+    it.concurrent("decodes UTF-32 across chunk boundaries", () => {
+      const count = 16384 * 2 + 1;
+      const le = new Uint8Array(count * 4);
+      for (let i = 0; i < count; i++) {
+        le.set([0x61, 0x00, 0x00, 0x00], i * 4);
+      }
+
+      const result = decodeUTF32(le, true);
+
+      expect(result.length).toBe(count);
+      expect(result[16383]).toBe("a");
+      expect(result[16384]).toBe("a");
+      expect(result[count - 1]).toBe("a");
+    });
+  });
+
+  describe.concurrent("readBlobContent", () => {
+    it.concurrent("returns empty string for empty Blob", async () => {
+      await expect(readBlobContent(new Blob([]), null)).resolves.toBe("");
+    });
+
+    it.concurrent("decodes short UTF-8 text without charset", async () => {
+      const text = "Hello World";
+      const blob = new Blob([text]);
+
+      await expect(readBlobContent(blob, null)).resolves.toBe(text);
+    });
+
+    it.concurrent("uses charset from valid Content-Type header", async () => {
+      const text = "你好世界";
+      const gbkBytes = new Uint8Array([0xc4, 0xe3, 0xba, 0xc3, 0xca, 0xc0, 0xbd, 0xe7]);
+      const blob = new Blob([gbkBytes.buffer]);
+
+      await expect(readBlobContent(blob, "text/plain; charset=gbk")).resolves.toBe(text);
+    });
+
+    it.concurrent("falls back when Content-Type charset is invalid", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const text = "Hello World";
+
+      await expect(readBlobContent(new Blob([text]), "text/plain; charset=invalid-charset")).resolves.toBe(text);
+
+      warn.mockRestore();
+    });
+
+    it.concurrent("falls back when invalid Content-Type charset is used with CJK bytes", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const text = "这是一个GBK编码测试Sentence混合12345。";
+      const gbkBytes = new Uint8Array([
         0xd5, 0xe2, 0xca, 0xc7, 0xd2, 0xbb, 0xb8, 0xf6, 0x47, 0x42, 0x4b, 0xb1, 0xe0, 0xc2, 0xeb, 0xb2, 0xe2, 0xca,
         0xd4, 0x53, 0x65, 0x6e, 0x74, 0x65, 0x6e, 0x63, 0x65, 0xbb, 0xec, 0xba, 0xcf, 0x31, 0x32, 0x33, 0x34, 0x35,
         0xa1, 0xa3,
       ]);
-      expect(detectEncoding(utf8Data, null)).toBe("gb18030");
 
-      // これはShiftJISのテスト文章withEnglish123
-      utf8Data = Uint8Array.from([
+      await expect(readBlobContent(blobFromBytes(gbkBytes), "text/plain; charset=bogus")).resolves.toBe(text);
+
+      warn.mockRestore();
+    });
+
+    it.concurrent("prioritizes Content-Type over BOM", async () => {
+      const bytes = new Uint8Array([0xef, 0xbb, 0xbf, 0x48, 0x65, 0x6c, 0x6c, 0x6f]);
+      const blob = new Blob([bytes.buffer]);
+
+      await expect(readBlobContent(blob, "text/plain; charset=utf-8")).resolves.toBe("Hello");
+    });
+
+    it.concurrent("detects UTF-8 BOM", async () => {
+      const bytes = new Uint8Array([0xef, 0xbb, 0xbf, 0x48, 0x65, 0x6c, 0x6c, 0x6f]);
+      const blob = new Blob([bytes.buffer]);
+
+      await expect(readBlobContent(blob, null)).resolves.toBe("Hello");
+    });
+
+    it.concurrent("detects UTF-16 BOM", async () => {
+      const utf16le = new Uint8Array([0xff, 0xfe, 0x48, 0x00, 0x69, 0x00]);
+      const utf16be = new Uint8Array([0xfe, 0xff, 0x00, 0x48, 0x00, 0x69]);
+
+      await expect(readBlobContent(new Blob([utf16le.buffer]), null)).resolves.toBe("Hi");
+      await expect(readBlobContent(new Blob([utf16be.buffer]), null)).resolves.toBe("Hi");
+    });
+
+    it.concurrent("detects UTF-32 BOM", async () => {
+      const utf32le = new Uint8Array([0xff, 0xfe, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x69, 0x00, 0x00, 0x00]);
+      const utf32be = new Uint8Array([0x00, 0x00, 0xfe, 0xff, 0x00, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00, 0x69]);
+
+      await expect(readBlobContent(new Blob([utf32le.buffer]), null)).resolves.toBe("Hi");
+      await expect(readBlobContent(new Blob([utf32be.buffer]), null)).resolves.toBe("Hi");
+    });
+
+    it.concurrent("detects UTF-16 without BOM via null pattern", async () => {
+      const text = "A".repeat(100);
+      const le = new Uint8Array(text.length * 2);
+      const be = new Uint8Array(text.length * 2);
+      for (let i = 0; i < text.length; i++) {
+        le[i * 2] = text.charCodeAt(i);
+        le[i * 2 + 1] = 0;
+        be[i * 2] = 0;
+        be[i * 2 + 1] = text.charCodeAt(i);
+      }
+
+      await expect(readBlobContent(new Blob([le.buffer]), null)).resolves.toBe(text);
+      await expect(readBlobContent(new Blob([be.buffer]), null)).resolves.toBe(text);
+    });
+
+    it.concurrent("detects UTF-32 without BOM via null pattern", async () => {
+      const text = "A".repeat(100);
+      const le = new Uint8Array(text.length * 4);
+      const be = new Uint8Array(text.length * 4);
+      for (let i = 0; i < text.length; i++) {
+        le[i * 4] = text.charCodeAt(i);
+        le[i * 4 + 1] = 0;
+        le[i * 4 + 2] = 0;
+        le[i * 4 + 3] = 0;
+        be[i * 4] = 0;
+        be[i * 4 + 1] = 0;
+        be[i * 4 + 2] = 0;
+        be[i * 4 + 3] = text.charCodeAt(i);
+      }
+
+      await expect(readBlobContent(new Blob([le.buffer]), null)).resolves.toBe(text);
+      await expect(readBlobContent(new Blob([be.buffer]), null)).resolves.toBe(text);
+    });
+
+    it.concurrent("falls through on invalid UTF null-pattern guesses", async () => {
+      const bytes = new Uint8Array(66);
+      for (let i = 0; i < bytes.length; i += 4) {
+        bytes[i] = 0x61;
+        if (i + 1 < bytes.length) bytes[i + 1] = 0x00;
+        if (i + 2 < bytes.length) bytes[i + 2] = 0x00;
+        if (i + 3 < bytes.length) bytes[i + 3] = 0x00;
+      }
+
+      await expect(readBlobContent(blobFromBytes(bytes), null)).resolves.toBe(bytesDecode("utf-8", bytes));
+    });
+
+    it.concurrent("rejects binary-looking false positive UTF-16 null patterns", async () => {
+      const bytes = new Uint8Array(200);
+      for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = i % 2 === 0 ? 0x01 : 0x00;
+      }
+
+      const result = await readBlobContent(blobFromBytes(bytes), null);
+
+      expect(result).not.toBe(bytesDecode("utf-16le", bytes));
+      expect(result).not.toBe(bytesDecode("utf-16be", bytes));
+    });
+
+    it.concurrent("does not treat borderline null-byte density as UTF-16", async () => {
+      const bytes = new Uint8Array(128);
+      bytes.fill(0x61);
+      for (let i = 0; i < bytes.length; i += 13) {
+        bytes[i] = 0;
+      }
+
+      await expect(readBlobContent(blobFromBytes(bytes), null)).resolves.toBe(bytesDecode("utf-8", bytes));
+    });
+
+    it.concurrent("does not misclassify even-length legacy CJK bytes as UTF-16 or UTF-32", async () => {
+      const gbkBytes = new Uint8Array([
+        0xd5, 0xe2, 0xca, 0xc7, 0xd2, 0xbb, 0xb8, 0xf6, 0x47, 0x42, 0x4b, 0xb1, 0xe0, 0xc2, 0xeb, 0xb2, 0xe2, 0xca,
+        0xd4, 0x53, 0x65, 0x6e, 0x74, 0x65, 0x6e, 0x63, 0x65, 0xbb, 0xec, 0xba, 0xcf, 0x31, 0x32, 0x33, 0x34, 0x35,
+        0xa1, 0xa3,
+      ]);
+
+      await expect(readBlobContent(blobFromBytes(gbkBytes), null)).resolves.toBe(
+        "这是一个GBK编码测试Sentence混合12345。"
+      );
+    });
+
+    it.concurrent("decodes valid UTF-8 text without BOM", async () => {
+      const text = "Hello 世界, UTF-8 测试";
+      const blob = new Blob([text]);
+
+      await expect(readBlobContent(blob, null)).resolves.toBe(text);
+    });
+
+    it.concurrent("keeps mostly valid UTF-8 with a small corrupt byte as UTF-8", async () => {
+      const prefix = "正常中文内容 ";
+      const suffix = " 继续 Emoji 🚀 测试";
+      const prefixBytes = new TextEncoder().encode(prefix);
+      const suffixBytes = new TextEncoder().encode(suffix);
+      const bytes = new Uint8Array(prefixBytes.length + 1 + suffixBytes.length);
+      bytes.set(prefixBytes);
+      bytes[prefixBytes.length] = 0xff;
+      bytes.set(suffixBytes, prefixBytes.length + 1);
+
+      await expect(readBlobContent(blobFromBytes(bytes), null)).resolves.toBe(`${prefix}\ufffd${suffix}`);
+    });
+
+    it.concurrent("handles GitHub release-like UTF-8 text without charset", async () => {
+      const text = [
+        "// ==UserScript==",
+        "// @name         Video Speed Controller",
+        "// @namespace    test",
+        "// @version      1.0.0",
+        "// @description  Adjust and remember video speed using keyboard shortcuts",
+        "// ==/UserScript==",
+        "const padding = 'ascii only';",
+        "/*",
+        "a".repeat(17 * 1024),
+        "*/",
+        'const vi = "Giảm tốc độ";',
+        'const saved = "Đã lưu!";',
+        'const menu = "🛠️ Mở cấu hình";',
+      ].join("\n");
+      const blob = new Blob([text], { type: "application/octet-stream" });
+
+      const result = await readBlobContent(blob, "application/octet-stream");
+
+      expect(result).toContain("Giảm tốc độ");
+      expect(result).toContain("Đã lưu!");
+      expect(result).toContain("🛠️ Mở cấu hình");
+      expect(result).not.toContain("Giáº£m tá»‘c Ä‘á»™");
+      expect(result).not.toContain("ðŸ› ");
+    });
+
+    it.concurrent("keeps valid UTF-8 multilingual userscripts intact without charset", async () => {
+      const cases = [
+        {
+          name: "Vietnamese",
+          text: "Tiếng Việt: Giảm tốc độ, Đã lưu, Mở cấu hình",
+          mojibake: ["Tiáº¿ng Viá»‡t", "Giáº£m"],
+        },
+        {
+          name: "Chinese",
+          text: "中文: 网页抖音体验增强，配置管理器",
+          mojibake: ["ç½‘é¡µ", "é…ç½®"],
+        },
+        {
+          name: "Japanese",
+          text: "日本語: これはテスト文章です",
+          mojibake: ["ã“ã‚Œ", "ãƒ†ã‚¹ãƒˆ"],
+        },
+        {
+          name: "Korean",
+          text: "한국어: 이것은 테스트 문장입니다",
+          mojibake: ["í•œêµ­ì–´", "í…ŒìŠ¤íŠ¸"],
+        },
+        {
+          name: "Cyrillic",
+          text: "Русский: Привет мир, тест кодировки",
+          mojibake: ["Ð ÑƒÑ", "ÐŸÑ€Ð¸Ð²ÐµÑ‚"],
+        },
+        {
+          name: "Arabic",
+          text: "العربية: اختبار ترميز النص",
+          mojibake: ["Ø§Ù„Ø¹Ø±Ø¨ÙŠØ©", "Ø§Ø®ØªØ¨Ø§Ø±"],
+        },
+        {
+          name: "Greek",
+          text: "Ελληνικά: δοκιμή κωδικοποίησης",
+          mojibake: ["Î•Î»Î»", "Î´Î¿ÎºÎ¹Î¼Î®"],
+        },
+        {
+          name: "Hebrew",
+          text: "עברית: בדיקת קידוד טקסט",
+          mojibake: ["×¢×‘×¨×™×ª", "×‘×“×™×§×ª"],
+        },
+        {
+          name: "Thai",
+          text: "ไทย: ทดสอบการเข้ารหัสข้อความ",
+          mojibake: ["à¹„à¸—à¸¢", "à¸—à¸”à¸ªà¸­à¸š"],
+        },
+        {
+          name: "Indic",
+          text: "हिन्दी: पाठ एन्कोडिंग परीक्षण",
+          mojibake: ["à¤¹à¤¿à¤¨", "à¤ªà¤°à¥€à¤•à¥à¤·à¤£"],
+        },
+        {
+          name: "Latin accents",
+          text: "Français/Español/Português: déjà vu, niño, ação",
+          mojibake: ["FranÃ§ais", "EspaÃ±ol", "aÃ§Ã£o"],
+        },
+        {
+          name: "Emoji",
+          text: "Emoji: 🛠️ 🔄 🚀 🎬",
+          mojibake: ["ðŸ› ", "ðŸš€", "ðŸŽ¬"],
+        },
+      ];
+
+      for (const item of cases) {
+        const text = [
+          "// ==UserScript==",
+          `// @name         ${item.name} UTF-8 regression`,
+          "// @namespace    test",
+          "// @version      1.0.0",
+          `// @description  ${item.text}`,
+          "// ==/UserScript==",
+          "/*",
+          "a".repeat(17 * 1024),
+          "*/",
+          `const message = ${JSON.stringify(item.text)};`,
+        ].join("\n");
+
+        const result = await readBlobContent(
+          new Blob([text], { type: "application/octet-stream" }),
+          "application/octet-stream"
+        );
+
+        expect(result, item.name).toContain(item.text);
+        for (const mojibake of item.mojibake) {
+          expect(result, item.name).not.toContain(mojibake);
+        }
+      }
+    });
+
+    it.concurrent("correctly decodes UTF-8 content larger than the full validation limit", async () => {
+      const text = "Hello 世界 Emoji 🚀\n".repeat(20 * 1024);
+
+      await expect(readBlobContent(new Blob([text]), null)).resolves.toBe(text);
+    });
+
+    it.concurrent("keeps a UTF-8 emoji crossing a sampled range boundary intact", async () => {
+      const text = `${"a".repeat(16 * 1024 - 2)}🚀${"b".repeat(300 * 1024)}`;
+
+      await expect(readBlobContent(new Blob([text]), null)).resolves.toBe(text);
+    });
+
+    it.concurrent("keeps large mostly valid UTF-8 with late corruption as UTF-8", async () => {
+      const prefix = "a".repeat(300 * 1024);
+      const suffix = "你好世界 Emoji 🚀";
+      const suffixBytes = new TextEncoder().encode(suffix);
+      const bytes = new Uint8Array(prefix.length + 1 + suffixBytes.length);
+      bytes.fill(0x61, 0, prefix.length);
+      bytes[prefix.length] = 0xff;
+      bytes.set(suffixBytes, prefix.length + 1);
+
+      const result = await readBlobContent(blobFromBytes(bytes), null);
+
+      expect(result).toBe(`${prefix}\ufffd${suffix}`);
+      expect(result).toContain(suffix);
+    });
+
+    it.concurrent("detects legacy CJK bytes hidden between large UTF-8 ranges", async () => {
+      const utf8Part = new TextEncoder().encode("// ==UserScript==\n".repeat(12000));
+      const gbkBlock = new Uint8Array([
+        ...Array.from({ length: 64 }).flatMap(() => [
+          0xd5, 0xe2, 0xca, 0xc7, 0xd2, 0xbb, 0xb8, 0xf6, 0x47, 0x42, 0x4b, 0xb1, 0xe0, 0xc2, 0xeb, 0xb2, 0xe2, 0xca,
+          0xd4,
+        ]),
+      ]);
+      const bytes = new Uint8Array(utf8Part.length * 2 + gbkBlock.length);
+      bytes.set(utf8Part);
+      bytes.set(gbkBlock, utf8Part.length);
+      bytes.set(utf8Part, utf8Part.length + gbkBlock.length);
+
+      const result = await readBlobContent(blobFromBytes(bytes), null);
+
+      expect(result).toContain("这是一个GBK编码测试");
+    });
+
+    it.concurrent("detects legacy CJK encodings when UTF-8 validation fails", async () => {
+      const gbkText = "这是一个GBK编码测试Sentence混合12345。";
+      const gbkBytes = new Uint8Array([
+        0xd5, 0xe2, 0xca, 0xc7, 0xd2, 0xbb, 0xb8, 0xf6, 0x47, 0x42, 0x4b, 0xb1, 0xe0, 0xc2, 0xeb, 0xb2, 0xe2, 0xca,
+        0xd4, 0x53, 0x65, 0x6e, 0x74, 0x65, 0x6e, 0x63, 0x65, 0xbb, 0xec, 0xba, 0xcf, 0x31, 0x32, 0x33, 0x34, 0x35,
+        0xa1, 0xa3,
+      ]);
+      const shiftJisText = "これはShiftJISのテスト文除withEnglish123";
+      const shiftJisBytes = new Uint8Array([
         0x82, 0xb1, 0x82, 0xea, 0x82, 0xcd, 0x53, 0x68, 0x69, 0x66, 0x74, 0x4a, 0x49, 0x53, 0x82, 0xcc, 0x83, 0x65,
         0x83, 0x58, 0x83, 0x67, 0x95, 0xb6, 0x8f, 0x9c, 0x77, 0x69, 0x74, 0x68, 0x45, 0x6e, 0x67, 0x6c, 0x69, 0x73,
         0x68, 0x31, 0x32, 0x33,
       ]);
-      expect(detectEncoding(utf8Data, null)).toBe("shift_jis");
 
-      // 이것은EUC-KR인코딩테스트문장Test123
-      utf8Data = Uint8Array.from([
-        0xc0, 0xcc, 0xb0, 0xcd, 0xc0, 0xba, 0x45, 0x55, 0x43, 0x2d, 0x4b, 0x52, 0xc0, 0xce, 0xc4, 0xda, 0xb5, 0xf9,
-        0xc5, 0xd7, 0xbd, 0xba, 0xc6, 0xae, 0xb9, 0xae, 0xc0, 0xe5, 0x54, 0x65, 0x73, 0x74, 0x31, 0x32, 0x33,
+      await expect(readBlobContent(new Blob([gbkBytes.buffer]), null)).resolves.toBe(gbkText);
+      await expect(readBlobContent(new Blob([shiftJisBytes.buffer]), null)).resolves.toBe(shiftJisText);
+    });
+
+    it.concurrent("preserves legacy fallback fixture coverage through decoded output", async () => {
+      const cases: [Uint8Array, string][] = [
+        [new Uint8Array([0xa7, 0xda, 0xb7, 0x52, 0x20, 0x43, 0x20, 0xbb, 0x79, 0xa8, 0xec]), "big5"],
+        [
+          new Uint8Array([
+            0xb3, 0x6f, 0xac, 0x4f, 0xa4, 0x40, 0xad, 0xd3, 0x42, 0x69, 0x67, 0x35, 0xb4, 0xfa, 0xb8, 0xd5, 0xa5, 0xdc,
+            0xa4, 0x40, 0xa5, 0x5f, 0xa6, 0x72, 0x45, 0x6e, 0x67, 0x6c, 0x69, 0x73, 0x68, 0xbb, 0x50, 0xa4, 0xa4, 0x31,
+            0x32, 0x33, 0xa1, 0x43,
+          ]),
+          "big5",
+        ],
+        [
+          new Uint8Array([
+            0xd5, 0xe2, 0xca, 0xc7, 0xd2, 0xbb, 0xb8, 0xf6, 0x47, 0x42, 0x4b, 0xb1, 0xe0, 0xc2, 0xeb, 0xb2, 0xe2, 0xca,
+            0xd4, 0x53, 0x65, 0x6e, 0x74, 0x65, 0x6e, 0x63, 0x65, 0xbb, 0xec, 0xba, 0xcf, 0x31, 0x32, 0x33, 0x34, 0x35,
+            0xa1, 0xa3,
+          ]),
+          "gb18030",
+        ],
+        [
+          new Uint8Array([
+            0x82, 0xb1, 0x82, 0xea, 0x82, 0xcd, 0x53, 0x68, 0x69, 0x66, 0x74, 0x4a, 0x49, 0x53, 0x82, 0xcc, 0x83, 0x65,
+            0x83, 0x58, 0x83, 0x67, 0x95, 0xb6, 0x8f, 0x9c, 0x77, 0x69, 0x74, 0x68, 0x45, 0x6e, 0x67, 0x6c, 0x69, 0x73,
+            0x68, 0x31, 0x32, 0x33,
+          ]),
+          "shift_jis",
+        ],
+        [
+          new Uint8Array([
+            0xc0, 0xcc, 0xb0, 0xcd, 0xc0, 0xba, 0x45, 0x55, 0x43, 0x2d, 0x4b, 0x52, 0xc0, 0xce, 0xc4, 0xda, 0xb5, 0xf9,
+            0xc5, 0xd7, 0xbd, 0xba, 0xc6, 0xae, 0xb9, 0xae, 0xc0, 0xe5, 0x54, 0x65, 0x73, 0x74, 0x31, 0x32, 0x33,
+          ]),
+          "euc-kr",
+        ],
+        [
+          new Uint8Array([
+            0x43, 0x61, 0x66, 0xe9, 0x20, 0x6e, 0x61, 0xef, 0x76, 0x65, 0x20, 0x72, 0xe9, 0x73, 0x75, 0x6d, 0xe9, 0x20,
+            0x77, 0x69, 0x74, 0x68, 0x20, 0x41, 0x53, 0x43, 0x49, 0x49, 0x20, 0x31, 0x32, 0x33, 0x34, 0x35,
+          ]),
+          "iso-8859-2",
+        ],
+        [
+          new Uint8Array([
+            0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0xe4, 0xb8, 0x96, 0xe7, 0x95, 0x8c, 0x2c, 0x20, 0x74, 0x68, 0x69, 0x73,
+            0x20, 0x69, 0x73, 0x20, 0x55, 0x54, 0x46, 0x38, 0x20, 0xe6, 0xb8, 0xac, 0xe8, 0xa9, 0xa6,
+          ]),
+          "utf-8",
+        ],
+        [
+          new Uint8Array([
+            84, 104, 105, 115, 32, 99, 111, 115, 116, 115, 32, 53, 48, 128, 32, 151, 32, 113, 117, 105, 116, 101, 32,
+            101, 120, 112, 101, 110, 115, 105, 118, 101, 148, 32, 105, 110, 100, 101, 101, 100, 46,
+          ]),
+          "windows-1252",
+        ],
+        [
+          new Uint8Array([
+            69, 108, 32, 110, 105, 241, 111, 32, 99, 111, 109, 105, 243, 32, 112, 105, 241, 97, 116, 97, 32, 121, 32,
+            116, 111, 109, 243, 32, 99, 97, 102, 233, 46,
+          ]),
+          "iso-8859-1",
+        ],
+        [
+          new Uint8Array([
+            208, 210, 201, 215, 197, 212, 32, 205, 201, 210, 32, 49, 50, 51, 32, 65, 66, 67, 32, 212, 197, 211, 212,
+          ]),
+          "koi8-r",
+        ],
+      ];
+
+      for (const [bytes, encoding] of cases) {
+        await expectReadBlobContentDecodesAs(bytes, encoding);
+      }
+    });
+
+    it.concurrent("preserves legacy GBK and GB18030 edge fixture coverage", async () => {
+      const cases: [Uint8Array, string][] = [
+        [new Uint8Array([0xc4, 0xe3, 0xba, 0xc3]), "big5"],
+        [new Uint8Array([0xc4, 0xe3, 0xba, 0xc3, 0xa3, 0xac, 0xca, 0xc0, 0xbd, 0xe7, 0xa3, 0xa1]), "big5"],
+        [new Uint8Array([0xd6, 0xd0, 0xce, 0xc4, 0xb2, 0xe2, 0xca, 0xd4]), "big5"],
+        [
+          new Uint8Array([0xd6, 0xd0, 0xce, 0xc4, 0xb2, 0xe2, 0xca, 0xd4, 0xc0, 0xa9, 0xd5, 0xb9, 0xfd, 0x9d]),
+          "gb18030",
+        ],
+        [
+          new Uint8Array([0xd6, 0xd0, 0xce, 0xc4, 0x81, 0x36, 0x92, 0x32, 0xb2, 0xe2, 0xca, 0xd4, 0x92, 0x57]),
+          "gb18030",
+        ],
+        [new Uint8Array([0xad, 0x71, 0x81, 0x92]), "gb18030"],
+        [new Uint8Array([0xd6, 0xd0, 0xce, 0xc4, 0x95, 0x34, 0xb2, 0x35, 0xb2, 0xe2, 0xca, 0xd4]), "gb18030"],
+      ];
+
+      for (const [bytes, encoding] of cases) {
+        await expectReadBlobContentDecodesAs(bytes, encoding);
+      }
+    });
+
+    it.concurrent("keeps legacy CJK readable when unsupported emoji bytes are present", async () => {
+      const gbkBytes = new Uint8Array([
+        0xd5, 0xe2, 0xca, 0xc7, 0xd2, 0xbb, 0xb8, 0xf6, 0x47, 0x42, 0x4b, 0xb1, 0xe0, 0xc2, 0xeb, 0xb2, 0xe2, 0xca,
+        0xd4, 0x53, 0x65, 0x6e, 0x74, 0x65, 0x6e, 0x63, 0x65,
       ]);
-      expect(detectEncoding(utf8Data, null)).toBe("euc-kr");
+      const emojiBytes = new TextEncoder().encode("🚀");
+      const bytes = new Uint8Array(gbkBytes.length + emojiBytes.length);
+      bytes.set(gbkBytes);
+      bytes.set(emojiBytes, gbkBytes.length);
 
-      // iso-8859-2: Café naïve résumé with ASCII 12345
-      utf8Data = Uint8Array.from([
-        0x43, 0x61, 0x66, 0xe9, 0x20, 0x6e, 0x61, 0xef, 0x76, 0x65, 0x20, 0x72, 0xe9, 0x73, 0x75, 0x6d, 0xe9, 0x20,
-        0x77, 0x69, 0x74, 0x68, 0x20, 0x41, 0x53, 0x43, 0x49, 0x49, 0x20, 0x31, 0x32, 0x33, 0x34, 0x35,
+      const result = await readBlobContent(blobFromBytes(bytes), null);
+
+      expect(result).toContain("这是一个GBK编码测试Sentence");
+    });
+
+    it.concurrent("preserves legacy single-byte fixture coverage", async () => {
+      const cases: [Uint8Array, string][] = [
+        [
+          new Uint8Array([
+            0x43, 0x61, 0x66, 0xe9, 0x20, 0x64, 0xe9, 0x6a, 0xe0, 0x20, 0x76, 0x75, 0x2c, 0x20, 0xe9, 0x6c, 0xe8, 0x76,
+            0x65, 0x20, 0x66, 0x72, 0x61, 0x6e, 0xe7, 0x61, 0x69, 0x73, 0x2c, 0x20, 0xe0, 0x20, 0x62, 0x69, 0x65, 0x6e,
+            0x74, 0xf4, 0x74, 0x21,
+          ]),
+          "iso-8859-1",
+        ],
+        [
+          new Uint8Array([
+            0x93, 0x50, 0x72, 0x69, 0x63, 0x65, 0x20, 0x69, 0x73, 0x20, 0x35, 0x30, 0x80, 0x20, 0x96, 0x20, 0x43, 0x61,
+            0x66, 0xe9, 0x99, 0x20, 0x64, 0xe9, 0x6a, 0xe0, 0x20, 0x76, 0x75, 0x94,
+          ]),
+          "windows-1252",
+        ],
+        [
+          new Uint8Array([
+            0x50, 0x72, 0x69, 0x63, 0x65, 0x3a, 0x20, 0x31, 0x30, 0x80, 0x20, 0x96, 0x20, 0x93, 0x73, 0x70, 0x65, 0x63,
+            0x69, 0x61, 0x6c, 0x94, 0x20, 0x83, 0x20, 0x6f, 0x66, 0x66, 0x65, 0x72, 0x85,
+          ]),
+          "windows-1252",
+        ],
+      ];
+
+      for (const [bytes, encoding] of cases) {
+        await expectReadBlobContentDecodesAs(bytes, encoding);
+      }
+    });
+
+    it.concurrent("detects legacy bytes after a large ASCII prefix", async () => {
+      const shiftJisText = "これはShiftJISのテスト文除withEnglish123";
+      const shiftJisBytes = new Uint8Array([
+        0x82, 0xb1, 0x82, 0xea, 0x82, 0xcd, 0x53, 0x68, 0x69, 0x66, 0x74, 0x4a, 0x49, 0x53, 0x82, 0xcc, 0x83, 0x65,
+        0x83, 0x58, 0x83, 0x67, 0x95, 0xb6, 0x8f, 0x9c, 0x77, 0x69, 0x74, 0x68, 0x45, 0x6e, 0x67, 0x6c, 0x69, 0x73,
+        0x68, 0x31, 0x32, 0x33,
       ]);
-      expect(detectEncoding(utf8Data, null)).toBe("iso-8859-2");
+      const bytes = new Uint8Array(40 * 1024);
+      bytes.fill(0x61);
+      bytes.set(shiftJisBytes, 18 * 1024);
 
-      // utf-8: Hello 世界, this is UTF8 測試
-      utf8Data = Uint8Array.from([
-        0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0xe4, 0xb8, 0x96, 0xe7, 0x95, 0x8c, 0x2c, 0x20, 0x74, 0x68, 0x69, 0x73,
-        0x20, 0x69, 0x73, 0x20, 0x55, 0x54, 0x46, 0x38, 0x20, 0xe6, 0xb8, 0xac, 0xe8, 0xa9, 0xa6,
-      ]);
-      expect(detectEncoding(utf8Data, null)).toBe("utf-8");
-
-      // windows-1252: This costs 50€ — quite “expensive” indeed.
-      utf8Data = Uint8Array.from([
-        84, 104, 105, 115, 32, 99, 111, 115, 116, 115, 32, 53, 48, 128, 32, 151, 32, 113, 117, 105, 116, 101, 32, 101,
-        120, 112, 101, 110, 115, 105, 118, 101, 148, 32, 105, 110, 100, 101, 101, 100, 46,
-      ]);
-      expect(detectEncoding(utf8Data, null)).toBe("windows-1252");
-
-      // iso-8859-1: This costs 50€ — quite “expensive” indeed.
-      utf8Data = Uint8Array.from([
-        69, 108, 32, 110, 105, 241, 111, 32, 99, 111, 109, 105, 243, 32, 112, 105, 241, 97, 116, 97, 32, 121, 32, 116,
-        111, 109, 243, 32, 99, 97, 102, 233, 46,
-      ]);
-      expect(detectEncoding(utf8Data, null)).toBe("iso-8859-1");
-
-      // koi8-r: Привет мир 123 ABC тест
-      utf8Data = Uint8Array.from([
-        208, 210, 201, 215, 197, 212, 32, 205, 201, 210, 32, 49, 50, 51, 32, 65, 66, 67, 32, 212, 197, 211, 212,
-      ]);
-      expect(detectEncoding(utf8Data, null)).toBe("koi8-r");
+      await expect(readBlobContent(blobFromBytes(bytes), null)).resolves.toBe(
+        `${"a".repeat(18 * 1024)}${shiftJisText}${"a".repeat(bytes.length - 18 * 1024 - shiftJisBytes.length)}`
+      );
     });
 
-    it("Charset Detection Test (2)", () => {
-      // Sentence (>10 chars): "Hello BOM world."
-
-      // UTF-8 BOM (EF BB BF)
-      const utf8_bom = new Uint8Array([
-        239, 187, 191, 72, 101, 108, 108, 111, 32, 66, 79, 77, 32, 119, 111, 114, 108, 100, 46,
-      ]);
-      expect(detectEncoding(utf8_bom, null)).toBe("utf-8");
-      expect(bytesDecode("utf-8", utf8_bom)).toBe("Hello BOM world.");
-
-      // UTF-16 LE BOM (FF FE)
-      const utf16le_bom = new Uint8Array([
-        255, 254, 72, 0, 101, 0, 108, 0, 108, 0, 111, 0, 32, 0, 66, 0, 79, 0, 77, 0, 32, 0, 119, 0, 111, 0, 114, 0, 108,
-        0, 100, 0, 46, 0,
-      ]);
-      expect(detectEncoding(utf16le_bom, null)).toBe("utf-16le");
-      expect(bytesDecode("utf-16le", utf16le_bom)).toBe("Hello BOM world.");
-
-      // UTF-16 BE BOM (FE FF)
-      const utf16be_bom = new Uint8Array([
-        254, 255, 0, 72, 0, 101, 0, 108, 0, 108, 0, 111, 0, 32, 0, 66, 0, 79, 0, 77, 0, 32, 0, 119, 0, 111, 0, 114, 0,
-        108, 0, 100, 0, 46,
-      ]);
-      expect(detectEncoding(utf16be_bom, null)).toBe("utf-16be");
-      expect(bytesDecode("utf-16be", utf16be_bom)).toBe("Hello BOM world.");
-
-      // UTF-32 LE BOM (FF FE 00 00)
-      const utf32le_bom = new Uint8Array([
-        255, 254, 0, 0, 72, 0, 0, 0, 101, 0, 0, 0, 108, 0, 0, 0, 108, 0, 0, 0, 111, 0, 0, 0, 32, 0, 0, 0, 66, 0, 0, 0,
-        79, 0, 0, 0, 77, 0, 0, 0, 32, 0, 0, 0, 119, 0, 0, 0, 111, 0, 0, 0, 114, 0, 0, 0, 108, 0, 0, 0, 100, 0, 0, 0, 46,
-        0, 0, 0,
-      ]);
-      expect(detectEncoding(utf32le_bom, null)).toBe("utf-32le");
-      expect(bytesDecode("utf-32le", utf32le_bom)).toBe("Hello BOM world.");
-
-      // UTF-32 BE BOM (00 00 FE FF)
-      const utf32be_bom = new Uint8Array([
-        0, 0, 254, 255, 0, 0, 0, 72, 0, 0, 0, 101, 0, 0, 0, 108, 0, 0, 0, 108, 0, 0, 0, 111, 0, 0, 0, 32, 0, 0, 0, 66,
-        0, 0, 0, 79, 0, 0, 0, 77, 0, 0, 0, 32, 0, 0, 0, 119, 0, 0, 0, 111, 0, 0, 0, 114, 0, 0, 0, 108, 0, 0, 0, 100, 0,
-        0, 0, 46,
-      ]);
-      expect(detectEncoding(utf32be_bom, null)).toBe("utf-32be");
-      expect(bytesDecode("utf-32be", utf32be_bom)).toBe("Hello BOM world.");
-    });
-
-    it("should prioritize valid charset from Content-Type header", () => {
-      const utf8Data = new TextEncoder().encode("hello world");
-      expect(detectEncoding(utf8Data, "text/javascript; charset=utf-8")).toBe("utf-8");
-    });
-
-    it("should fallback to chardet when Content-Type header is missing", () => {
-      // UTF-8 编码的中文
-      const utf8Data = new TextEncoder().encode("你好世界");
-      const encoding = detectEncoding(utf8Data, null);
-      expect(encoding).toBe("utf-8");
-    });
-
-    it("should fallback to chardet when Content-Type charset is invalid", () => {
-      const utf8Data = new TextEncoder().encode("hello world");
-      const encoding = detectEncoding(utf8Data, "text/javascript; charset=invalid-encoding");
-      // chardet 可能检测为 utf-8 或 ascii，都是合理的
-      expect(["utf-8", "ascii", "windows-1252"]).toContain(encoding);
-    });
-
-    it("should fallback to utf-8 when chardet returns null", () => {
-      // 模拟 chardet 返回 null 的情况（空数据）
-      const emptyData = new Uint8Array(0);
-      const encoding = detectEncoding(emptyData, null);
-      // 空数据时，chardet 可能返回 ascii 或其他编码，但都应该是有效的
-      expect(["utf-8", "ascii", "windows-1252"]).toContain(encoding);
-      expect(() => new TextDecoder(encoding)).not.toThrow();
-    });
-
-    it("should only use first 16KB for chardet detection", () => {
-      // 创建一个大于 16KB 的数据
-      const largeData = new Uint8Array(20 * 1024);
-      // 填充 UTF-8 编码的数据
-      const text = "a".repeat(20 * 1024);
-      const textBytes = new TextEncoder().encode(text);
-      largeData.set(textBytes.slice(0, largeData.length));
-
-      const encoding = detectEncoding(largeData, null);
-      // 应该成功检测，说明使用了采样
-      expect(["utf-8", "ascii", "windows-1252"]).toContain(encoding);
-    });
-
-    it("should NOT detect Shift_JIS when non-ASCII appears only after 16KB (1)", () => {
-      const buf = new Uint8Array(40 * 1024);
-
-      // 前 18KB → 纯 ASCII（看起来像 UTF-8 / ASCII）
-      buf.fill(0x61, 0, 18 * 1024); // 'a' * 18KB
-
-      // 18KB 之后 → 典型的 Shift_JIS 专用字节序列
-      // 0x82 0xA0 在 Shift_JIS 中表示字符“㈠”
-      // 如果被误当成 UTF-8，这些字节是非法的
-      const offset = 18 * 1024;
-      buf[offset] = 0x82;
-      buf[offset + 1] = 0xa0;
-      buf[offset + 2] = 0x82;
-      buf[offset + 3] = 0xa9; // 更多类似 Shift_JIS 的双字节组合
-
-      const encoding = detectEncoding(buf, null);
-
-      // 如果实现正确地将采样限制在约 8KB 以内 → 应判断为 UTF-8 / ASCII
-      expect(["utf-8", "ascii", "windows-1252"]).toContain(encoding);
-      // 如果错误地读取了整个 buffer → 可能会误判为 shift_jis
-      expect(encoding).not.toBe("shift_jis");
-    });
-
-    it("should NOT detect Shift_JIS when non-ASCII appears only after 16KB (2)", () => {
-      const buf = new Uint8Array(40 * 1024);
-
-      // 前 18KB → 纯 ASCII（仍在 8KB 采样范围内）
-      buf.fill(0x61, 0, 18 * 1024); // 'a' * 14KB
-
-      // 3KB 之后 → 出现典型的 Shift_JIS 字节
-      const offset = 14 * 1024;
-      buf[offset] = 0x82;
-      buf[offset + 1] = 0xa0;
-      buf[offset + 2] = 0x82;
-      buf[offset + 3] = 0xa9; // 更多 Shift_JIS 风格字节对
-
-      const encoding = detectEncoding(buf, null);
-
-      // 因为 Shift_JIS 字节出现在 8KB 采样范围内，应被正确识别
-      expect(encoding).toBe("shift_jis");
-    });
-
-    it("should handle GBK encoded data (1)", () => {
-      // GBK 编码的 "你好" (这是一个简化的测试，实际 GBK 编码更复杂)
-      // 注意：在浏览器环境中，GBK 编码可能被识别为其他兼容编码
-      // "你好" in GBK
-      const gbkLikeData = new Uint8Array([0xc4, 0xe3, 0xba, 0xc3]);
-      const encoding = detectEncoding(gbkLikeData, null);
-      // chardet 可能识别为 GBK、Shift_JIS、euc-jp 或相关的东亚编码
-      expect(["gbk", "big5"]).toContain(encoding);
-      expect(() => new TextDecoder(encoding)).not.toThrow();
-    });
-
-    it("should handle GBK encoded data (2)", () => {
-      // "你好，世界！"(GBK)
-      const gbkLikeData = new Uint8Array([0xc4, 0xe3, 0xba, 0xc3, 0xa3, 0xac, 0xca, 0xc0, 0xbd, 0xe7, 0xa3, 0xa1]);
-      const encoding = detectEncoding(gbkLikeData, null);
-      // chardet 可能识别为 GBK、Shift_JIS、euc-jp 或相关的东亚编码
-      expect(["gbk", "big5"]).toContain(encoding);
-      expect(() => new TextDecoder(encoding)).not.toThrow();
-    });
-
-    it("should handle GBK encoded data (GB2312)", () => {
-      // GB2312: 中文测试
-      const gb2312Data = new Uint8Array([
-        // 中
-        0xd6, 0xd0,
-        // 文
-        0xce, 0xc4,
-        // 测
-        0xb2, 0xe2,
-        // 试
-        0xca, 0xd4,
-      ]);
-      const encoding = detectEncoding(gb2312Data, null);
-      // chardet 可能识别为 GBK、Shift_JIS、euc-jp 或相关的东亚编码
-      expect(["gbk", "gb18030", "big5"]).toContain(encoding);
-      expect(() => new TextDecoder(encoding)).not.toThrow();
-    });
-
-    it("should handle GBK encoded data (GBK)", () => {
-      // GBK: 中文测试扩展凉
-      const gbkData = new Uint8Array([
-        // 中
-        0xd6, 0xd0,
-        // 文
-        0xce, 0xc4,
-        // 测
-        0xb2, 0xe2,
-        // 试
-        0xca, 0xd4,
-        // 扩
-        0xc0, 0xa9,
-        // 展
-        0xd5, 0xb9,
-        // 凉
-        0xfd, 0x9d,
-      ]);
-      const encoding = detectEncoding(gbkData, null);
-      // chardet 可能识别为 GBK、Shift_JIS、euc-jp 或相关的东亚编码
-      expect(["gbk", "gb18030", "big5"]).toContain(encoding);
-      expect(() => new TextDecoder(encoding)).not.toThrow();
-    });
-
-    it("should handle GBK encoded data (GB18030)", () => {
-      // GB18030: 中文测试扺
-      const gb18030Data1 = new Uint8Array([
-        // 中
-        0xd6, 0xd0,
-        // 文
-        0xce, 0xc4,
-        // 测
-        0xb2, 0xe2,
-        // 试
-        0xca, 0xd4,
-        // 扺
-        0x92, 0x57,
-      ]);
-      const encoding1 = detectEncoding(gb18030Data1, null);
-      // chardet 可能识别为 GBK、Shift_JIS、euc-jp 或相关的东亚编码
-      expect(["gbk", "gb18030", "big5"]).toContain(encoding1);
-      expect(() => new TextDecoder(encoding1)).not.toThrow();
-
-      // GB18030: 中文ὒ测试扺
-      const gb18030Data2 = new Uint8Array([
-        // 中
-        0xd6, 0xd0,
-        // 文
-        0xce, 0xc4,
-        // ὒ
-        0x81, 0x36, 0x92, 0x32,
-        // 测
-        0xb2, 0xe2,
-        // 试
-        0xca, 0xd4,
-        // 扺
-        0x92, 0x57,
-      ]);
-      const encoding2 = detectEncoding(gb18030Data2, null);
-      // chardet 可能识别为 GBK、Shift_JIS、euc-jp 或相关的东亚编码
-      expect(["gbk", "gb18030"]).toContain(encoding2);
-      expect(() => new TextDecoder(encoding2)).not.toThrow();
-    });
-
-    it("detect GBK", () => {
-      // not BIG5
-      // gb18030/gbk: 璹亽
-      const gbkLikeData = new Uint8Array([0xad, 0x71, 0x81, 0x92]);
-      const encoding = detectEncoding(gbkLikeData, null);
-      expect(["gbk", "gb18030"]).toContain(encoding);
-      expect(() => new TextDecoder(encoding)).not.toThrow();
-      expect(new TextDecoder(encoding).decode(gbkLikeData)).toBe("璹亽");
-    });
-
-    it("should handle ISO-8859-1 encoded data", () => {
-      // ISO-8859-1 特有字符（扩展 ASCII）
-      // "Café déjà vu, élève français, à bientôt!"
-      const iso88591Data = new Uint8Array([
-        // Café
-        0x43, 0x61, 0x66, 0xe9, 0x20,
-        // déjà
-        0x64, 0xe9, 0x6a, 0xe0, 0x20,
-        // vu,
-        0x76, 0x75, 0x2c, 0x20,
-        // élève
-        0xe9, 0x6c, 0xe8, 0x76, 0x65, 0x20,
-        // français,
-        0x66, 0x72, 0x61, 0x6e, 0xe7, 0x61, 0x69, 0x73, 0x2c, 0x20,
-        // à
-        0xe0, 0x20,
-        // bientôt!
-        0x62, 0x69, 0x65, 0x6e, 0x74, 0xf4, 0x74, 0x21,
-      ]);
-      const encoding = detectEncoding(iso88591Data, null);
-      expect(encoding).toBe("iso-8859-1");
-    });
-
-    it("should validate detected encoding is supported by TextDecoder", () => {
-      const utf8Data = new TextEncoder().encode("test");
-      const encoding = detectEncoding(utf8Data, null);
-
-      // 确保返回的编码可以被 TextDecoder 使用
-      expect(() => new TextDecoder(encoding)).not.toThrow();
-    });
-
-    it("should prefer Content-Type charset over chardet detection", () => {
-      // 即使数据看起来像 GBK，如果 Content-Type 指定了 UTF-8，应该使用 UTF-8
-      const data = new Uint8Array([0xc4, 0xe3, 0xba, 0xc3]);
-      const encoding = detectEncoding(data, "text/javascript; charset=utf-8");
-      expect(encoding).toBe("utf-8");
-    });
-
-    it("should handle charset with different cases from Content-Type", () => {
-      const data = new TextEncoder().encode("test");
-      expect(detectEncoding(data, "text/javascript; charset=UTF-8")).toBe("utf-8");
-      expect(detectEncoding(data, "text/javascript; charset=Utf-8")).toBe("utf-8");
-      expect(detectEncoding(data, "text/javascript; charset=GBK")).toBe("gbk");
-    });
-
-    it("should handle Windows-1252 encoded data (1)", () => {
-      // Windows-1252 特有字符（扩展 ASCII）
-      // “Price is 50€ – Café™ déjà vu”
-      const win1252Data = new Uint8Array([
-        // “
-        0x93,
-        // Price␠
-        0x50, 0x72, 0x69, 0x63, 0x65, 0x20,
-        // is␠
-        0x69, 0x73, 0x20,
-        // 50
-        0x35, 0x30,
-        // €
-        0x80, 0x20,
-        // –
-        0x96, 0x20,
-        // Café
-        0x43, 0x61, 0x66, 0xe9,
-        // ™
-        0x99, 0x20,
-        // déjà
-        0x64, 0xe9, 0x6a, 0xe0, 0x20,
-        // vu
-        0x76, 0x75,
-        // ”
-        0x94,
-      ]);
-      const encoding = detectEncoding(win1252Data, null);
-      expect(encoding).toBe("windows-1252");
-    });
-
-    it("should handle Windows-1252 encoded data (2)", () => {
-      // Windows-1252 string: "Price: 10€ – “special” ƒ offer…"
-      const win1252Data = new Uint8Array([
-        // "Price: "
-        0x50, 0x72, 0x69, 0x63, 0x65, 0x3a, 0x20,
-        // "10€ – "
-        0x31, 0x30, 0x80, 0x20, 0x96, 0x20,
-        // “special”
-        0x93, 0x73, 0x70, 0x65, 0x63, 0x69, 0x61, 0x6c, 0x94,
-        // " ƒ offer…"
-        0x20, 0x83, 0x20, 0x6f, 0x66, 0x66, 0x65, 0x72, 0x85,
-      ]);
-      const encoding = detectEncoding(win1252Data, null);
-      expect(encoding).toBe("windows-1252");
-    });
-
-    it("should fallback to utf-8 when chardet detects invalid encoding", () => {
-      // 使用 vi.spyOn 来模拟 console.warn
-      const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-      const data = new TextEncoder().encode("test");
-      const encoding = detectEncoding(data, null);
-
-      // 应该成功返回一个有效的编码
-      expect(["utf-8", "ascii", "windows-1252"]).toContain(encoding);
-      expect(() => new TextDecoder(encoding)).not.toThrow();
-
-      consoleWarnSpy.mockRestore();
-    });
-  });
-
-  describe("real script", () => {
-    it("script 1", () => {
-      const textBase64 = [
-        "Ly8gPT1Vc2VyU2NyaXB0PT0KLy8gQG5hbWUg572R6aG15oqW6Z+z5L2T6aqM5aKe5by6Ci8vIEBuYW1lc3BhY2UgVmlvbGVudG1vbmtleSBTY3JpcHRzCi8vIEBtYXRjaCBodHRwczovL3d3dy5kb3V5aW4uY29tLz8qCi8vIEBtYXRjaCAqOi8vKi5kb3V5aW4uY29tLyoKLy8gQG1hdGNoICo6Ly8qLmllc2RvdXlpbi5jb20vKgovLyBAZXhjbHVkZSAqOi8vbGYtenQuZG91eWluLmNvbSoKLy8gQGdyYW50IG5vbmUKLy8gQHZlcnNpb24gMy40Ci8vIEBjaGFuZ2Vsb2cg5LyY5YyW5paH5qGj5o+P6L+w77yM6LCD5pW06Leo5Z+f6YWN572u5oyH5byVCi8vIEBkZXNjcmlwdGlvbiDoh6rliqjot7Pov4fnm7Tmkq3jgIHmmbrog73lsY/olL3lhbPplK7lrZfvvIjoh6rliqjkuI3mhJ/lhbTotqPvvInjgIHot7Pov4flub/lkYrjgIHmnIDpq5jliIbovqjnjofjgIHliIbovqjnjofnrZvpgInjgIFBSeaZuuiDveetm+mAie+8iOiHquWKqOeCuei1nu+8ieOAgeaegemAn+aooeW8jwovLyBAYXV0aG9yIEZyZXF1ZW5rCi8vIEBsaWNlbnNlIEdQTC0zLjAgTGljZW5zZQovLyBAcnVuLWF0IGRvY3VtZW50LXN0YXJ0Ci8vIEBkb3dubG9hZFVSTCBodHRwczovL3VwZGF0ZS5ncmVhc3lmb3JrLm9yZy9zY3JpcHRzLzUzOTk0Mi8lRTclQkQlOTElRTklQTElQjUlRTYlOEElOTYlRTklOUYlQjMlRTQlQkQlOTMlRTklQUElOEMlRTUlQTIlOUUlRTUlQkMlQkEudXNlci5qcwovLyBAdXBkYXRlVVJMIGh0dHBzOi8vdXBkYXRlLmdyZWFzeWZvcmsub3JnL3NjcmlwdHMvNTM5OTQyLyVFNyVCRCU5MSVFOSVBMSVCNSVFNiU4QSU5NiVFOSU5RiVCMyVFNCVCRCU5MyVFOSVBQSU4QyVFNSVBMiU5RSVFNSVCQyVCQS5tZXRhLmpzCi8vID09L1VzZXJTY3JpcHQ9PQoKKGZ1bmN0aW9uICgpIHsKICAgICd1c2Ugc3RyaWN0JzsKCiAgICBmdW5jdGlvbiBpc0VsZW1lbnRJblZpZXdwb3J0KGVsLCB0ZXh0ID0gIiIpIHsKICAgICAgICBpZiAoIWVsKSByZXR1cm4gZmFsc2U7CiAgICAgICAgY29uc3QgcmVjdCA9IGVsLmdldEJvdW5kaW5nQ2xpZW50UmVjdCgpOwogICAgICAgIHJldHVybiAoCiAgICAgICAgICAgIHJlY3Qud2lkdGggPiAwICYmCiAgICAgICAgICAgIHJlY3QuaGVpZ2h0ID4gMCAmJgogICAgICAgICAgICByZWN0LmJvdHRvbSA+IDAgJiYKICAgICAgICAgICAgcmVjdC5yaWdodCA+IDAgJiYKICAgICAgICAgICAgcmVjdC50b3AgPCB3aW5kb3cuaW5uZXJIZWlnaHQgJiYKICAgICAgICAgICAgcmVjdC5sZWZ0IDwgd2luZG93LmlubmVyV2lkdGgKICAgICAgICApOwogICAgfQoKICAgIGZ1bmN0aW9uIGdldEJlc3RWaXNpYmxlRWxlbWVudChlbGVtZW50cykgewogICAgICAgIGlmICghZWxlbWVudHMgfHwgZWxlbWVudHMubGVuZ3RoID09PSAwKSB7CiAgICAgICAgICAgIHJldHVybiBudWxsOwogICAgICAgIH0KCiAgICAgICAgY29uc3QgdmlzaWJsZUVsZW1lbnRzID0gQXJyYXkuZnJvbShlbGVtZW50cykuZmlsdGVyKGlzRWxlbWVudEluVmlld3BvcnQpOwoKICAgICAgICBpZiAodmlzaWJsZUVsZW1lbnRzLmxlbmd0aCA9PT0gMCkgewogICAgICAgICAgICByZXR1cm4gbnVsbDsKICAgICAgICB9CgogICAgICAgIGlmICh2aXNpYmxlRWxlbWVudHMubGVuZ3RoID09PSAxKSB7CiAgICAgICAgICAgIHJldHVybiB2aXNpYmxlRWxlbWVudHNbMF07CiAgICAgICAgfQoKICAgICAgICBsZXQgYmVzdENhbmRpZGF0ZSA9IG51bGw7CiAgICAgICAgbGV0IG1pbkRpc3RhbmNlID0gSW5maW5pdHk7CgogICAgICAgIGZvciAoY29uc3QgZWwgb2YgdmlzaWJsZUVsZW1lbnRzKSB7CiAgICAgICAgICAgIGNvbnN0IHJlY3QgPSBlbC5nZXRCb3VuZGluZ0NsaWVudFJlY3QoKTsKICAgICAgICAgICAgY29uc3QgZGlzdGFuY2UgPSBNYXRoLmFicyhyZWN0LnRvcCk7CiAgICAgICAgICAgIGlmIChkaXN0YW5jZSA8IG1pbkRpc3RhbmNlKSB7CiAgICAgICAgICAgICAgICBtaW5EaXN0YW5jZSA9IGRpc3RhbmNlOwogICAgICAgICAgICAgICAgYmVzdENhbmRpZGF0ZSA9IGVsOwogICAgICAgICAgICB9CiAgICAgICAgfQogICAgICAgIHJldHVybiBiZXN0Q2FuZGlkYXRlOwogICAgfQoKICAgIC8vID09PT09PT09PT0g6YCa55+l566h55CG5ZmoID09PT09PT09PT0KICAgIGNsYXNzIE5vdGlmaWNhdGlvbk1hbmFnZXIgewogICAgICAgIGNvbnN0cnVjdG9yKCkgewogICAgICAgICAgICB0aGlzLmNvbnRhaW5lciA9IG51bGw7CiAgICAgICAgfQoKICAgICAgICBjcmVhdGVDb250YWluZXIoKSB7CiAgICAgICAgICAgIGlmICh0aGlzLmNvbnRhaW5lciAmJiBkb2N1bWVudC5ib2R5LmNvbnRhaW5zKHRoaXMuY29udGFpbmVyKSkgcmV0dXJuOwogICAgICAgICAgICB0aGlzLmNvbnRhaW5lciA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2RpdicpOwogICAgICAgICAgICBPYmplY3QuYXNzaWduKHRoaXMuY29udGFpbmVyLnN0eWxlLCB7CiAgICAgICAgICAgICAgICBwb3NpdGlvbjogJ2ZpeGVkJywKICAgICAgICAgICAgICAgIHRvcDogJzEwMHB4JywKICAgICAgICAgICAgICAgIGxlZnQ6ICc1MCUnLAogICAgICAgICAgICAgICAgdHJhbnNmb3JtOiAndHJhbnNsYXRlWCgtNTAlKScsCiAgICAgICAgICAgICAgICB6SW5kZXg6ICcxMDAwMScsCiAgICAgICAgICAgICAgICBkaXNwbGF5OiAnZmxleCcsCiAgICAgICAgICAgICAgICBmbGV4RGlyZWN0aW9uOiAnY29sdW1uJywKICAgICAgICAgICAgICAgIGFsaWduSXRlbXM6ICdjZW50ZXInLAogICAgICAgICAgICAgICAgZ2FwOiAnMTBweCcKICAgICAgICAgICAgfSk7CiAgICAgICAgICAgIGRvY3VtZW50LmJvZHkuYXBwZW5kQ2hpbGQodGhpcy5jb250YWluZXIpOwogICAgICAgIH0KCiAgICAgICAgc2hvd01lc3NhZ2UobWVzc2FnZSwgZHVyYXRpb24gPSAyMDAwKSB7CiAgICAgICAgICAgIHRoaXMuY3JlYXRlQ29udGFpbmVyKCk7CgogICAgICAgICAgICBjb25zdCBtZXNzYWdlRWxlbWVudCA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2RpdicpOwogICAgICAgICAgICBtZXNzYWdlRWxlbWVudC50ZXh0Q29udGVudCA9IG1lc3NhZ2U7CiAgICAgICAgICAgIE9iamVjdC5hc3NpZ24obWVzc2FnZUVsZW1lbnQuc3R5bGUsIHsKICAgICAgICAgICAgICAgIGJhY2tncm91bmQ6ICdyZ2JhKDAsIDAsIDAsIDAuOCknLAogICAgICAgICAgICAgICAgY29sb3I6ICd3aGl0ZScsCiAgICAgICAgICAgICAgICBwYWRkaW5nOiAnMTBweCAyMHB4JywKICAgICAgICAgICAgICAgIGJvcmRlclJhZGl1czogJzZweCcsCiAgICAgICAgICAgICAgICBmb250U2l6ZTogJzE0cHgnLAogICAgICAgICAgICAgICAgYm94U2hhZG93OiAnMCAycHggOHB4IHJnYmEoMCwgMCwgMCwgMC4xNSknLAogICAgICAgICAgICAgICAgb3BhY2l0eTogJzAnLAogICAgICAgICAgICAgICAgdHJhbnNpdGlvbjogJ29wYWNpdHkgMC4zcyBlYXNlLWluLW91dCwgdHJhbnNmb3JtIDAuM3MgZWFzZS1pbi1vdXQnLAogICAgICAgICAgICAgICAgdHJhbnNmb3JtOiAndHJhbnNsYXRlWSgtMjBweCknCiAgICAgICAgICAgIH0pOwoKICAgICAgICAgICAgdGhpcy5jb250YWluZXIuYXBwZW5kQ2hpbGQobWVzc2FnZUVsZW1lbnQpOwoKICAgICAgICAgICAgLy8gQW5pbWF0ZSBpbgogICAgICAgICAgICBzZXRUaW1lb3V0KCgpID0+IHsKICAgICAgICAgICAgICAgIG1lc3NhZ2VFbGVtZW50LnN0eWxlLm9wYWNpdHkgPSAnMSc7CiAgICAgICAgICAgICAgICBtZXNzYWdlRWxlbWVudC5zdHlsZS50cmFuc2Zvcm0gPSAndHJhbnNsYXRlWSgwKSc7CiAgICAgICAgICAgIH0sIDEwKTsKCiAgICAgICAgICAgIC8vIEFuaW1hdGUgb3V0IGFuZCByZW1vdmUKICAgICAgICAgICAgc2V0VGltZW91dCgoKSA9PiB7CiAgICAgICAgICAgICAgICBtZXNzYWdlRWxlbWVudC5zdHlsZS5vcGFjaXR5ID0gJzAnOwogICAgICAgICAgICAgICAgbWVzc2FnZUVsZW1lbnQuc3R5bGUudHJhbnNmb3JtID0gJ3RyYW5zbGF0ZVkoLTIwcHgpJzsKICAgICAgICAgICAgICAgIHNldFRpbWVvdXQoKCkgPT4gewogICAgICAgICAgICAgICAgICAgIGlmIChtZXNzYWdlRWxlbWVudC5wYXJlbnRFbGVtZW50KSB7CiAgICAgICAgICAgICAgICAgICAgICAgIG1lc3NhZ2VFbGVtZW50LnJlbW92ZSgpOwogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICBpZiAodGhpcy5jb250YWluZXIgJiYgdGhpcy5jb250YWluZXIuY2hpbGRFbGVtZW50Q291bnQgPT09IDApIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGhpcy5jb250YWluZXIucmVtb3ZlKCk7CiAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMuY29udGFpbmVyID0gbnVsbDsKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICB9LCAzMDApOwogICAgICAgICAgICB9LCBkdXJhdGlvbik7CiAgICAgICAgfQogICAgfQoKICAgIC8vID09PT09PT09PT0g6YWN572u566h55CG5qih5Z2XID09PT09PT09PT0KICAgIGNsYXNzIENvbmZpZ01hbmFnZXIgewogICAgICAgIGNvbnN0cnVjdG9yKCkgewogICAgICAgICAgICB0aGlzLmNvbmZpZyA9IHsKICAgICAgICAgICAgICAgIHNraXBMaXZlOiB7IGVuYWJsZWQ6IHRydWUsIGtleTogJ3NraXBMaXZlJyB9LAogICAgICAgICAgICAgICAgYXV0b0hpZ2hSZXM6IHsgZW5hYmxlZDogdHJ1ZSwga2V5OiAnYXV0b0hpZ2hSZXMnIH0sCiAgICAgICAgICAgICAgICBibG9ja0tleXdvcmRzOiB7CiAgICAgICAgICAgICAgICAgICAgZW5hYmxlZDogdHJ1ZSwKICAgICAgICAgICAgICAgICAgICBrZXk6ICdibG9ja0tleXdvcmRzJywKICAgICAgICAgICAgICAgICAgICBrZXl3b3JkczogdGhpcy5sb2FkS2V5d29yZHMoKSwKICAgICAgICAgICAgICAgICAgICBwcmVzc1I6IHRoaXMubG9hZFByZXNzUlNldHRpbmcoKSwKICAgICAgICAgICAgICAgICAgICBibG9ja05hbWU6IHRoaXMubG9hZEJsb2NrTmFtZVNldHRpbmcoKSwKICAgICAgICAgICAgICAgICAgICBibG9ja0Rlc2M6IHRoaXMubG9hZEJsb2NrRGVzY1NldHRpbmcoKSwKICAgICAgICAgICAgICAgICAgICBibG9ja1RhZ3M6IHRoaXMubG9hZEJsb2NrVGFnc1NldHRpbmcoKQogICAgICAgICAgICAgICAgfSwKICAgICAgICAgICAgICAgIHNraXBBZDogeyBlbmFibGVkOiB0cnVlLCBrZXk6ICdza2lwQWQnIH0sCiAgICAgICAgICAgICAgICBvbmx5UmVzb2x1dGlvbjogewogICAgICAgICAgICAgICAgICAgIGVuYWJsZWQ6IGZhbHNlLAogICAgICAgICAgICAgICAgICAgIGtleTogJ29ubHlSZXNvbHV0aW9uJywKICAgICAgICAgICAgICAgICAgICByZXNvbHV0aW9uOiB0aGlzLmxvYWRUYXJnZXRSZXNvbHV0aW9uKCkKICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICBhaVByZWZlcmVuY2U6IHsKICAgICAgICAgICAgICAgICAgICBlbmFibGVkOiBmYWxzZSwKICAgICAgICAgICAgICAgICAgICBrZXk6ICdhaVByZWZlcmVuY2UnLAogICAgICAgICAgICAgICAgICAgIGNvbnRlbnQ6IHRoaXMubG9hZEFpQ29udGVudCgpLAogICAgICAgICAgICAgICAgICAgIG1vZGVsOiB0aGlzLmxvYWRBaU1vZGVsKCksCiAgICAgICAgICAgICAgICAgICAgYXV0b0xpa2U6IHRoaXMubG9hZEF1dG9MaWtlU2V0dGluZygpCiAgICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICAgc3BlZWRNb2RlOiB7CiAgICAgICAgICAgICAgICAgICAgZW5hYmxlZDogZmFsc2UsCiAgICAgICAgICAgICAgICAgICAga2V5OiAnc3BlZWRNb2RlJywKICAgICAgICAgICAgICAgICAgICBzZWNvbmRzOiB0aGlzLmxvYWRTcGVlZFNlY29uZHMoKSwKICAgICAgICAgICAgICAgICAgICBtb2RlOiB0aGlzLmxvYWRTcGVlZE1vZGVUeXBlKCksCiAgICAgICAgICAgICAgICAgICAgbWluU2Vjb25kczogdGhpcy5sb2FkU3BlZWRNaW5TZWNvbmRzKCksCiAgICAgICAgICAgICAgICAgICAgbWF4U2Vjb25kczogdGhpcy5sb2FkU3BlZWRNYXhTZWNvbmRzKCkKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfTsKICAgICAgICB9CgogICAgICAgIGxvYWRLZXl3b3JkcygpIHsKICAgICAgICAgICAgcmV0dXJuIEpTT04ucGFyc2UobG9jYWxTdG9yYWdlLmdldEl0ZW0oJ2RvdXlpbl9ibG9ja2VkX2tleXdvcmRzJykgfHwgJ1si5bqXIiwgIueUhOmAiSJdJyk7CiAgICAgICAgfQoKICAgICAgICBsb2FkU3BlZWRTZWNvbmRzKCkgewogICAgICAgICAgICBjb25zdCB2",
-        "YWx1ZSA9IHBhcnNlSW50KGxvY2FsU3RvcmFnZS5nZXRJdGVtKCdkb3V5aW5fc3BlZWRfbW9kZV9zZWNvbmRzJykgfHwgJzYnLCAxMCk7CiAgICAgICAgICAgIHJldHVybiBOdW1iZXIuaXNGaW5pdGUodmFsdWUpID8gTWF0aC5taW4oTWF0aC5tYXgodmFsdWUsIDEpLCAzNjAwKSA6IDY7CiAgICAgICAgfQoKICAgICAgICBsb2FkU3BlZWRNb2RlVHlwZSgpIHsKICAgICAgICAgICAgY29uc3QgbW9kZSA9IGxvY2FsU3RvcmFnZS5nZXRJdGVtKCdkb3V5aW5fc3BlZWRfbW9kZV90eXBlJykgfHwgJ2ZpeGVkJzsKICAgICAgICAgICAgcmV0dXJuIG1vZGUgPT09ICdyYW5kb20nID8gJ3JhbmRvbScgOiAnZml4ZWQnOwogICAgICAgIH0KCiAgICAgICAgbG9hZFNwZWVkTWluU2Vjb25kcygpIHsKICAgICAgICAgICAgY29uc3QgdmFsdWUgPSBwYXJzZUludChsb2NhbFN0b3JhZ2UuZ2V0SXRlbSgnZG91eWluX3NwZWVkX21vZGVfbWluX3NlY29uZHMnKSB8fCAnNScsIDEwKTsKICAgICAgICAgICAgcmV0dXJuIE51bWJlci5pc0Zpbml0ZSh2YWx1ZSkgPyBNYXRoLm1pbihNYXRoLm1heCh2YWx1ZSwgMSksIDM2MDApIDogNTsKICAgICAgICB9CgogICAgICAgIGxvYWRTcGVlZE1heFNlY29uZHMoKSB7CiAgICAgICAgICAgIGNvbnN0IHZhbHVlID0gcGFyc2VJbnQobG9jYWxTdG9yYWdlLmdldEl0ZW0oJ2RvdXlpbl9zcGVlZF9tb2RlX21heF9zZWNvbmRzJykgfHwgJzEwJywgMTApOwogICAgICAgICAgICByZXR1cm4gTnVtYmVyLmlzRmluaXRlKHZhbHVlKSA/IE1hdGgubWluKE1hdGgubWF4KHZhbHVlLCAxKSwgMzYwMCkgOiAxMDsKICAgICAgICB9CgogICAgICAgIGxvYWRBaUNvbnRlbnQoKSB7CiAgICAgICAgICAgIHJldHVybiBsb2NhbFN0b3JhZ2UuZ2V0SXRlbSgnZG91eWluX2FpX2NvbnRlbnQnKSB8fCAn6Zyy6IS455qE576O5aWzJzsKICAgICAgICB9CgogICAgICAgIGxvYWRBaU1vZGVsKCkgewogICAgICAgICAgICByZXR1cm4gbG9jYWxTdG9yYWdlLmdldEl0ZW0oJ2RvdXlpbl9haV9tb2RlbCcpIHx8ICdxd2VuMy12bDo4Yic7CiAgICAgICAgfQoKICAgICAgICBsb2FkVGFyZ2V0UmVzb2x1dGlvbigpIHsKICAgICAgICAgICAgcmV0dXJuIGxvY2FsU3RvcmFnZS5nZXRJdGVtKCdkb3V5aW5fdGFyZ2V0X3Jlc29sdXRpb24nKSB8fCAnNEsnOwogICAgICAgIH0KCiAgICAgICAgbG9hZFByZXNzUlNldHRpbmcoKSB7CiAgICAgICAgICAgIHJldHVybiBsb2NhbFN0b3JhZ2UuZ2V0SXRlbSgnZG91eWluX3ByZXNzX3JfZW5hYmxlZCcpICE9PSAnZmFsc2UnOyAvLyDpu5jorqTlvIDlkK8KICAgICAgICB9CgogICAgICAgIGxvYWRBdXRvTGlrZVNldHRpbmcoKSB7CiAgICAgICAgICAgIHJldHVybiBsb2NhbFN0b3JhZ2UuZ2V0SXRlbSgnZG91eWluX2F1dG9fbGlrZV9lbmFibGVkJykgIT09ICdmYWxzZSc7IC8vIOm7mOiupOW8gOWQrwogICAgICAgIH0KCiAgICAgICAgbG9hZEJsb2NrTmFtZVNldHRpbmcoKSB7CiAgICAgICAgICAgIHJldHVybiBsb2NhbFN0b3JhZ2UuZ2V0SXRlbSgnZG91eWluX2Jsb2NrX25hbWVfZW5hYmxlZCcpICE9PSAnZmFsc2UnOyAvLyDpu5jorqTlvIDlkK8KICAgICAgICB9CgogICAgICAgIGxvYWRCbG9ja0Rlc2NTZXR0aW5nKCkgewogICAgICAgICAgICByZXR1cm4gbG9jYWxTdG9yYWdlLmdldEl0ZW0oJ2RvdXlpbl9ibG9ja19kZXNjX2VuYWJsZWQnKSAhPT0gJ2ZhbHNlJzsgLy8g6buY6K6k5byA5ZCvCiAgICAgICAgfQoKICAgICAgICBsb2FkQmxvY2tUYWdzU2V0dGluZygpIHsKICAgICAgICAgICAgcmV0dXJuIGxvY2FsU3RvcmFnZS5nZXRJdGVtKCdkb3V5aW5fYmxvY2tfdGFnc19lbmFibGVkJykgIT09ICdmYWxzZSc7IC8vIOm7mOiupOW8gOWQrwogICAgICAgIH0KCiAgICAgICAgc2F2ZUtleXdvcmRzKGtleXdvcmRzKSB7CiAgICAgICAgICAgIHRoaXMuY29uZmlnLmJsb2NrS2V5d29yZHMua2V5d29yZHMgPSBrZXl3b3JkczsKICAgICAgICAgICAgbG9jYWxTdG9yYWdlLnNldEl0ZW0oJ2RvdXlpbl9ibG9ja2VkX2tleXdvcmRzJywgSlNPTi5zdHJpbmdpZnkoa2V5d29yZHMpKTsKICAgICAgICB9CgogICAgICAgIHNhdmVTcGVlZFNlY29uZHMoc2Vjb25kcykgewogICAgICAgICAgICB0aGlzLmNvbmZpZy5zcGVlZE1vZGUuc2Vjb25kcyA9IHNlY29uZHM7CiAgICAgICAgICAgIGxvY2FsU3RvcmFnZS5zZXRJdGVtKCdkb3V5aW5fc3BlZWRfbW9kZV9zZWNvbmRzJywgc2Vjb25kcy50b1N0cmluZygpKTsKICAgICAgICB9CgogICAgICAgIHNhdmVTcGVlZE1vZGVUeXBlKG1vZGUpIHsKICAgICAgICAgICAgdGhpcy5jb25maWcuc3BlZWRNb2RlLm1vZGUgPSBtb2RlOwogICAgICAgICAgICBsb2NhbFN0b3JhZ2Uuc2V0SXRlbSgnZG91eWluX3NwZWVkX21vZGVfdHlwZScsIG1vZGUpOwogICAgICAgIH0KCiAgICAgICAgc2F2ZVNwZWVkTW9kZVJhbmdlKG1pblNlY29uZHMsIG1heFNlY29uZHMpIHsKICAgICAgICAgICAgdGhpcy5jb25maWcuc3BlZWRNb2RlLm1pblNlY29uZHMgPSBtaW5TZWNvbmRzOwogICAgICAgICAgICB0aGlzLmNvbmZpZy5zcGVlZE1vZGUubWF4U2Vjb25kcyA9IG1heFNlY29uZHM7CiAgICAgICAgICAgIGxvY2FsU3RvcmFnZS5zZXRJdGVtKCdkb3V5aW5fc3BlZWRfbW9kZV9taW5fc2Vjb25kcycsIG1pblNlY29uZHMudG9TdHJpbmcoKSk7CiAgICAgICAgICAgIGxvY2FsU3RvcmFnZS5zZXRJdGVtKCdkb3V5aW5fc3BlZWRfbW9kZV9tYXhfc2Vjb25kcycsIG1heFNlY29uZHMudG9TdHJpbmcoKSk7CiAgICAgICAgfQoKICAgICAgICBzYXZlQWlDb250ZW50KGNvbnRlbnQpIHsKICAgICAgICAgICAgdGhpcy5jb25maWcuYWlQcmVmZXJlbmNlLmNvbnRlbnQgPSBjb250ZW50OwogICAgICAgICAgICBsb2NhbFN0b3JhZ2Uuc2V0SXRlbSgnZG91eWluX2FpX2NvbnRlbnQnLCBjb250ZW50KTsKICAgICAgICB9CgogICAgICAgIHNhdmVBaU1vZGVsKG1vZGVsKSB7CiAgICAgICAgICAgIHRoaXMuY29uZmlnLmFpUHJlZmVyZW5jZS5tb2RlbCA9IG1vZGVsOwogICAgICAgICAgICBsb2NhbFN0b3JhZ2Uuc2V0SXRlbSgnZG91eWluX2FpX21vZGVsJywgbW9kZWwpOwogICAgICAgIH0KCiAgICAgICAgc2F2ZVRhcmdldFJlc29sdXRpb24ocmVzb2x1dGlvbikgewogICAgICAgICAgICB0aGlzLmNvbmZpZy5vbmx5UmVzb2x1dGlvbi5yZXNvbHV0aW9uID0gcmVzb2x1dGlvbjsKICAgICAgICAgICAgbG9jYWxTdG9yYWdlLnNldEl0ZW0oJ2RvdXlpbl90YXJnZXRfcmVzb2x1dGlvbicsIHJlc29sdXRpb24pOwogICAgICAgIH0KCiAgICAgICAgc2F2ZVByZXNzUlNldHRpbmcoZW5hYmxlZCkgewogICAgICAgICAgICB0aGlzLmNvbmZpZy5ibG9ja0tleXdvcmRzLnByZXNzUiA9IGVuYWJsZWQ7CiAgICAgICAgICAgIGxvY2FsU3RvcmFnZS5zZXRJdGVtKCdkb3V5aW5fcHJlc3Nfcl9lbmFibGVkJywgZW5hYmxlZC50b1N0cmluZygpKTsKICAgICAgICB9CgogICAgICAgIHNhdmVBdXRvTGlrZVNldHRpbmcoZW5hYmxlZCkgewogICAgICAgICAgICB0aGlzLmNvbmZpZy5haVByZWZlcmVuY2UuYXV0b0xpa2UgPSBlbmFibGVkOwogICAgICAgICAgICBsb2NhbFN0b3JhZ2Uuc2V0SXRlbSgnZG91eWluX2F1dG9fbGlrZV9lbmFibGVkJywgZW5hYmxlZC50b1N0cmluZygpKTsKICAgICAgICB9CgogICAgICAgIHNhdmVCbG9ja05hbWVTZXR0aW5nKGVuYWJsZWQpIHsKICAgICAgICAgICAgdGhpcy5jb25maWcuYmxvY2tLZXl3b3Jkcy5ibG9ja05hbWUgPSBlbmFibGVkOwogICAgICAgICAgICBsb2NhbFN0b3JhZ2Uuc2V0SXRlbSgnZG91eWluX2Jsb2NrX25hbWVfZW5hYmxlZCcsIGVuYWJsZWQudG9TdHJpbmcoKSk7CiAgICAgICAgfQoKICAgICAgICBzYXZlQmxvY2tEZXNjU2V0dGluZyhlbmFibGVkKSB7CiAgICAgICAgICAgIHRoaXMuY29uZmlnLmJsb2NrS2V5d29yZHMuYmxvY2tEZXNjID0gZW5hYmxlZDsKICAgICAgICAgICAgbG9jYWxTdG9yYWdlLnNldEl0ZW0oJ2RvdXlpbl9ibG9ja19kZXNjX2VuYWJsZWQnLCBlbmFibGVkLnRvU3RyaW5nKCkpOwogICAgICAgIH0KCiAgICAgICAgc2F2ZUJsb2NrVGFnc1NldHRpbmcoZW5hYmxlZCkgewogICAgICAgICAgICB0aGlzLmNvbmZpZy5ibG9ja0tleXdvcmRzLmJsb2NrVGFncyA9IGVuYWJsZWQ7CiAgICAgICAgICAgIGxvY2FsU3RvcmFnZS5zZXRJdGVtKCdkb3V5aW5fYmxvY2tfdGFnc19lbmFibGVkJywgZW5hYmxlZC50b1N0cmluZygpKTsKICAgICAgICB9CgogICAgICAgIGdldChrZXkpIHsKICAgICAgICAgICAgcmV0dXJuIHRoaXMuY29uZmlnW2tleV07CiAgICAgICAgfQoKICAgICAgICBzZXRFbmFibGVkKGtleSwgdmFsdWUpIHsKICAgICAgICAgICAgaWYgKHRoaXMuY29uZmlnW2tleV0pIHsKICAgICAgICAgICAgICAgIHRoaXMuY29uZmlnW2tleV0uZW5hYmxlZCA9IHZhbHVlOwogICAgICAgICAgICB9CiAgICAgICAgfQoKICAgICAgICBpc0VuYWJsZWQoa2V5KSB7CiAgICAgICAgICAgIHJldHVybiB0aGlzLmNvbmZpZ1trZXldPy5lbmFibGVkIHx8IGZhbHNlOwogICAgICAgIH0KICAgIH0KCiAgICAvLyA9PT09PT09PT09IERPTemAieaLqeWZqOW4uOmHjyA9PT09PT09PT09CiAgICBjb25zdCBTRUxFQ1RPUlMgPSB7CiAgICAgICAgYWN0aXZlVmlkZW86ICJbZGF0YS1lMmU9J2ZlZWQtYWN0aXZlLXZpZGVvJ106aGFzKHZpZGVvW3NyY10pIiwKICAgICAgICByZXNvbHV0aW9uT3B0aW9uczogIi54Z3BsYXllci1wbGF5aW5nIGRpdi52aXJ0dWFsID4gZGl2Lml0ZW0iLAogICAgICAgIGFjY291bnROYW1lOiAnW2RhdGEtZTJlPSJmZWVkLXZpZGVvLW5pY2tuYW1lIl0nLAogICAgICAgIHNldHRpbmdzUGFuZWw6ICd4Zy1pY29uLnhncGxheWVyLWF1dG9wbGF5LXNldHRpbmcnLAogICAgICAgIGFkSW5kaWNhdG9yOiAnc3ZnW3ZpZXdCb3g9IjAgMCAzMCAxNiJdJywKICAgICAgICB2aWRlb0VsZW1lbnQ6ICd2aWRlb1tzcmNdJywKICAgICAgICB2aWRlb0Rlc2M6ICdbZGF0YS1lMmU9InZpZGVvLWRlc2MiXScKICAgIH07CgogICAgLy8gPT09PT09PT09PSDop4bpopHmjqfliLblmaggPT09PT09PT09PQogICAgY2xhc3MgVmlkZW9Db250cm9sbGVyIHsKICAgICAgICBjb25zdHJ1Y3Rvcihub3RpZmljYXRpb25NYW5hZ2VyKSB7CiAgICAgICAgICAgIHRoaXMuc2tpcENoZWNrSW50ZXJ2YWwgPSBudWxsOwogICAgICAgICAgICB0aGlzLnNraXBBdHRlbXB0Q291bnQgPSAwOwogICAgICAgICAgICB0aGlzLm5vdGlmaWNhdGlvbk1hbmFnZXIgPSBub3RpZmljYXRpb25NYW5hZ2VyOwogICAgICAgIH0KCiAgICAgICAgc2tpcChyZWFzb24pIHsKICAgICAgICAgICAgY29uc3QgdGlwID0gYOi3s+i/h+inhumike+8jOWOn+WboO+8miR7cmVhc29ufWA7CiAgICAgICAgICAgIGlmIChyZWFzb24pIHsKICAgICAgICAgICAgICAgIHRoaXMubm90aWZpY2F0aW9uTWFuYWdlci5zaG93TWVzc2FnZSh0aXApOwogICAgICAgICAgICB9CiAgICAgICAgICAgIGNvbnNvbGUubG9nKHRpcCk7CiAgICAgICAgICAgIGlmICghZG9jdW1lbnQuYm9keSkgcmV0dXJuOwoKICAgICAgICAgICAgY29uc3QgdmlkZW9CZWZvcmUgPSB0aGlzLmdldEN1cnJlbnRWaWRlb1VybCgpOwogICAgICAgICAgICB0aGlzLnNlbmRLZXlFdmVudCgnQXJyb3dEb3duJyk7CgogICAgICAgICAgICB0aGlzLmNsZWFyU2tpcENoZWNrKCk7CiAgICAgICAgICAgIHRoaXMuc3RhcnRTa2lwQ2hlY2sodmlkZW9CZWZvcmUpOwogICAgICAgIH0KCiAgICAgICAgbGlrZSgpIHsKICAgICAgICAgICAgdGhpcy5ub3RpZmljYXRpb25NYW5hZ2VyLnNob3dNZXNzYWdlKCdBSeWWnOWlvTog4p2k77iPIOiHquWKqOeCuei1nicpOwogICAgICAgICAgICB0aGlzLnNlbmRLZXlFdmVudCgneicsICdLZXlaJywgOTApOwogICAgICAgIH0KCiAgICAgICAgcHJlc3NSKCkgewogICAgICAgICAgICB0aGlzLm5vdGlmaWNhdGlvbk1hbmFnZXIuc2hvd01lc3NhZ2UoJ+Wxj+iUvei0puWPtzog8J+aqyDkuI3mhJ/lhbTotqMnKTsKICAgICAgICAgICAgdGhpcy5zZW5kS2V5RXZlbnQoJ3InLCAnS2V5UicsIDgyKTsKICAgICAgICB9CgogICAgICAgIHNlbmRLZXlFdmVudChrZXksIGNvZGUgPSBudWxsLCBrZXlDb2RlID0gbnVsbCkgewogICAgICAgICAgICB0cnkgewogICAgICAgICAgICAgICAgY29uc3QgZXZl",
-        "bnQgPSBuZXcgS2V5Ym9hcmRFdmVudCgna2V5ZG93bicsIHsKICAgICAgICAgICAgICAgICAgICBrZXk6IGtleSwKICAgICAgICAgICAgICAgICAgICBjb2RlOiBjb2RlIHx8IChrZXkgPT09ICdBcnJvd0Rvd24nID8gJ0Fycm93RG93bicgOiBjb2RlKSwKICAgICAgICAgICAgICAgICAgICBrZXlDb2RlOiBrZXlDb2RlIHx8IChrZXkgPT09ICdBcnJvd0Rvd24nID8gNDAgOiBrZXlDb2RlKSwKICAgICAgICAgICAgICAgICAgICB3aGljaDoga2V5Q29kZSB8fCAoa2V5ID09PSAnQXJyb3dEb3duJyA/IDQwIDoga2V5Q29kZSksCiAgICAgICAgICAgICAgICAgICAgYnViYmxlczogdHJ1ZSwKICAgICAgICAgICAgICAgICAgICBjYW5jZWxhYmxlOiB0cnVlCiAgICAgICAgICAgICAgICB9KTsKICAgICAgICAgICAgICAgIGRvY3VtZW50LmJvZHkuZGlzcGF0Y2hFdmVudChldmVudCk7CiAgICAgICAgICAgIH0gY2F0Y2ggKGVycm9yKSB7CiAgICAgICAgICAgICAgICBjb25zb2xlLmxvZygn5Y+R6YCB6ZSu55uY5LqL5Lu25aSx6LSlOicsIGVycm9yKTsKICAgICAgICAgICAgfQogICAgICAgIH0KCiAgICAgICAgZ2V0Q3VycmVudFZpZGVvVXJsKCkgewogICAgICAgICAgICBjb25zdCBhY3RpdmVDb250YWluZXJzID0gZG9jdW1lbnQucXVlcnlTZWxlY3RvckFsbChTRUxFQ1RPUlMuYWN0aXZlVmlkZW8pOwogICAgICAgICAgICBjb25zdCBsYXN0QWN0aXZlQ29udGFpbmVyID0gZ2V0QmVzdFZpc2libGVFbGVtZW50KGFjdGl2ZUNvbnRhaW5lcnMpOwogICAgICAgICAgICBpZiAoIWxhc3RBY3RpdmVDb250YWluZXIpIHJldHVybiAnJzsKICAgICAgICAgICAgY29uc3QgdmlkZW9FbCA9IGxhc3RBY3RpdmVDb250YWluZXIucXVlcnlTZWxlY3RvcihTRUxFQ1RPUlMudmlkZW9FbGVtZW50KTsKICAgICAgICAgICAgcmV0dXJuIHZpZGVvRWw/LnNyYyB8fCAnJzsKICAgICAgICB9CgogICAgICAgIGNsZWFyU2tpcENoZWNrKCkgewogICAgICAgICAgICBpZiAodGhpcy5za2lwQ2hlY2tJbnRlcnZhbCkgewogICAgICAgICAgICAgICAgY2xlYXJJbnRlcnZhbCh0aGlzLnNraXBDaGVja0ludGVydmFsKTsKICAgICAgICAgICAgICAgIHRoaXMuc2tpcENoZWNrSW50ZXJ2YWwgPSBudWxsOwogICAgICAgICAgICB9CiAgICAgICAgICAgIHRoaXMuc2tpcEF0dGVtcHRDb3VudCA9IDA7CiAgICAgICAgfQoKICAgICAgICBzdGFydFNraXBDaGVjayh1cmxCZWZvcmUpIHsKICAgICAgICAgICAgdGhpcy5za2lwQ2hlY2tJbnRlcnZhbCA9IHNldEludGVydmFsKCgpID0+IHsKICAgICAgICAgICAgICAgIGlmICh0aGlzLnNraXBBdHRlbXB0Q291bnQgPj0gNSkgewogICAgICAgICAgICAgICAgICAgIHRoaXMubm90aWZpY2F0aW9uTWFuYWdlci5zaG93TWVzc2FnZSgn4pqg77iPIOi3s+i/h+Wksei0pe+8jOivt+aJi+WKqOaTjeS9nCcpOwogICAgICAgICAgICAgICAgICAgIHRoaXMuY2xlYXJTa2lwQ2hlY2soKTsKICAgICAgICAgICAgICAgICAgICByZXR1cm47CiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgdGhpcy5za2lwQXR0ZW1wdENvdW50Kys7CiAgICAgICAgICAgICAgICBjb25zdCB1cmxBZnRlciA9IHRoaXMuZ2V0Q3VycmVudFZpZGVvVXJsKCk7CiAgICAgICAgICAgICAgICBpZiAodXJsQWZ0ZXIgJiYgdXJsQWZ0ZXIgIT09IHVybEJlZm9yZSkgewogICAgICAgICAgICAgICAgICAgIGNvbnNvbGUubG9nKCfop4bpopHlt7LmiJDlip/liIfmjaInKTsKICAgICAgICAgICAgICAgICAgICB0aGlzLmNsZWFyU2tpcENoZWNrKCk7CiAgICAgICAgICAgICAgICAgICAgcmV0dXJuOwogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIGNvbnN0IGF0dGVtcHRNZXNzYWdlID0gYOi3s+i/h+Wksei0pe+8jOato+WcqOmHjeivlSAoJHt0aGlzLnNraXBBdHRlbXB0Q291bnR9LzUpYDsKICAgICAgICAgICAgICAgIHRoaXMubm90aWZpY2F0aW9uTWFuYWdlci5zaG93TWVzc2FnZShhdHRlbXB0TWVzc2FnZSwgMTAwMCk7CiAgICAgICAgICAgICAgICBjb25zb2xlLmxvZyhhdHRlbXB0TWVzc2FnZSk7CiAgICAgICAgICAgICAgICB0aGlzLnNlbmRLZXlFdmVudCgnQXJyb3dEb3duJyk7CiAgICAgICAgICAgIH0sIDUwMCk7CiAgICAgICAgfQogICAgfQoKICAgIC8vID09PT09PT09PT0gVUnnu4Tku7blt6XljoIgPT09PT09PT09PQogICAgY2xhc3MgVUlGYWN0b3J5IHsKICAgICAgICBzdGF0aWMgY3JlYXRlRGlhbG9nKGNsYXNzTmFtZSwgdGl0bGUsIGNvbnRlbnQsIG9uU2F2ZSwgb25DYW5jZWwpIHsKICAgICAgICAgICAgY29uc3QgZXhpc3RpbmdEaWFsb2cgPSBkb2N1bWVudC5xdWVyeVNlbGVjdG9yKGAuJHtjbGFzc05hbWV9YCk7CiAgICAgICAgICAgIGlmIChleGlzdGluZ0RpYWxvZykgewogICAgICAgICAgICAgICAgZXhpc3RpbmdEaWFsb2cucmVtb3ZlKCk7CiAgICAgICAgICAgICAgICByZXR1cm47CiAgICAgICAgICAgIH0KCiAgICAgICAgICAgIGNvbnN0IGRpYWxvZyA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ2RpdicpOwogICAgICAgICAgICBkaWFsb2cuY2xhc3NOYW1lID0gY2xhc3NOYW1lOwogICAgICAgICAgICBPYmplY3QuYXNzaWduKGRpYWxvZy5zdHlsZSwgewogICAgICAgICAgICAgICAgcG9zaXRpb246ICdmaXhlZCcsCiAgICAgICAgICAgICAgICB0b3A6ICc1MCUnLAogICAgICAgICAgICAgICAgbGVmdDogJzUwJScsCiAgICAgICAgICAgICAgICB0cmFuc2Zvcm06ICd0cmFuc2xhdGUoLTUwJSwgLTUwJSknLAogICAgICAgICAgICAgICAgYmFja2dyb3VuZDogJ3JnYmEoMCwgMCwgMCwgMC45KScsCiAgICAgICAgICAgICAgICBib3JkZXI6ICcxcHggc29saWQgcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjIpJywKICAgICAgICAgICAgICAgIGJvcmRlclJhZGl1czogJzhweCcsCiAgICAgICAgICAgICAgICBwYWRkaW5nOiAnMjBweCcsCiAgICAgICAgICAgICAgICB6SW5kZXg6ICcxMDAwMCcsCiAgICAgICAgICAgICAgICBtaW5XaWR0aDogJzI1MHB4JwogICAgICAgICAgICB9KTsKCiAgICAgICAgICAgIGRpYWxvZy5pbm5lckhUTUwgPSBgCiAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJjb2xvcjogd2hpdGU7IG1hcmdpbi1ib3R0b206IDE1cHg7IGZvbnQtc2l6ZTogMTRweDsiPiR7dGl0bGV9PC9kaXY+CiAgICAgICAgICAgICAgICAke2NvbnRlbnR9CiAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJkaXNwbGF5OiBmbGV4OyBnYXA6IDEwcHg7IG1hcmdpbi10b3A6IDE1cHg7Ij4KICAgICAgICAgICAgICAgICAgICA8YnV0dG9uIGNsYXNzPSJkaWFsb2ctY29uZmlybSIgc3R5bGU9ImZsZXg6IDE7IHBhZGRpbmc6IDVweDsgYmFja2dyb3VuZDogI2ZlMmM1NTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNvbG9yOiB3aGl0ZTsgYm9yZGVyOiBub25lOyBib3JkZXItcmFkaXVzOiA0cHg7IGN1cnNvcjogcG9pbnRlcjsiPuehruWumjwvYnV0dG9uPgogICAgICAgICAgICAgICAgICAgIDxidXR0b24gY2xhc3M9ImRpYWxvZy1jYW5jZWwiIHN0eWxlPSJmbGV4OiAxOyBwYWRkaW5nOiA1cHg7IGJhY2tncm91bmQ6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC4xKTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNvbG9yOiB3aGl0ZTsgYm9yZGVyOiAxcHggc29saWQgcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjMpOyBib3JkZXItcmFkaXVzOiA0cHg7IGN1cnNvcjogcG9pbnRlcjsiPuWPlua2iDwvYnV0dG9uPgogICAgICAgICAgICAgICAgPC9kaXY+CiAgICAgICAgICAgIGA7CgogICAgICAgICAgICBkb2N1bWVudC5ib2R5LmFwcGVuZENoaWxkKGRpYWxvZyk7CgogICAgICAgICAgICBkaWFsb2cucXVlcnlTZWxlY3RvcignLmRpYWxvZy1jb25maXJtJykuYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiB7CiAgICAgICAgICAgICAgICBpZiAob25TYXZlKCkpIGRpYWxvZy5yZW1vdmUoKTsKICAgICAgICAgICAgfSk7CgogICAgICAgICAgICBkaWFsb2cucXVlcnlTZWxlY3RvcignLmRpYWxvZy1jYW5jZWwnKS5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsICgpID0+IHsKICAgICAgICAgICAgICAgIGRpYWxvZy5yZW1vdmUoKTsKICAgICAgICAgICAgICAgIGlmIChvbkNhbmNlbCkgb25DYW5jZWwoKTsKICAgICAgICAgICAgfSk7CgogICAgICAgICAgICBzZXRUaW1lb3V0KCgpID0+IHsKICAgICAgICAgICAgICAgIGRvY3VtZW50LmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgZnVuY3Rpb24gY2xvc2VEaWFsb2coZSkgewogICAgICAgICAgICAgICAgICAgIGlmICghZGlhbG9nLmNvbnRhaW5zKGUudGFyZ2V0KSkgewogICAgICAgICAgICAgICAgICAgICAgICBkaWFsb2cucmVtb3ZlKCk7CiAgICAgICAgICAgICAgICAgICAgICAgIGRvY3VtZW50LnJlbW92ZUV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgY2xvc2VEaWFsb2cpOwogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH0pOwogICAgICAgICAgICB9LCAxMDApOwoKICAgICAgICAgICAgcmV0dXJuIGRpYWxvZzsKICAgICAgICB9CgogICAgICAgIHN0YXRpYyBjcmVhdGVUb2dnbGVCdXR0b24odGV4dCwgY2xhc3NOYW1lLCBpc0VuYWJsZWQsIG9uVG9nZ2xlLCBvbkNsaWNrID0gbnVsbCwgc2hvcnRjdXQgPSBudWxsKSB7CiAgICAgICAgICAgIGNvbnN0IGJ0bkNvbnRhaW5lciA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ3hnLWljb24nKTsKICAgICAgICAgICAgYnRuQ29udGFpbmVyLmNsYXNzTmFtZSA9IGB4Z3BsYXllci1hdXRvcGxheS1zZXR0aW5nICR7Y2xhc3NOYW1lfWA7CgogICAgICAgICAgICBjb25zdCBzaG9ydGN1dEhpbnQgPSBzaG9ydGN1dAogICAgICAgICAgICAgICAgPyBgPGRpdiBjbGFzcz0ieGdUaXBzIj48c3Bhbj4ke3RleHQucmVwbGFjZSgvPFtePl0qPi9nLCAnJyl9PC9zcGFuPjxzcGFuIGNsYXNzPSJzaG9ydGN1dEtleSI+JHtzaG9ydGN1dH08L3NwYW4+PC9kaXY+YAogICAgICAgICAgICAgICAgOiAnJzsKCiAgICAgICAgICAgIGJ0bkNvbnRhaW5lci5pbm5lckhUTUwgPSBgCiAgICAgICAgICAgICAgICA8ZGl2IGNsYXNzPSJ4Z3BsYXllci1pY29uIj4KICAgICAgICAgICAgICAgICAgICA8ZGl2IGNsYXNzPSJ4Z3BsYXllci1zZXR0aW5nLWxhYmVsIj4KICAgICAgICAgICAgICAgICAgICAgICAgPGJ1dHRvbiBhcmlhLWNoZWNrZWQ9IiR7aXNFbmFibGVkfSIgY2xhc3M9InhnLXN3aXRjaCAke2lzRW5hYmxlZCA/ICd4Zy1zd2l0Y2gtY2hlY2tlZCcgOiAnJ30iPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgPHNwYW4gY2xhc3M9InhnLXN3aXRjaC1pbm5lciI+PC9zcGFuPgogICAgICAgICAgICAgICAgICAgICAgICA8L2J1dHRvbj4KICAgICAgICAgICAgICAgICAgICAgICAgPHNwYW4gY2xhc3M9InhncGxheWVyLXNldHRpbmctdGl0bGUiIHN0eWxlPSIke29uQ2xpY2sgPyAnY3Vyc29yOiBwb2ludGVyOyB0ZXh0LWRlY29yYXRpb246IHVuZGVybGluZTsnIDogJyd9Ij4ke3RleHR9PC9zcGFuPgogICAgICAgICAgICAgICAgICAgIDwvZGl2PgogICAgICAgICAgICAgICAgPC9kaXY+JHtzaG9ydGN1dEhpbnR9YDsKCiAgICAgICAgICAgIGJ0bkNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCdidXR0b24nKS5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIChlKSA9PiB7CiAgICAgICAgICAgICAgICBjb25zdCBuZXdTdGF0ZSA9IGUuY3VycmVudFRhcmdldC5nZXRBdHRyaWJ1dGUoJ2FyaWEtY2hlY2tlZCcpID09PSAnZmFsc2UnOwogICAgICAgICAgICAgICAgVUlNYW5hZ2VyLnVwZGF0ZVRvZ2dsZUJ1dHRvbnMoY2xhc3NOYW1lLCBuZXdTdGF0ZSk7CiAgICAgICAgICAgICAgICBvblRvZ2dsZShuZXdTdGF0ZSk7CiAgICAgICAgICAgIH0pOwoKICAgICAgICAgICAgaWYgKG9uQ2xpY2spIHsKICAgICAgICAgICAgICAgIGJ0bkNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKCcueGdwbGF5ZXItc2V0dGluZy10aXRsZScpLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKGUpID0+IHsKICAgICAgICAgICAgICAgICAgICBlLnN0b3BQcm9wYWdhdGlvbigpOwogICAgICAgICAgICAgICAgICAgIG9uQ2xpY2soKTsKICAgICAgICAgICAgICAgIH0pOwogICAgICAgICAgICB9CgogICAgICAgICAgICByZXR1cm4gYnRuQ29udGFpbmVyOwogICAgICAgIH0KCiAgICAgICAgc3RhdGljIHNob3dFcnJvckRpYWxv",
-        "ZygpIHsKICAgICAgICAgICAgY29uc3QgZGlhbG9nID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnZGl2Jyk7CiAgICAgICAgICAgIGRpYWxvZy5jbGFzc05hbWUgPSAnZXJyb3ItZGlhbG9nLScgKyBEYXRlLm5vdygpOwogICAgICAgICAgICBkaWFsb2cuc3R5bGUuY3NzVGV4dCA9IGAKICAgICAgICAgICAgICAgIHBvc2l0aW9uOiBmaXhlZDsKICAgICAgICAgICAgICAgIHRvcDogNTAlOwogICAgICAgICAgICAgICAgbGVmdDogNTAlOwogICAgICAgICAgICAgICAgdHJhbnNmb3JtOiB0cmFuc2xhdGUoLTUwJSwgLTUwJSk7CiAgICAgICAgICAgICAgICBiYWNrZ3JvdW5kOiByZ2JhKDAsIDAsIDAsIDAuOTUpOwogICAgICAgICAgICAgICAgYm9yZGVyOiAycHggc29saWQgcmdiYSgyNTQsIDQ0LCA4NSwgMC44KTsKICAgICAgICAgICAgICAgIGNvbG9yOiB3aGl0ZTsKICAgICAgICAgICAgICAgIHBhZGRpbmc6IDI1cHg7CiAgICAgICAgICAgICAgICBib3JkZXItcmFkaXVzOiAxMnB4OwogICAgICAgICAgICAgICAgei1pbmRleDogMTAwMDE7CiAgICAgICAgICAgICAgICBtYXgtd2lkdGg6IDUwMHB4OwogICAgICAgICAgICAgICAgbWF4LWhlaWdodDogODB2aDsKICAgICAgICAgICAgICAgIG92ZXJmbG93LXk6IGF1dG87CiAgICAgICAgICAgICAgICB0ZXh0LWFsaWduOiBsZWZ0OwogICAgICAgICAgICAgICAgZm9udC1zaXplOiAxNHB4OwogICAgICAgICAgICAgICAgYm94LXNoYWRvdzogMCA4cHggMzJweCByZ2JhKDAsIDAsIDAsIDAuNSk7CiAgICAgICAgICAgICAgICBmb250LWZhbWlseTogLWFwcGxlLXN5c3RlbSwgQmxpbmtNYWNTeXN0ZW1Gb250LCAiU2Vnb2UgVUkiLCBSb2JvdG8sIEhlbHZldGljYSwgQXJpYWwsIHNhbnMtc2VyaWY7CiAgICAgICAgICAgIGA7CgogICAgICAgICAgICBjb25zdCBjb21tb25TdHlsZSA9IGBiYWNrZ3JvdW5kOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuMSk7IHBhZGRpbmc6IDhweDsgYm9yZGVyLXJhZGl1czogNHB4OyBmb250LWZhbWlseTogbW9ub3NwYWNlOyBtYXJnaW46IDVweCAwOyBkaXNwbGF5OiBibG9jazsgdXNlci1zZWxlY3Q6IHRleHQ7YDsKICAgICAgICAgICAgY29uc3QgaDNTdHlsZSA9IGBjb2xvcjogI2ZlMmM1NTsgbWFyZ2luOiAxNXB4IDAgOHB4IDA7IGZvbnQtc2l6ZTogMTVweDsgYm9yZGVyLWJvdHRvbTogMXB4IHNvbGlkIHJnYmEoMjU1LDI1NSwyNTUsMC4xKTsgcGFkZGluZy1ib3R0b206IDVweDtgOwoKICAgICAgICAgICAgZGlhbG9nLmlubmVySFRNTCA9IGAKICAgICAgICAgICAgICAgIDxkaXYgc3R5bGU9InRleHQtYWxpZ246IGNlbnRlcjsgbWFyZ2luLWJvdHRvbTogMjBweDsiPgogICAgICAgICAgICAgICAgICAgIDxkaXYgc3R5bGU9ImZvbnQtc2l6ZTogMzJweDsgbWFyZ2luLWJvdHRvbTogMTBweDsiPuKaoO+4jyDov57mjqXlpLHotKU8L2Rpdj4KICAgICAgICAgICAgICAgICAgICA8cCBzdHlsZT0iY29sb3I6ICNhYWE7IGZvbnQtc2l6ZTogMTNweDsiPuivt+ehruS/nSA8YSBocmVmPSJodHRwczovL29sbGFtYS5jb20vIiB0YXJnZXQ9Il9ibGFuayIgc3R5bGU9ImNvbG9yOiAjZmUyYzU1OyI+T2xsYW1hPC9hPiDlt7Lov5DooYzlubbphY3nva7ot6jln5/orr/pl648L3A+CiAgICAgICAgICAgICAgICA8L2Rpdj4KCiAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJiYWNrZ3JvdW5kOiByZ2JhKDAsMCwwLDAuMyk7IHBhZGRpbmc6IDE1cHg7IGJvcmRlci1yYWRpdXM6IDhweDsgbWFyZ2luLWJvdHRvbTogMjBweDsiPgogICAgICAgICAgICAgICAgICAgIDxoMyBzdHlsZT0iJHtoM1N0eWxlfSI+8J+Wpe+4jyBXaW5kb3dzIOmFjee9rjwvaDM+CiAgICAgICAgICAgICAgICAgICAgPG9sIHN0eWxlPSJwYWRkaW5nLWxlZnQ6IDIwcHg7IG1hcmdpbjogMDsgbGluZS1oZWlnaHQ6IDEuNjsiPgogICAgICAgICAgICAgICAgICAgICAgICA8bGk+5omT5byAIDxzdHJvbmc+5o6n5Yi26Z2i5p2/PC9zdHJvbmc+IC0+IOezu+e7nyAtPiDpq5jnuqfns7vnu5/orr7nva4gLT4g546v5aKD5Y+Y6YePPC9saT4KICAgICAgICAgICAgICAgICAgICAgICAgPGxpPuWcqCA8c3Ryb25nPueUqOaIt+WPmOmHjzwvc3Ryb25nPiDngrnlh7vmlrDlu7rvvIzmt7vliqDkuKTkuKrlj5jph4/vvJoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxkaXYgc3R5bGU9IiR7Y29tbW9uU3R5bGV9Ij4KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBPTExBTUFfSE9TVCA9IDAuMC4wLjA8YnI+CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgT0xMQU1BX09SSUdJTlMgPSAqCiAgICAgICAgICAgICAgICAgICAgICAgICAgICA8L2Rpdj4KICAgICAgICAgICAgICAgICAgICAgICAgPC9saT4KICAgICAgICAgICAgICAgICAgICAgICAgPGxpPueCueWHu+ehruWumuS/neWtmO+8jOmHjeWQryBPbGxhbWE8L2xpPgogICAgICAgICAgICAgICAgICAgIDwvb2w+CgogICAgICAgICAgICAgICAgICAgIDxoMyBzdHlsZT0iJHtoM1N0eWxlfSI+8J+NjiBtYWNPUyDphY3nva48L2gzPgogICAgICAgICAgICAgICAgICAgIDxkaXYgc3R5bGU9Im1hcmdpbi1ib3R0b206IDVweDsiPuaJk+W8gOe7iOerr+i/kOihjOS7peS4i+WRveS7pO+8jOeEtuWQjumHjeWQryBPbGxhbWHvvJo8L2Rpdj4KICAgICAgICAgICAgICAgICAgICA8Y29kZSBzdHlsZT0iJHtjb21tb25TdHlsZX0iPgogICAgICAgICAgICAgICAgICAgICAgICBsYXVuY2hjdGwgc2V0ZW52IE9MTEFNQV9IT1NUICIwLjAuMC4wIjxicj4KICAgICAgICAgICAgICAgICAgICAgICAgbGF1bmNoY3RsIHNldGVudiBPTExBTUFfT1JJR0lOUyAiKiIKICAgICAgICAgICAgICAgICAgICA8L2NvZGU+CgogICAgICAgICAgICAgICAgICAgIDxoMyBzdHlsZT0iJHtoM1N0eWxlfSI+8J+QpyBMaW51eCAoc3lzdGVtZCkg6YWN572uPC9oMz4KICAgICAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJtYXJnaW4tYm90dG9tOiA1cHg7Ij4xLiDnvJbovpHmnI3liqHphY3nva46IDxjb2RlIHN0eWxlPSJiYWNrZ3JvdW5kOnJnYmEoMjU1LDI1NSwyNTUsMC4xKTsgcHgtMSI+c3VkbyBzeXN0ZW1jdGwgZWRpdCBvbGxhbWEuc2VydmljZTwvY29kZT48L2Rpdj4KICAgICAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJtYXJnaW4tYm90dG9tOiA1cHg7Ij4yLiDlnKggPGNvZGUgc3R5bGU9ImNvbG9yOiNhYWEiPltTZXJ2aWNlXTwvY29kZT4g5LiL5pa55re75Yqg77yaPC9kaXY+CiAgICAgICAgICAgICAgICAgICAgPGNvZGUgc3R5bGU9IiR7Y29tbW9uU3R5bGV9Ij4KICAgICAgICAgICAgICAgICAgICAgICAgW1NlcnZpY2VdPGJyPgogICAgICAgICAgICAgICAgICAgICAgICBFbnZpcm9ubWVudD0iT0xMQU1BX0hPU1Q9MC4wLjAuMCI8YnI+CiAgICAgICAgICAgICAgICAgICAgICAgIEVudmlyb25tZW50PSJPTExBTUFfT1JJR0lOUz0qIgogICAgICAgICAgICAgICAgICAgIDwvY29kZT4KICAgICAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJtYXJnaW4tdG9wOiA1cHg7Ij4zLiDph43lkK/mnI3liqE6IDxjb2RlIHN0eWxlPSJiYWNrZ3JvdW5kOnJnYmEoMjU1LDI1NSwyNTUsMC4xKTsgcHgtMSI+c3VkbyBzeXN0ZW1jdGwgZGFlbW9uLXJlbG9hZCAmJiBzdWRvIHN5c3RlbWN0bCByZXN0YXJ0IG9sbGFtYTwvY29kZT48L2Rpdj4KICAgICAgICAgICAgICAgIDwvZGl2PgoKICAgICAgICAgICAgICAgIDxkaXYgc3R5bGU9InRleHQtYWxpZ246IGNlbnRlcjsiPgogICAgICAgICAgICAgICAgICAgIDxkaXYgY2xhc3M9ImVycm9yLWRpYWxvZy1jbG9zZSIgc3R5bGU9Im1hcmdpbi10b3A6IDEwcHg7IGZvbnQtc2l6ZTogMTRweDsgY29sb3I6ICNmZTJjNTU7IGN1cnNvcjogcG9pbnRlcjsgdGV4dC1kZWNvcmF0aW9uOiB1bmRlcmxpbmU7Ij7lhbPpl608L2Rpdj4KICAgICAgICAgICAgICAgIDwvZGl2PgogICAgICAgICAgICBgOwoKICAgICAgICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmRDaGlsZChkaWFsb2cpOwoKICAgICAgICAgICAgLy8g54K55Ye75YWz6Zet5paH5a2XCiAgICAgICAgICAgIGRpYWxvZy5xdWVyeVNlbGVjdG9yKCcuZXJyb3ItZGlhbG9nLWNsb3NlJykuYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoKSA9PiB7CiAgICAgICAgICAgICAgICBkaWFsb2cucmVtb3ZlKCk7CiAgICAgICAgICAgIH0pOwoKICAgICAgICAgICAgLy8g54K55Ye76IOM5pmv5YWz6ZetCiAgICAgICAgICAgIGRpYWxvZy5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIChlKSA9PiB7CiAgICAgICAgICAgICAgICBpZiAoZS50YXJnZXQgPT09IGRpYWxvZykgZGlhbG9nLnJlbW92ZSgpOwogICAgICAgICAgICB9KTsKICAgICAgICB9CiAgICB9CgogICAgLy8gPT09PT09PT09PSBVSeeuoeeQhuWZqCA9PT09PT09PT09CiAgICBjbGFzcyBVSU1hbmFnZXIgewogICAgICAgIGNvbnN0cnVjdG9yKGNvbmZpZywgdmlkZW9Db250cm9sbGVyLCBub3RpZmljYXRpb25NYW5hZ2VyKSB7CiAgICAgICAgICAgIHRoaXMuY29uZmlnID0gY29uZmlnOwogICAgICAgICAgICB0aGlzLnZpZGVvQ29udHJvbGxlciA9IHZpZGVvQ29udHJvbGxlcjsKICAgICAgICAgICAgdGhpcy5ub3RpZmljYXRpb25NYW5hZ2VyID0gbm90aWZpY2F0aW9uTWFuYWdlcjsKICAgICAgICAgICAgdGhpcy5pbml0QnV0dG9ucygpOwogICAgICAgIH0KCiAgICAgICAgaW5pdEJ1dHRvbnMoKSB7CiAgICAgICAgICAgIHRoaXMuYnV0dG9uQ29uZmlncyA9IFsKICAgICAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICAgICB0ZXh0OiAn6Lez55u05pKtJywKICAgICAgICAgICAgICAgICAgICBjbGFzc05hbWU6ICdza2lwLWxpdmUtYnV0dG9uJywKICAgICAgICAgICAgICAgICAgICBjb25maWdLZXk6ICdza2lwTGl2ZScsCiAgICAgICAgICAgICAgICAgICAgc2hvcnRjdXQ6ICc9JwogICAgICAgICAgICAgICAgfSwKICAgICAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICAgICB0ZXh0OiAn6Lez5bm/5ZGKJywKICAgICAgICAgICAgICAgICAgICBjbGFzc05hbWU6ICdza2lwLWFkLWJ1dHRvbicsCiAgICAgICAgICAgICAgICAgICAgY29uZmlnS2V5OiAnc2tpcEFkJwogICAgICAgICAgICAgICAgfSwKICAgICAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICAgICB0ZXh0OiAn6LSm5Y+35bGP6JS9JywKICAgICAgICAgICAgICAgICAgICBjbGFzc05hbWU6ICdibG9jay1hY2NvdW50LWtleXdvcmQtYnV0dG9uJywKICAgICAgICAgICAgICAgICAgICBjb25maWdLZXk6ICdibG9ja0tleXdvcmRzJywKICAgICAgICAgICAgICAgICAgICBvbkNsaWNrOiAoKSA9PiB0aGlzLnNob3dLZXl3b3JkRGlhbG9nKCkKICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgdGV4dDogJ+acgOmrmOa4hScsCiAgICAgICAgICAgICAgICAgICAgY2xhc3NOYW1lOiAnYXV0by1oaWdoLXJlc29sdXRpb24tYnV0dG9uJywKICAgICAgICAgICAgICAgICAgICBjb25maWdLZXk6ICdhdXRvSGlnaFJlcycKICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgdGV4dDogYCR7dGhpcy5jb25maWcuZ2V0KCdvbmx5UmVzb2x1dGlvbicpLnJlc29sdXRpb259562b6YCJYCwKICAgICAgICAgICAgICAgICAgICBjbGFzc05hbWU6ICdyZXNvbHV0aW9uLWZpbHRlci1idXR0b24nLAogICAgICAgICAgICAgICAgICAgIGNvbmZpZ0tleTogJ29ubHlSZXNvbHV0aW9uJywKICAgICAgICAgICAgICAgICAgICBvbkNsaWNrOiAoKSA9PiB0aGlzLnNob3dSZXNvbHV0aW9uRGlhbG9nKCkKICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAgICAgdGV4dDogJ0FJ5Zac5aW9JywKICAgICAgICAgICAgICAgICAgICBjbGFzc05hbWU6ICdhaS1wcmVmZXJlbmNlLWJ1dHRvbicsCiAgICAgICAgICAgICAgICAgICAgY29uZmlnS2V5OiAnYWlQcmVmZXJlbmNlJywKICAgICAgICAgICAgICAgICAgICBvbkNsaWNrOiAoKSA9PiB0aGlzLnNob3dBaVByZWZlcmVuY2VEaWFsb2coKQogICAgICAgICAgICAgICAgfSwKICAgICAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICAgICB0ZXh0OiB0aGlzLmdldFNwZWVkTW9kZUxhYmVsKCksCiAgICAgICAgICAgICAgICAgICAgY2xhc3NOYW1lOiAn",
-        "c3BlZWQtbW9kZS1idXR0b24nLAogICAgICAgICAgICAgICAgICAgIGNvbmZpZ0tleTogJ3NwZWVkTW9kZScsCiAgICAgICAgICAgICAgICAgICAgb25DbGljazogKCkgPT4gdGhpcy5zaG93U3BlZWREaWFsb2coKQogICAgICAgICAgICAgICAgfQogICAgICAgICAgICBdOwogICAgICAgIH0KCiAgICAgICAgaW5zZXJ0QnV0dG9ucygpIHsKICAgICAgICAgICAgZG9jdW1lbnQucXVlcnlTZWxlY3RvckFsbChTRUxFQ1RPUlMuc2V0dGluZ3NQYW5lbCkuZm9yRWFjaChwYW5lbCA9PiB7CiAgICAgICAgICAgICAgICBjb25zdCBwYXJlbnQgPSBwYW5lbC5wYXJlbnROb2RlOwogICAgICAgICAgICAgICAgaWYgKCFwYXJlbnQpIHJldHVybjsKCiAgICAgICAgICAgICAgICBsZXQgbGFzdEJ1dHRvbiA9IHBhbmVsOwogICAgICAgICAgICAgICAgdGhpcy5idXR0b25Db25maWdzLmZvckVhY2goY29uZmlnID0+IHsKICAgICAgICAgICAgICAgICAgICBsZXQgYnV0dG9uID0gcGFyZW50LnF1ZXJ5U2VsZWN0b3IoYC4ke2NvbmZpZy5jbGFzc05hbWV9YCk7CiAgICAgICAgICAgICAgICAgICAgaWYgKCFidXR0b24pIHsKICAgICAgICAgICAgICAgICAgICAgICAgYnV0dG9uID0gVUlGYWN0b3J5LmNyZWF0ZVRvZ2dsZUJ1dHRvbigKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNvbmZpZy50ZXh0LAogICAgICAgICAgICAgICAgICAgICAgICAgICAgY29uZmlnLmNsYXNzTmFtZSwKICAgICAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMuY29uZmlnLmlzRW5hYmxlZChjb25maWcuY29uZmlnS2V5KSwKICAgICAgICAgICAgICAgICAgICAgICAgICAgIChzdGF0ZSkgPT4gewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMuY29uZmlnLnNldEVuYWJsZWQoY29uZmlnLmNvbmZpZ0tleSwgc3RhdGUpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGlmIChjb25maWcuY29uZmlnS2V5ID09PSAnc2tpcExpdmUnKSB7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMubm90aWZpY2F0aW9uTWFuYWdlci5zaG93TWVzc2FnZShg5Yqf6IO95byA5YWzOiDot7Pov4fnm7Tmkq3lt7IgJHtzdGF0ZSA/ICfinIUnIDogJ+KdjCd9YCk7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgfSBlbHNlIGlmIChjb25maWcuY29uZmlnS2V5ID09PSAnc3BlZWRNb2RlJykgewogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBkb2N1bWVudC5kaXNwYXRjaEV2ZW50KG5ldyBDdXN0b21FdmVudCgnZG91eWluLXNwZWVkLW1vZGUtdXBkYXRlZCcpKTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICAgICAgICAgICAgICAgY29uZmlnLm9uQ2xpY2ssCiAgICAgICAgICAgICAgICAgICAgICAgICAgICBjb25maWcuc2hvcnRjdXQKICAgICAgICAgICAgICAgICAgICAgICAgKTsKICAgICAgICAgICAgICAgICAgICAgICAgcGFyZW50Lmluc2VydEJlZm9yZShidXR0b24sIGxhc3RCdXR0b24ubmV4dFNpYmxpbmcpOwogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICBjb25zdCBpc0VuYWJsZWQgPSB0aGlzLmNvbmZpZy5pc0VuYWJsZWQoY29uZmlnLmNvbmZpZ0tleSk7CiAgICAgICAgICAgICAgICAgICAgY29uc3Qgc3dpdGNoRWwgPSBidXR0b24ucXVlcnlTZWxlY3RvcignLnhnLXN3aXRjaCcpOwogICAgICAgICAgICAgICAgICAgIGlmIChzd2l0Y2hFbCkgewogICAgICAgICAgICAgICAgICAgICAgICBzd2l0Y2hFbC5jbGFzc0xpc3QudG9nZ2xlKCd4Zy1zd2l0Y2gtY2hlY2tlZCcsIGlzRW5hYmxlZCk7CiAgICAgICAgICAgICAgICAgICAgICAgIHN3aXRjaEVsLnNldEF0dHJpYnV0ZSgnYXJpYS1jaGVja2VkJywgU3RyaW5nKGlzRW5hYmxlZCkpOwogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICBjb25zdCB0aXRsZUVsID0gYnV0dG9uLnF1ZXJ5U2VsZWN0b3IoJy54Z3BsYXllci1zZXR0aW5nLXRpdGxlJyk7CiAgICAgICAgICAgICAgICAgICAgaWYgKHRpdGxlRWwgJiYgdHlwZW9mIGNvbmZpZy50ZXh0ID09PSAnc3RyaW5nJykgewogICAgICAgICAgICAgICAgICAgICAgICB0aXRsZUVsLnRleHRDb250ZW50ID0gY29uZmlnLnRleHQ7CiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIGxhc3RCdXR0b24gPSBidXR0b247CiAgICAgICAgICAgICAgICB9KTsKICAgICAgICAgICAgfSk7CiAgICAgICAgfQoKICAgICAgICBzdGF0aWMgdXBkYXRlVG9nZ2xlQnV0dG9ucyhjbGFzc05hbWUsIGlzRW5hYmxlZCkgewogICAgICAgICAgICBkb2N1bWVudC5xdWVyeVNlbGVjdG9yQWxsKGAuJHtjbGFzc05hbWV9IC54Zy1zd2l0Y2hgKS5mb3JFYWNoKHN3ID0+IHsKICAgICAgICAgICAgICAgIHN3LmNsYXNzTGlzdC50b2dnbGUoJ3hnLXN3aXRjaC1jaGVja2VkJywgaXNFbmFibGVkKTsKICAgICAgICAgICAgICAgIHN3LnNldEF0dHJpYnV0ZSgnYXJpYS1jaGVja2VkJywgU3RyaW5nKGlzRW5hYmxlZCkpOwogICAgICAgICAgICB9KTsKICAgICAgICB9CgogICAgICAgIHVwZGF0ZVNwZWVkTW9kZVRleHQoKSB7CiAgICAgICAgICAgIGNvbnN0IGxhYmVsID0gdGhpcy5nZXRTcGVlZE1vZGVMYWJlbCgpOwogICAgICAgICAgICBjb25zdCBzcGVlZEJ1dHRvbkNvbmZpZyA9IHRoaXMuYnV0dG9uQ29uZmlncz8uZmluZChjb25maWcgPT4gY29uZmlnLmNvbmZpZ0tleSA9PT0gJ3NwZWVkTW9kZScpOwogICAgICAgICAgICBpZiAoc3BlZWRCdXR0b25Db25maWcpIHsKICAgICAgICAgICAgICAgIHNwZWVkQnV0dG9uQ29uZmlnLnRleHQgPSBsYWJlbDsKICAgICAgICAgICAgfQogICAgICAgICAgICBkb2N1bWVudC5xdWVyeVNlbGVjdG9yQWxsKCcuc3BlZWQtbW9kZS1idXR0b24gLnhncGxheWVyLXNldHRpbmctdGl0bGUnKS5mb3JFYWNoKGVsID0+IHsKICAgICAgICAgICAgICAgIGVsLnRleHRDb250ZW50ID0gbGFiZWw7CiAgICAgICAgICAgIH0pOwogICAgICAgIH0KCiAgICAgICAgZ2V0U3BlZWRNb2RlTGFiZWwoKSB7CiAgICAgICAgICAgIGNvbnN0IHNwZWVkQ29uZmlnID0gdGhpcy5jb25maWcuZ2V0KCdzcGVlZE1vZGUnKTsKICAgICAgICAgICAgY29uc29sZS5sb2coJ3NwZWVkQ29uZmlnJywgc3BlZWRDb25maWcpCiAgICAgICAgICAgIGlmIChzcGVlZENvbmZpZy5tb2RlID09PSAncmFuZG9tJykgewogICAgICAgICAgICAgICAgcmV0dXJuIGDpmo/mnLoke3NwZWVkQ29uZmlnLm1pblNlY29uZHN9LSR7c3BlZWRDb25maWcubWF4U2Vjb25kc33np5JgOwogICAgICAgICAgICB9CiAgICAgICAgICAgIHJldHVybiBgJHtzcGVlZENvbmZpZy5zZWNvbmRzfeenkuWIh2A7CiAgICAgICAgfQoKICAgICAgICB1cGRhdGVSZXNvbHV0aW9uVGV4dCgpIHsKICAgICAgICAgICAgY29uc3QgcmVzb2x1dGlvbiA9IHRoaXMuY29uZmlnLmdldCgnb25seVJlc29sdXRpb24nKS5yZXNvbHV0aW9uOwogICAgICAgICAgICBjb25zdCByZXNvbHV0aW9uQnV0dG9uQ29uZmlnID0gdGhpcy5idXR0b25Db25maWdzPy5maW5kKGNvbmZpZyA9PiBjb25maWcuY29uZmlnS2V5ID09PSAnb25seVJlc29sdXRpb24nKTsKICAgICAgICAgICAgaWYgKHJlc29sdXRpb25CdXR0b25Db25maWcpIHsKICAgICAgICAgICAgICAgIHJlc29sdXRpb25CdXR0b25Db25maWcudGV4dCA9IGAke3Jlc29sdXRpb259562b6YCJYDsKICAgICAgICAgICAgfQogICAgICAgICAgICBkb2N1bWVudC5xdWVyeVNlbGVjdG9yQWxsKCcucmVzb2x1dGlvbi1maWx0ZXItYnV0dG9uIC54Z3BsYXllci1zZXR0aW5nLXRpdGxlJykuZm9yRWFjaChlbCA9PiB7CiAgICAgICAgICAgICAgICBlbC50ZXh0Q29udGVudCA9IGAke3Jlc29sdXRpb259562b6YCJYDsKICAgICAgICAgICAgfSk7CiAgICAgICAgfQoKICAgICAgICBzaG93U3BlZWREaWFsb2coKSB7CiAgICAgICAgICAgIGNvbnN0IHNwZWVkQ29uZmlnID0gdGhpcy5jb25maWcuZ2V0KCdzcGVlZE1vZGUnKTsKICAgICAgICAgICAgY29uc3QgaXNSYW5kb20gPSBzcGVlZENvbmZpZy5tb2RlID09PSAncmFuZG9tJzsKICAgICAgICAgICAgY29uc3QgY29udGVudCA9IGAKICAgICAgICAgICAgICAgIDxkaXYgc3R5bGU9Im1hcmdpbi1ib3R0b206IDE1cHg7IGNvbG9yOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuOCk7IGZvbnQtc2l6ZTogMTNweDsiPgogICAgICAgICAgICAgICAgICAgIDxsYWJlbCBzdHlsZT0iZGlzcGxheTogZmxleDsgYWxpZ24taXRlbXM6IGNlbnRlcjsgbWFyZ2luLWJvdHRvbTogOHB4OyBjdXJzb3I6IHBvaW50ZXI7Ij4KICAgICAgICAgICAgICAgICAgICAgICAgPGlucHV0IHR5cGU9InJhZGlvIiBuYW1lPSJzcGVlZC1tb2RlLXR5cGUiIHZhbHVlPSJmaXhlZCIgJHtpc1JhbmRvbSA/ICcnIDogJ2NoZWNrZWQnfQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgc3R5bGU9Im1hcmdpbi1yaWdodDogOHB4OyI+CiAgICAgICAgICAgICAgICAgICAgICAgIOWbuuWumuaXtumXtOaooeW8jwogICAgICAgICAgICAgICAgICAgIDwvbGFiZWw+CiAgICAgICAgICAgICAgICAgICAgPGxhYmVsIHN0eWxlPSJkaXNwbGF5OiBmbGV4OyBhbGlnbi1pdGVtczogY2VudGVyOyBjdXJzb3I6IHBvaW50ZXI7Ij4KICAgICAgICAgICAgICAgICAgICAgICAgPGlucHV0IHR5cGU9InJhZGlvIiBuYW1lPSJzcGVlZC1tb2RlLXR5cGUiIHZhbHVlPSJyYW5kb20iICR7aXNSYW5kb20gPyAnY2hlY2tlZCcgOiAnJ30KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHN0eWxlPSJtYXJnaW4tcmlnaHQ6IDhweDsiPgogICAgICAgICAgICAgICAgICAgICAgICDpmo/mnLrml7bpl7TmqKHlvI8KICAgICAgICAgICAgICAgICAgICA8L2xhYmVsPgogICAgICAgICAgICAgICAgPC9kaXY+CiAgICAgICAgICAgICAgICA8ZGl2IGNsYXNzPSJzcGVlZC1maXhlZC13cmFwcGVyIiBzdHlsZT0iZGlzcGxheTogJHtpc1JhbmRvbSA/ICdub25lJyA6ICdibG9jayd9OyI+CiAgICAgICAgICAgICAgICAgICAgPGlucHV0IHR5cGU9Im51bWJlciIgY2xhc3M9InNwZWVkLWlucHV0IiBtaW49IjEiIG1heD0iMzYwMCIgdmFsdWU9IiR7c3BlZWRDb25maWcuc2Vjb25kc30iCiAgICAgICAgICAgICAgICAgICAgICAgIHN0eWxlPSJ3aWR0aDogMTAwJTsgcGFkZGluZzogOHB4OyBiYWNrZ3JvdW5kOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuMSk7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBjb2xvcjogd2hpdGU7IGJvcmRlcjogMXB4IHNvbGlkIHJnYmEoMjU1LCAyNTUsIDI1NSwgMC4zKTsgYm9yZGVyLXJhZGl1czogNHB4OyI+CiAgICAgICAgICAgICAgICA8L2Rpdj4KICAgICAgICAgICAgICAgIDxkaXYgY2xhc3M9InNwZWVkLXJhbmRvbS13cmFwcGVyIiBzdHlsZT0iZGlzcGxheTogJHtpc1JhbmRvbSA/ICdmbGV4JyA6ICdub25lJ307IGdhcDogMTBweDsgYWxpZ24taXRlbXM6IGNlbnRlcjsiPgogICAgICAgICAgICAgICAgICAgIDxpbnB1dCB0eXBlPSJudW1iZXIiIGNsYXNzPSJzcGVlZC1taW4taW5wdXQiIG1pbj0iMSIgbWF4PSIzNjAwIiB2YWx1ZT0iJHtzcGVlZENvbmZpZy5taW5TZWNvbmRzfSIKICAgICAgICAgICAgICAgICAgICAgICAgc3R5bGU9ImZsZXg6IDE7IHBhZGRpbmc6IDhweDsgYmFja2dyb3VuZDogcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjEpOyBjb2xvcjogd2hpdGU7IGJvcmRlcjogMXB4IHNvbGlkIHJnYmEoMjU1LCAyNTUsIDI1NSwgMC4zKTsgYm9yZGVyLXJhZGl1czogNHB4OyI+CiAgICAgICAgICAgICAgICAgICAgPHNwYW4gc3R5bGU9ImNvbG9yOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuNik7Ij7igJQ8L3NwYW4+CiAgICAgICAgICAgICAgICAgICAgPGlucHV0IHR5cGU9Im51bWJlciIgY2xhc3M9InNwZWVkLW1heC1pbnB1dCIgbWluPSIxIiBtYXg9IjM2MDAiIHZhbHVlPSIke3NwZWVkQ29uZmlnLm1heFNlY29uZHN9IgogICAgICAgICAgICAgICAgICAgICAgICBzdHlsZT0iZmxleDogMTsgcGFkZGluZzogOHB4OyBiYWNrZ3JvdW5kOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuMSk7IGNvbG9yOiB3aGl0ZTsgYm9yZGVyOiAxcHggc29saWQgcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjMpOyBib3JkZXItcmFkaXVz",
-        "OiA0cHg7Ij4KICAgICAgICAgICAgICAgIDwvZGl2PgogICAgICAgICAgICAgICAgPGRpdiBzdHlsZT0iY29sb3I6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC41KTsgZm9udC1zaXplOiAxMXB4OyBtYXJnaW4tdG9wOiAxMnB4OyI+CiAgICAgICAgICAgICAgICAgICAg6IyD5Zu06ZyA5ZyoIDEtMzYwMCDnp5LkuYvpl7TvvIzpmo/mnLrmqKHlvI/lsIblnKjljLrpl7TlhoXkuLrmr4/kuKrop4bpopHnlJ/miJDkuIDkuKrnrYnlvoXml7bpl7QKICAgICAgICAgICAgICAgIDwvZGl2PgogICAgICAgICAgICBgOwoKICAgICAgICAgICAgY29uc3QgZGlhbG9nID0gVUlGYWN0b3J5LmNyZWF0ZURpYWxvZygnc3BlZWQtbW9kZS10aW1lLWRpYWxvZycsICforr7nva7mnoHpgJ/mqKHlvI8nLCBjb250ZW50LCAoKSA9PiB7CiAgICAgICAgICAgICAgICBjb25zdCBtb2RlSW5wdXQgPSBkaWFsb2cucXVlcnlTZWxlY3RvcignaW5wdXRbbmFtZT0ic3BlZWQtbW9kZS10eXBlIl06Y2hlY2tlZCcpOwogICAgICAgICAgICAgICAgY29uc3QgbW9kZSA9IG1vZGVJbnB1dCA/IG1vZGVJbnB1dC52YWx1ZSA6ICdmaXhlZCc7CgogICAgICAgICAgICAgICAgaWYgKG1vZGUgPT09ICdmaXhlZCcpIHsKICAgICAgICAgICAgICAgICAgICBjb25zdCBpbnB1dCA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCcuc3BlZWQtaW5wdXQnKTsKICAgICAgICAgICAgICAgICAgICBjb25zdCB2YWx1ZSA9IHBhcnNlSW50KGlucHV0LnZhbHVlLCAxMCk7CiAgICAgICAgICAgICAgICAgICAgaWYgKCFOdW1iZXIuaXNGaW5pdGUodmFsdWUpIHx8IHZhbHVlIDwgMSB8fCB2YWx1ZSA+IDM2MDApIHsKICAgICAgICAgICAgICAgICAgICAgICAgYWxlcnQoJ+ivt+i+k+WFpSAxIC0gMzYwMCDnp5LkuYvpl7TnmoTmlbTmlbAnKTsKICAgICAgICAgICAgICAgICAgICAgICAgcmV0dXJuIGZhbHNlOwogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICB0aGlzLmNvbmZpZy5zYXZlU3BlZWRNb2RlVHlwZSgnZml4ZWQnKTsKICAgICAgICAgICAgICAgICAgICB0aGlzLmNvbmZpZy5zYXZlU3BlZWRTZWNvbmRzKHZhbHVlKTsKICAgICAgICAgICAgICAgICAgICB0aGlzLm5vdGlmaWNhdGlvbk1hbmFnZXIuc2hvd01lc3NhZ2UoYOKame+4jyDmnoHpgJ/mqKHlvI86IOaSreaUvuaXtumXtOW3suiuvuS4uiAke3ZhbHVlfSDnp5JgKTsKICAgICAgICAgICAgICAgIH0gZWxzZSB7CiAgICAgICAgICAgICAgICAgICAgY29uc3QgbWluSW5wdXQgPSBkaWFsb2cucXVlcnlTZWxlY3RvcignLnNwZWVkLW1pbi1pbnB1dCcpOwogICAgICAgICAgICAgICAgICAgIGNvbnN0IG1heElucHV0ID0gZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJy5zcGVlZC1tYXgtaW5wdXQnKTsKICAgICAgICAgICAgICAgICAgICBjb25zdCBtaW5WYWx1ZSA9IHBhcnNlSW50KG1pbklucHV0LnZhbHVlLCAxMCk7CiAgICAgICAgICAgICAgICAgICAgY29uc3QgbWF4VmFsdWUgPSBwYXJzZUludChtYXhJbnB1dC52YWx1ZSwgMTApOwogICAgICAgICAgICAgICAgICAgIGlmICghTnVtYmVyLmlzRmluaXRlKG1pblZhbHVlKSB8fCBtaW5WYWx1ZSA8IDEgfHwgbWluVmFsdWUgPiAzNjAwIHx8CiAgICAgICAgICAgICAgICAgICAgICAgICFOdW1iZXIuaXNGaW5pdGUobWF4VmFsdWUpIHx8IG1heFZhbHVlIDwgMSB8fCBtYXhWYWx1ZSA+IDM2MDApIHsKICAgICAgICAgICAgICAgICAgICAgICAgYWxlcnQoJ+maj+acuuiMg+WbtOmcgOWcqCAxIC0gMzYwMCDnp5LkuYvpl7QnKTsKICAgICAgICAgICAgICAgICAgICAgICAgcmV0dXJuIGZhbHNlOwogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICBpZiAobWluVmFsdWUgPiBtYXhWYWx1ZSkgewogICAgICAgICAgICAgICAgICAgICAgICBhbGVydCgn5pyA5bCP5pe26Ze05LiN6IO95aSn5LqO5pyA5aSn5pe26Ze0Jyk7CiAgICAgICAgICAgICAgICAgICAgICAgIHJldHVybiBmYWxzZTsKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgdGhpcy5jb25maWcuc2F2ZVNwZWVkTW9kZVR5cGUoJ3JhbmRvbScpOwogICAgICAgICAgICAgICAgICAgIHRoaXMuY29uZmlnLnNhdmVTcGVlZE1vZGVSYW5nZShtaW5WYWx1ZSwgbWF4VmFsdWUpOwogICAgICAgICAgICAgICAgICAgIHRoaXMubm90aWZpY2F0aW9uTWFuYWdlci5zaG93TWVzc2FnZShg4pqZ77iPIOaegemAn+aooeW8jzog5bey6K6+5Li66ZqP5py6ICR7bWluVmFsdWV9LSR7bWF4VmFsdWV9IOenkmApOwogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIHRoaXMudXBkYXRlU3BlZWRNb2RlVGV4dCgpOwogICAgICAgICAgICAgICAgZG9jdW1lbnQuZGlzcGF0Y2hFdmVudChuZXcgQ3VzdG9tRXZlbnQoJ2RvdXlpbi1zcGVlZC1tb2RlLXVwZGF0ZWQnKSk7CiAgICAgICAgICAgICAgICByZXR1cm4gdHJ1ZTsKICAgICAgICAgICAgfSk7CgogICAgICAgICAgICBpZiAoIWRpYWxvZykgcmV0dXJuOwoKICAgICAgICAgICAgY29uc3QgdG9nZ2xlVmlzaWJpbGl0eSA9ICgpID0+IHsKICAgICAgICAgICAgICAgIGNvbnN0IG1vZGVJbnB1dCA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCdpbnB1dFtuYW1lPSJzcGVlZC1tb2RlLXR5cGUiXTpjaGVja2VkJyk7CiAgICAgICAgICAgICAgICBjb25zdCBpc1JhbmRvbU1vZGUgPSBtb2RlSW5wdXQgJiYgbW9kZUlucHV0LnZhbHVlID09PSAncmFuZG9tJzsKICAgICAgICAgICAgICAgIGRpYWxvZy5xdWVyeVNlbGVjdG9yKCcuc3BlZWQtZml4ZWQtd3JhcHBlcicpLnN0eWxlLmRpc3BsYXkgPSBpc1JhbmRvbU1vZGUgPyAnbm9uZScgOiAnYmxvY2snOwogICAgICAgICAgICAgICAgZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJy5zcGVlZC1yYW5kb20td3JhcHBlcicpLnN0eWxlLmRpc3BsYXkgPSBpc1JhbmRvbU1vZGUgPyAnZmxleCcgOiAnbm9uZSc7CiAgICAgICAgICAgIH07CgogICAgICAgICAgICBkaWFsb2cucXVlcnlTZWxlY3RvckFsbCgnaW5wdXRbbmFtZT0ic3BlZWQtbW9kZS10eXBlIl0nKS5mb3JFYWNoKHJhZGlvID0+IHsKICAgICAgICAgICAgICAgIHJhZGlvLmFkZEV2ZW50TGlzdGVuZXIoJ2NoYW5nZScsIHRvZ2dsZVZpc2liaWxpdHkpOwogICAgICAgICAgICB9KTsKICAgICAgICB9CgogICAgICAgIHNob3dBaVByZWZlcmVuY2VEaWFsb2coKSB7CiAgICAgICAgICAgIGNvbnN0IGN1cnJlbnRDb250ZW50ID0gdGhpcy5jb25maWcuZ2V0KCdhaVByZWZlcmVuY2UnKS5jb250ZW50OwogICAgICAgICAgICBjb25zdCBjdXJyZW50TW9kZWwgPSB0aGlzLmNvbmZpZy5nZXQoJ2FpUHJlZmVyZW5jZScpLm1vZGVsOwogICAgICAgICAgICBjb25zdCBhdXRvTGlrZUVuYWJsZWQgPSB0aGlzLmNvbmZpZy5nZXQoJ2FpUHJlZmVyZW5jZScpLmF1dG9MaWtlOwoKICAgICAgICAgICAgY29uc3QgY29udGVudCA9IGAKICAgICAgICAgICAgICAgIDxkaXYgc3R5bGU9Im1hcmdpbi1ib3R0b206IDE1cHg7Ij4KICAgICAgICAgICAgICAgICAgICA8bGFiZWwgc3R5bGU9ImNvbG9yOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuNyk7IGZvbnQtc2l6ZTogMTJweDsgZGlzcGxheTogYmxvY2s7IG1hcmdpbi1ib3R0b206IDVweDsiPgogICAgICAgICAgICAgICAgICAgICAgICDmg7PnnIvku4DkuYjlhoXlrrnvvJ/vvIjkvovlpoLvvJrpnLLohLjnmoTnvo7lpbPjgIHnjKvlkqrvvIkKICAgICAgICAgICAgICAgICAgICA8L2xhYmVsPgogICAgICAgICAgICAgICAgICAgIDxpbnB1dCB0eXBlPSJ0ZXh0IiBjbGFzcz0iYWktY29udGVudC1pbnB1dCIgdmFsdWU9IiR7Y3VycmVudENvbnRlbnR9IiBwbGFjZWhvbGRlcj0i6L6T5YWl5L2g5oOz55yL55qE5YaF5a65IgogICAgICAgICAgICAgICAgICAgICAgICBzdHlsZT0id2lkdGg6IDEwMCU7IHBhZGRpbmc6IDhweDsgYmFja2dyb3VuZDogcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjEpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgY29sb3I6IHdoaXRlOyBib3JkZXI6IDFweCBzb2xpZCByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuMyk7IGJvcmRlci1yYWRpdXM6IDRweDsiPgogICAgICAgICAgICAgICAgPC9kaXY+CgogICAgICAgICAgICAgICAgPGRpdiBzdHlsZT0ibWFyZ2luLWJvdHRvbTogMTVweDsiPgogICAgICAgICAgICAgICAgICAgIDxsYWJlbCBzdHlsZT0iY29sb3I6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC43KTsgZm9udC1zaXplOiAxMnB4OyBkaXNwbGF5OiBibG9jazsgbWFyZ2luLWJvdHRvbTogNXB4OyI+CiAgICAgICAgICAgICAgICAgICAgICAgIEFJ5qih5Z6L6YCJ5oupCiAgICAgICAgICAgICAgICAgICAgPC9sYWJlbD4KICAgICAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJwb3NpdGlvbjogcmVsYXRpdmU7Ij4KICAgICAgICAgICAgICAgICAgICAgICAgPHNlbGVjdCBjbGFzcz0iYWktbW9kZWwtc2VsZWN0IgogICAgICAgICAgICAgICAgICAgICAgICAgICAgc3R5bGU9IndpZHRoOiAxMDAlOyBwYWRkaW5nOiA4cHg7IGJhY2tncm91bmQ6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC4xKTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBjb2xvcjogd2hpdGU7IGJvcmRlcjogMXB4IHNvbGlkIHJnYmEoMjU1LCAyNTUsIDI1NSwgMC4zKTsgYm9yZGVyLXJhZGl1czogNHB4OwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGFwcGVhcmFuY2U6IG5vbmU7IGN1cnNvcjogcG9pbnRlcjsiPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgPG9wdGlvbiB2YWx1ZT0icXdlbjMtdmw6OGIiIHN0eWxlPSJiYWNrZ3JvdW5kOiByZ2JhKDAsIDAsIDAsIDAuOSk7IGNvbG9yOiB3aGl0ZTsiICR7Y3VycmVudE1vZGVsID09PSAncXdlbjMtdmw6OGInID8gJ3NlbGVjdGVkJyA6ICcnfT5xd2VuMy12bDo4YiAo5o6o6I2QKTwvb3B0aW9uPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgPG9wdGlvbiB2YWx1ZT0icXdlbjIuNXZsOjdiIiBzdHlsZT0iYmFja2dyb3VuZDogcmdiYSgwLCAwLCAwLCAwLjkpOyBjb2xvcjogd2hpdGU7IiAke2N1cnJlbnRNb2RlbCA9PT0gJ3F3ZW4yLjV2bDo3YicgPyAnc2VsZWN0ZWQnIDogJyd9PnF3ZW4yLjV2bDo3Yjwvb3B0aW9uPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgPG9wdGlvbiB2YWx1ZT0iY3VzdG9tIiBzdHlsZT0iYmFja2dyb3VuZDogcmdiYSgwLCAwLCAwLCAwLjkpOyBjb2xvcjogd2hpdGU7IiAke2N1cnJlbnRNb2RlbCAhPT0gJ3F3ZW4zLXZsOjhiJyAmJiBjdXJyZW50TW9kZWwgIT09ICdxd2VuMi41dmw6N2InID8gJ3NlbGVjdGVkJyA6ICcnfT7oh6rlrprkuYnmqKHlnos8L29wdGlvbj4KICAgICAgICAgICAgICAgICAgICAgICAgPC9zZWxlY3Q+CiAgICAgICAgICAgICAgICAgICAgICAgIDxzcGFuIHN0eWxlPSJwb3NpdGlvbjogYWJzb2x1dGU7IHJpZ2h0OiAxMHB4OyB0b3A6IDUwJTsgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKC01MCUpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHBvaW50ZXItZXZlbnRzOiBub25lOyBjb2xvcjogcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjUpOyI+4pa8PC9zcGFuPgogICAgICAgICAgICAgICAgICAgIDwvZGl2PgogICAgICAgICAgICAgICAgICAgIDxpbnB1dCB0eXBlPSJ0ZXh0IiBjbGFzcz0iYWktbW9kZWwtaW5wdXQiIHZhbHVlPSIke2N1cnJlbnRNb2RlbCAhPT0gJ3F3ZW4zLXZsOjhiJyAmJiBjdXJyZW50TW9kZWwgIT09ICdxd2VuMi41dmw6N2InID8gY3VycmVudE1vZGVsIDogJyd9IgogICAgICAgICAgICAgICAgICAgICAgICBwbGFjZWhvbGRlcj0i6L6T5YWl6Ieq5a6a5LmJ5qih5Z6L5ZCN56ewIgogICAgICAgICAgICAgICAgICAgICAgICBzdHlsZT0id2lkdGg6IDEwMCU7IHBhZGRpbmc6IDhweDsgbWFyZ2luLXRvcDogMTBweDsgYmFja2dyb3VuZDogcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjEpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgY29sb3I6IHdoaXRlOyBib3JkZXI6IDFweCBzb2xpZCByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuMyk7IGJvcmRlci1yYWRpdXM6IDRweDsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGRpc3BsYXk6ICR7Y3VycmVudE1vZGVsICE9PSAncXdlbjMtdmw6OGInICYmIGN1cnJlbnRNb2RlbCAhPT0gJ3F3ZW4yLjV2bDo3YicgPyAnYmxvY2snIDogJ25vbmUnfTsiPgog",
-        "ICAgICAgICAgICAgICAgPC9kaXY+CgogICAgICAgICAgICAgICAgPGRpdiBzdHlsZT0ibWFyZ2luLWJvdHRvbTogMTVweDsgcGFkZGluZzogMTBweDsgYmFja2dyb3VuZDogcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjA1KTsgYm9yZGVyLXJhZGl1czogNnB4OyI+CiAgICAgICAgICAgICAgICAgICAgPGxhYmVsIHN0eWxlPSJkaXNwbGF5OiBmbGV4OyBhbGlnbi1pdGVtczogY2VudGVyOyBjdXJzb3I6IHBvaW50ZXI7IGNvbG9yOiB3aGl0ZTsgZm9udC1zaXplOiAxM3B4OyI+CiAgICAgICAgICAgICAgICAgICAgICAgIDxpbnB1dCB0eXBlPSJjaGVja2JveCIgY2xhc3M9ImF1dG8tbGlrZS1jaGVja2JveCIgJHthdXRvTGlrZUVuYWJsZWQgPyAnY2hlY2tlZCcgOiAnJ30KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHN0eWxlPSJtYXJnaW4tcmlnaHQ6IDhweDsgdHJhbnNmb3JtOiBzY2FsZSgxLjIpOyI+CiAgICAgICAgICAgICAgICAgICAgICAgIEFJ5Yik5a6a5Li65Zac5qyi55qE5YaF5a655bCG6Ieq5Yqo54K56LWe77yIWumUru+8iQogICAgICAgICAgICAgICAgICAgIDwvbGFiZWw+CiAgICAgICAgICAgICAgICAgICAgPGRpdiBzdHlsZT0iY29sb3I6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC41KTsgZm9udC1zaXplOiAxMXB4OyBtYXJnaW4tdG9wOiA1cHg7IG1hcmdpbi1sZWZ0OiAyNHB4OyI+CiAgICAgICAgICAgICAgICAgICAgICAgIOW4ruWKqeaKlumfs+eul+azleS6huino+S9oOWWnOasouatpOexu+WGheWuuQogICAgICAgICAgICAgICAgICAgIDwvZGl2PgogICAgICAgICAgICAgICAgPC9kaXY+CgogICAgICAgICAgICAgICAgPGRpdiBzdHlsZT0iY29sb3I6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC41KTsgZm9udC1zaXplOiAxMXB4OyBtYXJnaW4tYm90dG9tOiAxMHB4OyI+CiAgICAgICAgICAgICAgICAgICAg5o+Q56S677ya6ZyA6KaB5a6J6KOFIDxhIGhyZWY9Imh0dHBzOi8vb2xsYW1hLmNvbS8iIHRhcmdldD0iX2JsYW5rIiBzdHlsZT0iY29sb3I6ICNmZTJjNTU7Ij5PbGxhbWE8L2E+IOW5tuS4i+i9veinhuinieaooeWeiwogICAgICAgICAgICAgICAgPC9kaXY+CiAgICAgICAgICAgIGA7CgogICAgICAgICAgICBjb25zdCBkaWFsb2cgPSBVSUZhY3RvcnkuY3JlYXRlRGlhbG9nKCdhaS1wcmVmZXJlbmNlLWRpYWxvZycsICforr7nva5BSeWWnOWlvScsIGNvbnRlbnQsICgpID0+IHsKICAgICAgICAgICAgICAgIGNvbnN0IGNvbnRlbnRJbnB1dCA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCcuYWktY29udGVudC1pbnB1dCcpOwogICAgICAgICAgICAgICAgY29uc3QgbW9kZWxTZWxlY3QgPSBkaWFsb2cucXVlcnlTZWxlY3RvcignLmFpLW1vZGVsLXNlbGVjdCcpOwogICAgICAgICAgICAgICAgY29uc3QgbW9kZWxJbnB1dCA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCcuYWktbW9kZWwtaW5wdXQnKTsKICAgICAgICAgICAgICAgIGNvbnN0IGF1dG9MaWtlQ2hlY2tib3ggPSBkaWFsb2cucXVlcnlTZWxlY3RvcignLmF1dG8tbGlrZS1jaGVja2JveCcpOwoKICAgICAgICAgICAgICAgIGNvbnN0IGNvbnRlbnQgPSBjb250ZW50SW5wdXQudmFsdWUudHJpbSgpOwogICAgICAgICAgICAgICAgbGV0IG1vZGVsID0gbW9kZWxTZWxlY3QudmFsdWUgPT09ICdjdXN0b20nCiAgICAgICAgICAgICAgICAgICAgPyBtb2RlbElucHV0LnZhbHVlLnRyaW0oKQogICAgICAgICAgICAgICAgICAgIDogbW9kZWxTZWxlY3QudmFsdWU7CgogICAgICAgICAgICAgICAgaWYgKCFjb250ZW50KSB7CiAgICAgICAgICAgICAgICAgICAgYWxlcnQoJ+ivt+i+k+WFpeaDs+eci+eahOWGheWuuScpOwogICAgICAgICAgICAgICAgICAgIHJldHVybiBmYWxzZTsKICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICBpZiAoIW1vZGVsKSB7CiAgICAgICAgICAgICAgICAgICAgYWxlcnQoJ+ivt+mAieaLqeaIlui+k+WFpeaooeWei+WQjeensCcpOwogICAgICAgICAgICAgICAgICAgIHJldHVybiBmYWxzZTsKICAgICAgICAgICAgICAgIH0KCiAgICAgICAgICAgICAgICB0aGlzLmNvbmZpZy5zYXZlQWlDb250ZW50KGNvbnRlbnQpOwogICAgICAgICAgICAgICAgdGhpcy5jb25maWcuc2F2ZUFpTW9kZWwobW9kZWwpOwogICAgICAgICAgICAgICAgdGhpcy5jb25maWcuc2F2ZUF1dG9MaWtlU2V0dGluZyhhdXRvTGlrZUNoZWNrYm94LmNoZWNrZWQpOwoKICAgICAgICAgICAgICAgIHRoaXMubm90aWZpY2F0aW9uTWFuYWdlci5zaG93TWVzc2FnZSgn8J+kliBBSeWWnOWlvTog6K6+572u5bey5L+d5a2YJyk7CiAgICAgICAgICAgICAgICByZXR1cm4gdHJ1ZTsKICAgICAgICAgICAgfSk7CgogICAgICAgICAgICAvLyDlpITnkIbmqKHlnovpgInmi6nliIfmjaIKICAgICAgICAgICAgY29uc3QgbW9kZWxTZWxlY3QgPSBkaWFsb2cucXVlcnlTZWxlY3RvcignLmFpLW1vZGVsLXNlbGVjdCcpOwogICAgICAgICAgICBjb25zdCBtb2RlbElucHV0ID0gZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJy5haS1tb2RlbC1pbnB1dCcpOwoKICAgICAgICAgICAgbW9kZWxTZWxlY3QuYWRkRXZlbnRMaXN0ZW5lcignY2hhbmdlJywgKGUpID0+IHsKICAgICAgICAgICAgICAgIGlmIChlLnRhcmdldC52YWx1ZSA9PT0gJ2N1c3RvbScpIHsKICAgICAgICAgICAgICAgICAgICBtb2RlbElucHV0LnN0eWxlLmRpc3BsYXkgPSAnYmxvY2snOwogICAgICAgICAgICAgICAgfSBlbHNlIHsKICAgICAgICAgICAgICAgICAgICBtb2RlbElucHV0LnN0eWxlLmRpc3BsYXkgPSAnbm9uZSc7CiAgICAgICAgICAgICAgICAgICAgbW9kZWxJbnB1dC52YWx1ZSA9ICcnOwogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9KTsKCiAgICAgICAgICAgIC8vIOmYsuatouWkjemAieahhueCueWHu+aXtuWFs+mXreW8ueeqlwogICAgICAgICAgICBkaWFsb2cucXVlcnlTZWxlY3RvcignLmF1dG8tbGlrZS1jaGVja2JveCcpLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKGUpID0+IHsKICAgICAgICAgICAgICAgIGUuc3RvcFByb3BhZ2F0aW9uKCk7CiAgICAgICAgICAgIH0pOwogICAgICAgIH0KCiAgICAgICAgc2hvd0tleXdvcmREaWFsb2coKSB7CiAgICAgICAgICAgIGNvbnN0IGtleXdvcmRzID0gdGhpcy5jb25maWcuZ2V0KCdibG9ja0tleXdvcmRzJykua2V5d29yZHM7CiAgICAgICAgICAgIGxldCB0ZW1wS2V5d29yZHMgPSBbLi4ua2V5d29yZHNdOwoKICAgICAgICAgICAgY29uc3QgdXBkYXRlTGlzdCA9ICgpID0+IHsKICAgICAgICAgICAgICAgIGNvbnN0IGNvbnRhaW5lciA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3IoJy5rZXl3b3JkLWxpc3QnKTsKICAgICAgICAgICAgICAgIGlmICghY29udGFpbmVyKSByZXR1cm47CgogICAgICAgICAgICAgICAgY29udGFpbmVyLmlubmVySFRNTCA9IHRlbXBLZXl3b3Jkcy5sZW5ndGggPT09IDAKICAgICAgICAgICAgICAgICAgICA/ICc8ZGl2IHN0eWxlPSJjb2xvcjogcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjUpOyB0ZXh0LWFsaWduOiBjZW50ZXI7Ij7mmoLml6DlhbPplK7lrZc8L2Rpdj4nCiAgICAgICAgICAgICAgICAgICAgOiB0ZW1wS2V5d29yZHMubWFwKChrZXl3b3JkLCBpbmRleCkgPT4gYAogICAgICAgICAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJkaXNwbGF5OiBmbGV4OyBhbGlnbi1pdGVtczogY2VudGVyOyBtYXJnaW4tYm90dG9tOiA4cHg7Ij4KICAgICAgICAgICAgICAgICAgICAgICAgICAgIDxzcGFuIHN0eWxlPSJmbGV4OiAxOyBjb2xvcjogd2hpdGU7IHBhZGRpbmc6IDVweCAxMHB4OyBiYWNrZ3JvdW5kOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuMSk7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgYm9yZGVyLXJhZGl1czogNHB4OyBtYXJnaW4tcmlnaHQ6IDEwcHg7Ij4ke2tleXdvcmR9PC9zcGFuPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgPGJ1dHRvbiBkYXRhLWluZGV4PSIke2luZGV4fSIgY2xhc3M9ImRlbGV0ZS1rZXl3b3JkIiBzdHlsZT0icGFkZGluZzogNXB4IDEwcHg7IGJhY2tncm91bmQ6ICNmZjQ3NTc7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNvbG9yOiB3aGl0ZTsgYm9yZGVyOiBub25lOyBib3JkZXItcmFkaXVzOiA0cHg7IGN1cnNvcjogcG9pbnRlcjsiPuWIoOmZpDwvYnV0dG9uPgogICAgICAgICAgICAgICAgICAgICAgICA8L2Rpdj4KICAgICAgICAgICAgICAgICAgICBgKS5qb2luKCcnKTsKCiAgICAgICAgICAgICAgICAvLyDkvb/nlKjkuovku7blp5TmiZjmnaXlpITnkIbliKDpmaTmjInpkq7ngrnlh7sKICAgICAgICAgICAgICAgIGNvbnRhaW5lci5vbmNsaWNrID0gKGUpID0+IHsKICAgICAgICAgICAgICAgICAgICBpZiAoZS50YXJnZXQuY2xhc3NMaXN0LmNvbnRhaW5zKCdkZWxldGUta2V5d29yZCcpKSB7CiAgICAgICAgICAgICAgICAgICAgICAgIGUuc3RvcFByb3BhZ2F0aW9uKCk7IC8vIOmYu+atouS6i+S7tuWGkuazoe+8jOmYsuatouinpuWPkeW8ueeql+WFs+mXrQogICAgICAgICAgICAgICAgICAgICAgICBjb25zdCBpbmRleCA9IHBhcnNlSW50KGUudGFyZ2V0LmRhdGFzZXQuaW5kZXgpOwogICAgICAgICAgICAgICAgICAgICAgICB0ZW1wS2V5d29yZHMuc3BsaWNlKGluZGV4LCAxKTsKICAgICAgICAgICAgICAgICAgICAgICAgdXBkYXRlTGlzdCgpOwogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH07CiAgICAgICAgICAgIH07CgogICAgICAgICAgICBjb25zdCBwcmVzc1JFbmFibGVkID0gdGhpcy5jb25maWcuZ2V0KCdibG9ja0tleXdvcmRzJykucHJlc3NSOwogICAgICAgICAgICBjb25zdCBibG9ja05hbWVFbmFibGVkID0gdGhpcy5jb25maWcuZ2V0KCdibG9ja0tleXdvcmRzJykuYmxvY2tOYW1lOwogICAgICAgICAgICBjb25zdCBibG9ja0Rlc2NFbmFibGVkID0gdGhpcy5jb25maWcuZ2V0KCdibG9ja0tleXdvcmRzJykuYmxvY2tEZXNjOwogICAgICAgICAgICBjb25zdCBibG9ja1RhZ3NFbmFibGVkID0gdGhpcy5jb25maWcuZ2V0KCdibG9ja0tleXdvcmRzJykuYmxvY2tUYWdzOwoKICAgICAgICAgICAgY29uc3QgY29udGVudCA9IGAKICAgICAgICAgICAgICAgIDxkaXYgc3R5bGU9ImNvbG9yOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuNyk7IG1hcmdpbi1ib3R0b206IDE1cHg7IGZvbnQtc2l6ZTogMTJweDsiPgogICAgICAgICAgICAgICAgICAgIOWMheWQq+i/meS6m+WFs+mUruWtl+eahOWGheWuueWwhuiiq+iHquWKqOi3s+i/hwogICAgICAgICAgICAgICAgPC9kaXY+CgogICAgICAgICAgICAgICAgPGRpdiBzdHlsZT0ibWFyZ2luLWJvdHRvbTogMTVweDsgcGFkZGluZzogMTBweDsgYmFja2dyb3VuZDogcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjA1KTsgYm9yZGVyLXJhZGl1czogNnB4OyI+CiAgICAgICAgICAgICAgICAgICAgPGxhYmVsIHN0eWxlPSJkaXNwbGF5OiBmbGV4OyBhbGlnbi1pdGVtczogY2VudGVyOyBjdXJzb3I6IHBvaW50ZXI7IGNvbG9yOiB3aGl0ZTsgZm9udC1zaXplOiAxM3B4OyI+CiAgICAgICAgICAgICAgICAgICAgICAgIDxpbnB1dCB0eXBlPSJjaGVja2JveCIgY2xhc3M9InByZXNzLXItY2hlY2tib3giICR7cHJlc3NSRW5hYmxlZCA/ICdjaGVja2VkJyA6ICcnfQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgc3R5bGU9Im1hcmdpbi1yaWdodDogOHB4OyB0cmFuc2Zvcm06IHNjYWxlKDEuMik7Ij4KICAgICAgICAgICAgICAgICAgICAgICAg6Lez6L+H5pe26Ieq5Yqo5oyJUumUru+8iOS4jeaEn+WFtOi2o++8iQogICAgICAgICAgICAgICAgICAgIDwvbGFiZWw+CiAgICAgICAgICAgICAgICAgICAgPGRpdiBzdHlsZT0iY29sb3I6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC41KTsgZm9udC1zaXplOiAxMXB4OyBtYXJnaW4tdG9wOiA1cHg7IG1hcmdpbi1sZWZ0OiAyNHB4OyI+CiAgICAgICAgICAgICAgICAgICAgICAgIOWLvumAie+8muWRiuivieaKlumfs+S9oOS4jeWWnOasou+8jOS8mOWMluaOqOiNkOeul+azlTxicj4KICAgICAgICAgICAgICAgICAgICAgICAg5LiN5Yu+77ya5LuF6Lez5Yiw5LiL5LiA5Liq6KeG6aKRCiAgICAgICAgICAgICAgICAgICAgPC9kaXY+CiAgICAgICAgICAgICAgICA8L2Rpdj4KCiAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJtYXJnaW4tYm90dG9tOiAxNXB4OyBwYWRkaW5nOiAxMHB4",
-        "OyBiYWNrZ3JvdW5kOiByZ2JhKDI1NSwgMjU1LCAyNTUsIDAuMDUpOyBib3JkZXItcmFkaXVzOiA2cHg7Ij4KICAgICAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJjb2xvcjogcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjcpOyBmb250LXNpemU6IDEycHg7IG1hcmdpbi1ib3R0b206IDhweDsiPuajgOa1i+iMg+WbtO+8mjwvZGl2PgogICAgICAgICAgICAgICAgICAgIDxsYWJlbCBzdHlsZT0iZGlzcGxheTogZmxleDsgYWxpZ24taXRlbXM6IGNlbnRlcjsgY3Vyc29yOiBwb2ludGVyOyBjb2xvcjogd2hpdGU7IGZvbnQtc2l6ZTogMTNweDsgbWFyZ2luLWJvdHRvbTogNnB4OyI+CiAgICAgICAgICAgICAgICAgICAgICAgIDxpbnB1dCB0eXBlPSJjaGVja2JveCIgY2xhc3M9ImJsb2NrLW5hbWUtY2hlY2tib3giICR7YmxvY2tOYW1lRW5hYmxlZCA/ICdjaGVja2VkJyA6ICcnfQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgc3R5bGU9Im1hcmdpbi1yaWdodDogOHB4OyB0cmFuc2Zvcm06IHNjYWxlKDEuMik7Ij4KICAgICAgICAgICAgICAgICAgICAgICAg5bGP6JS95ZCN56ew77yI6LSm5Y+35pi156ew77yJCiAgICAgICAgICAgICAgICAgICAgPC9sYWJlbD4KICAgICAgICAgICAgICAgICAgICA8bGFiZWwgc3R5bGU9ImRpc3BsYXk6IGZsZXg7IGFsaWduLWl0ZW1zOiBjZW50ZXI7IGN1cnNvcjogcG9pbnRlcjsgY29sb3I6IHdoaXRlOyBmb250LXNpemU6IDEzcHg7IG1hcmdpbi1ib3R0b206IDZweDsiPgogICAgICAgICAgICAgICAgICAgICAgICA8aW5wdXQgdHlwZT0iY2hlY2tib3giIGNsYXNzPSJibG9jay1kZXNjLWNoZWNrYm94IiAke2Jsb2NrRGVzY0VuYWJsZWQgPyAnY2hlY2tlZCcgOiAnJ30KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHN0eWxlPSJtYXJnaW4tcmlnaHQ6IDhweDsgdHJhbnNmb3JtOiBzY2FsZSgxLjIpOyI+CiAgICAgICAgICAgICAgICAgICAgICAgIOWxj+iUveeugOS7i++8iOinhumikeaPj+i/sOaWh+ahiO+8iQogICAgICAgICAgICAgICAgICAgIDwvbGFiZWw+CiAgICAgICAgICAgICAgICAgICAgPGxhYmVsIHN0eWxlPSJkaXNwbGF5OiBmbGV4OyBhbGlnbi1pdGVtczogY2VudGVyOyBjdXJzb3I6IHBvaW50ZXI7IGNvbG9yOiB3aGl0ZTsgZm9udC1zaXplOiAxM3B4OyI+CiAgICAgICAgICAgICAgICAgICAgICAgIDxpbnB1dCB0eXBlPSJjaGVja2JveCIgY2xhc3M9ImJsb2NrLXRhZ3MtY2hlY2tib3giICR7YmxvY2tUYWdzRW5hYmxlZCA/ICdjaGVja2VkJyA6ICcnfQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgc3R5bGU9Im1hcmdpbi1yaWdodDogOHB4OyB0cmFuc2Zvcm06IHNjYWxlKDEuMik7Ij4KICAgICAgICAgICAgICAgICAgICAgICAg5bGP6JS95qCH562+77yII+ivnemimOagh+etvu+8iQogICAgICAgICAgICAgICAgICAgIDwvbGFiZWw+CiAgICAgICAgICAgICAgICA8L2Rpdj4KCiAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJkaXNwbGF5OiBmbGV4OyBnYXA6IDEwcHg7IG1hcmdpbi1ib3R0b206IDEwcHg7Ij4KICAgICAgICAgICAgICAgICAgICA8aW5wdXQgdHlwZT0idGV4dCIgY2xhc3M9ImtleXdvcmQtaW5wdXQiIHBsYWNlaG9sZGVyPSLovpPlhaXmlrDlhbPplK7lrZciCiAgICAgICAgICAgICAgICAgICAgICAgIHN0eWxlPSJmbGV4OiAxOyBwYWRkaW5nOiA4cHg7IGJhY2tncm91bmQ6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC4xKTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNvbG9yOiB3aGl0ZTsgYm9yZGVyOiAxcHggc29saWQgcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjMpOyBib3JkZXItcmFkaXVzOiA0cHg7Ij4KICAgICAgICAgICAgICAgICAgICA8YnV0dG9uIGNsYXNzPSJhZGQta2V5d29yZCIgc3R5bGU9InBhZGRpbmc6IDhweCAxNXB4OyBiYWNrZ3JvdW5kOiAjMDBkNjM5OwogICAgICAgICAgICAgICAgICAgICAgICAgICAgY29sb3I6IHdoaXRlOyBib3JkZXI6IG5vbmU7IGJvcmRlci1yYWRpdXM6IDRweDsgY3Vyc29yOiBwb2ludGVyOyI+5re75YqgPC9idXR0b24+CiAgICAgICAgICAgICAgICA8L2Rpdj4KCiAgICAgICAgICAgICAgICA8ZGl2IHN0eWxlPSJkaXNwbGF5OiBmbGV4OyBnYXA6IDEwcHg7IG1hcmdpbi1ib3R0b206IDEwcHg7Ij4KICAgICAgICAgICAgICAgICAgICA8YnV0dG9uIGNsYXNzPSJpbXBvcnQta2V5d29yZHMiIHN0eWxlPSJmbGV4OiAxOyBwYWRkaW5nOiA4cHggMTJweDsgYmFja2dyb3VuZDogcmdiYSg1MiwgMTUyLCAyMTksIDAuOCk7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICBjb2xvcjogd2hpdGU7IGJvcmRlcjogbm9uZTsgYm9yZGVyLXJhZGl1czogNHB4OyBjdXJzb3I6IHBvaW50ZXI7IGZvbnQtc2l6ZTogMTJweDsiPgogICAgICAgICAgICAgICAgICAgICAgICDwn5OBIOWvvOWFpeWFs+mUruWtlwogICAgICAgICAgICAgICAgICAgIDwvYnV0dG9uPgogICAgICAgICAgICAgICAgICAgIDxidXR0b24gY2xhc3M9ImV4cG9ydC1rZXl3b3JkcyIgc3R5bGU9ImZsZXg6IDE7IHBhZGRpbmc6IDhweCAxMnB4OyBiYWNrZ3JvdW5kOiByZ2JhKDE1NSwgODksIDE4MiwgMC44KTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNvbG9yOiB3aGl0ZTsgYm9yZGVyOiBub25lOyBib3JkZXItcmFkaXVzOiA0cHg7IGN1cnNvcjogcG9pbnRlcjsgZm9udC1zaXplOiAxMnB4OyI+CiAgICAgICAgICAgICAgICAgICAgICAgIPCfkr4g5a+85Ye65YWz6ZSu5a2XCiAgICAgICAgICAgICAgICAgICAgPC9idXR0b24+CiAgICAgICAgICAgICAgICA8L2Rpdj4KICAgICAgICAgICAgICAgIDxkaXYgY2xhc3M9ImtleXdvcmQtbGlzdCIgc3R5bGU9Im1hcmdpbi1ib3R0b206IDE1cHg7IG1heC1oZWlnaHQ6IDIwMHB4OyBvdmVyZmxvdy15OiBhdXRvOyI+PC9kaXY+CiAgICAgICAgICAgIGA7CgogICAgICAgICAgICBjb25zdCBkaWFsb2cgPSBVSUZhY3RvcnkuY3JlYXRlRGlhbG9nKCdrZXl3b3JkLXNldHRpbmctZGlhbG9nJywgJ+euoeeQhuWxj+iUveWFs+mUruWtlycsIGNvbnRlbnQsICgpID0+IHsKICAgICAgICAgICAgICAgIGNvbnN0IHByZXNzUkNoZWNrYm94ID0gZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJy5wcmVzcy1yLWNoZWNrYm94Jyk7CiAgICAgICAgICAgICAgICBjb25zdCBibG9ja05hbWVDaGVja2JveCA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCcuYmxvY2stbmFtZS1jaGVja2JveCcpOwogICAgICAgICAgICAgICAgY29uc3QgYmxvY2tEZXNjQ2hlY2tib3ggPSBkaWFsb2cucXVlcnlTZWxlY3RvcignLmJsb2NrLWRlc2MtY2hlY2tib3gnKTsKICAgICAgICAgICAgICAgIGNvbnN0IGJsb2NrVGFnc0NoZWNrYm94ID0gZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJy5ibG9jay10YWdzLWNoZWNrYm94Jyk7CgogICAgICAgICAgICAgICAgdGhpcy5jb25maWcuc2F2ZUtleXdvcmRzKHRlbXBLZXl3b3Jkcyk7CiAgICAgICAgICAgICAgICB0aGlzLmNvbmZpZy5zYXZlUHJlc3NSU2V0dGluZyhwcmVzc1JDaGVja2JveC5jaGVja2VkKTsKICAgICAgICAgICAgICAgIHRoaXMuY29uZmlnLnNhdmVCbG9ja05hbWVTZXR0aW5nKGJsb2NrTmFtZUNoZWNrYm94LmNoZWNrZWQpOwogICAgICAgICAgICAgICAgdGhpcy5jb25maWcuc2F2ZUJsb2NrRGVzY1NldHRpbmcoYmxvY2tEZXNjQ2hlY2tib3guY2hlY2tlZCk7CiAgICAgICAgICAgICAgICB0aGlzLmNvbmZpZy5zYXZlQmxvY2tUYWdzU2V0dGluZyhibG9ja1RhZ3NDaGVja2JveC5jaGVja2VkKTsKCiAgICAgICAgICAgICAgICB0aGlzLm5vdGlmaWNhdGlvbk1hbmFnZXIuc2hvd01lc3NhZ2UoJ/Cfmqsg5bGP6JS95YWz6ZSu5a2XOiDorr7nva7lt7Lmm7TmlrAnKTsKICAgICAgICAgICAgICAgIHJldHVybiB0cnVlOwogICAgICAgICAgICB9KTsKCiAgICAgICAgICAgIGNvbnN0IGFkZEtleXdvcmQgPSAoKSA9PiB7CiAgICAgICAgICAgICAgICBjb25zdCBpbnB1dCA9IGRpYWxvZy5xdWVyeVNlbGVjdG9yKCcua2V5d29yZC1pbnB1dCcpOwogICAgICAgICAgICAgICAgY29uc3Qga2V5d29yZCA9IGlucHV0LnZhbHVlLnRyaW0oKTsKICAgICAgICAgICAgICAgIGlmIChrZXl3b3JkICYmICF0ZW1wS2V5d29yZHMuaW5jbHVkZXMoa2V5d29yZCkpIHsKICAgICAgICAgICAgICAgICAgICB0ZW1wS2V5d29yZHMucHVzaChrZXl3b3JkKTsKICAgICAgICAgICAgICAgICAgICB1cGRhdGVMaXN0KCk7CiAgICAgICAgICAgICAgICAgICAgaW5wdXQudmFsdWUgPSAnJzsKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfTsKCiAgICAgICAgICAgIGRpYWxvZy5xdWVyeVNlbGVjdG9yKCcuYWRkLWtleXdvcmQnKS5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIChlKSA9PiB7CiAgICAgICAgICAgICAgICBlLnN0b3BQcm9wYWdhdGlvbigpOyAvLyDpmLvmraLkuovku7blhpLms6HvvIzpmLLmraLop6blj5HlvLnnqpflhbPpl60KICAgICAgICAgICAgICAgIGFkZEtleXdvcmQoKTsKICAgICAgICAgICAgfSk7CiAgICAgICAgICAgIGRpYWxvZy5xdWVyeVNlbGVjdG9yKCcua2V5d29yZC1pbnB1dCcpLmFkZEV2ZW50TGlzdGVuZXIoJ2tleXByZXNzJywgKGUpID0+IHsKICAgICAgICAgICAgICAgIGlmIChlLmtleSA9PT0gJ0VudGVyJykgewogICAgICAgICAgICAgICAgICAgIGUuc3RvcFByb3BhZ2F0aW9uKCk7IC8vIOmYu+atouS6i+S7tuWGkuazoQogICAgICAgICAgICAgICAgICAgIGFkZEtleXdvcmQoKTsKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfSk7CgogICAgICAgICAgICAvLyDpmLLmraLlnKjovpPlhaXmoYblhoXngrnlh7vml7blhbPpl63lvLnnqpcKICAgICAgICAgICAgZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJy5rZXl3b3JkLWlucHV0JykuYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoZSkgPT4gewogICAgICAgICAgICAgICAgZS5zdG9wUHJvcGFnYXRpb24oKTsKICAgICAgICAgICAgfSk7CgogICAgICAgICAgICAvLyDpmLLmraLlpI3pgInmoYbngrnlh7vml7blhbPpl63lvLnnqpcKICAgICAgICAgICAgZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJy5wcmVzcy1yLWNoZWNrYm94JykuYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoZSkgPT4gewogICAgICAgICAgICAgICAgZS5zdG9wUHJvcGFnYXRpb24oKTsKICAgICAgICAgICAgfSk7CiAgICAgICAgICAgIGRpYWxvZy5xdWVyeVNlbGVjdG9yKCcuYmxvY2stbmFtZS1jaGVja2JveCcpLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKGUpID0+IHsKICAgICAgICAgICAgICAgIGUuc3RvcFByb3BhZ2F0aW9uKCk7CiAgICAgICAgICAgIH0pOwogICAgICAgICAgICBkaWFsb2cucXVlcnlTZWxlY3RvcignLmJsb2NrLWRlc2MtY2hlY2tib3gnKS5hZGRFdmVudExpc3RlbmVyKCdjbGljaycsIChlKSA9PiB7CiAgICAgICAgICAgICAgICBlLnN0b3BQcm9wYWdhdGlvbigpOwogICAgICAgICAgICB9KTsKICAgICAgICAgICAgZGlhbG9nLnF1ZXJ5U2VsZWN0b3IoJy5ibG9jay10YWdzLWNoZWNrYm94JykuYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoZSkgPT4gewogICAgICAgICAgICAgICAgZS5zdG9wUHJvcGFnYXRpb24oKTsKICAgICAgICAgICAgfSk7CgogICAgICAgICAgICAvLyDlr7zlh7rlip/og70KICAgICAgICAgICAgY29uc3QgZXhwb3J0S2V5d29yZHMgPSAoKSA9PiB7CiAgICAgICAgICAgICAgICBjb25zdCBjb250ZW50ID0gdGVtcEtleXdvcmRzLmpvaW4oJ1xuJyk7CiAgICAgICAgICAgICAgICBjb25zdCBibG9iID0gbmV3IEJsb2IoW2NvbnRlbnRdLCB7IHR5cGU6ICd0ZXh0L3BsYWluO2NoYXJzZXQ9dXRmLTgnIH0pOwogICAgICAgICAgICAgICAgY29uc3QgdXJsID0gVVJMLmNyZWF0ZU9iamVjdFVSTChibG9iKTsKICAgICAgICAgICAgICAgIGNvbnN0IGEgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdhJyk7CiAgICAgICAgICAgICAgICBhLmhyZWYgPSB1cmw7CiAgICAgICAgICAgICAgICBhLmRvd25sb2FkID0gYOaKlumfs+Wxj+iUveWFs+mUruWtl18ke25ldyBEYXRlKCkudG9JU09TdHJpbmcoKS5zcGxpdCgnVCcpWzBdfS50eHRgOwogICAgICAgICAgICAgICAgZG9jdW1lbnQuYm9keS5hcHBlbmRDaGlsZChhKTsKICAgICAgICAgICAgICAgIGEuY2xpY2soKTsKICAgICAgICAgICAgICAgIGRvY3VtZW50LmJvZHkucmVtb3ZlQ2hpbGQoYSk7CiAgICAgICAg",
-        "ICAgICAgICBVUkwucmV2b2tlT2JqZWN0VVJMKHVybCk7CiAgICAgICAgICAgICAgICB0aGlzLm5vdGlmaWNhdGlvbk1hbmFnZXIuc2hvd01lc3NhZ2UoJ/Cfkr4g5bGP6JS96LSm5Y+3OiDlhbPplK7lrZflt7Llr7zlh7onKTsKICAgICAgICAgICAgfTsKCiAgICAgICAgICAgIGRpYWxvZy5xdWVyeVNlbGVjdG9yKCcuZXhwb3J0LWtleXdvcmRzJykuYWRkRXZlbnRMaXN0ZW5lcignY2xpY2snLCAoZSkgPT4gewogICAgICAgICAgICAgICAgZS5zdG9wUHJvcGFnYXRpb24oKTsKICAgICAgICAgICAgICAgIGV4cG9ydEtleXdvcmRzKCk7CiAgICAgICAgICAgIH0pOwoKICAgICAgICAgICAgLy8g5a+85YWl5Yqf6IO9CiAgICAgICAgICAgIGNvbnN0IGltcG9ydEtleXdvcmRzID0gKCkgPT4gewogICAgICAgICAgICAgICAgY29uc3QgaW5wdXQgPSBkb2N1bWVudC5jcmVhdGVFbGVtZW50KCdpbnB1dCcpOwogICAgICAgICAgICAgICAgaW5wdXQudHlwZSA9ICdmaWxlJzsKICAgICAgICAgICAgICAgIGlucHV0LmFjY2VwdCA9ICcudHh0JzsKICAgICAgICAgICAgICAgIGlucHV0LmFkZEV2ZW50TGlzdGVuZXIoJ2NoYW5nZScsIChlKSA9PiB7CiAgICAgICAgICAgICAgICAgICAgY29uc3QgZmlsZSA9IGUudGFyZ2V0LmZpbGVzWzBdOwogICAgICAgICAgICAgICAgICAgIGlmIChmaWxlKSB7CiAgICAgICAgICAgICAgICAgICAgICAgIGNvbnN0IHJlYWRlciA9IG5ldyBGaWxlUmVhZGVyKCk7CiAgICAgICAgICAgICAgICAgICAgICAgIHJlYWRlci5vbmxvYWQgPSAoZSkgPT4gewogICAgICAgICAgICAgICAgICAgICAgICAgICAgY29uc3QgY29udGVudCA9IGUudGFyZ2V0LnJlc3VsdDsKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGNvbnN0IGltcG9ydGVkS2V5d29yZHMgPSBjb250ZW50LnNwbGl0KCdcbicpCiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgLm1hcChsaW5lID0+IGxpbmUudHJpbSgpKQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC5maWx0ZXIobGluZSA9PiBsaW5lLmxlbmd0aCA+IDApOwoKICAgICAgICAgICAgICAgICAgICAgICAgICAgIGlmIChpbXBvcnRlZEtleXdvcmRzLmxlbmd0aCA+IDApIHsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAvLyDlkIjlubblhbPplK7lrZfvvIzljrvph40KICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBjb25zdCBhbGxLZXl3b3JkcyA9IFsuLi5uZXcgU2V0KFsuLi50ZW1wS2V5d29yZHMsIC4uLmltcG9ydGVkS2V5d29yZHNdKV07CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdGVtcEtleXdvcmRzLnNwbGljZSgwLCB0ZW1wS2V5d29yZHMubGVuZ3RoLCAuLi5hbGxLZXl3b3Jkcyk7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgdXBkYXRlTGlzdCgpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMubm90aWZpY2F0aW9uTWFuYWdlci5zaG93TWVzc2FnZSgn8J+TgSDlsY/olL3otKblj7c6IOWFs+mUruWtl+WvvOWFpeaIkOWKnycpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgfSBlbHNlIHsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBhbGVydCgn5paH5Lu25YaF5a655Li656m65oiW5qC85byP5LiN5q2j56Gu77yBJyk7CiAgICAgICAgICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgICAgIH07CiAgICAgICAgICAgICAgICAgICAgICAgIHJlYWRlci5vbmVycm9yID0gKCkgPT4gewogICAgICAgICAgICAgICAgICAgICAgICAgICAgYWxlcnQoJ+aWh+S7tuivu+WPluWksei0pe+8gScpOwogICAgICAgICAgICAgICAgICAgICAgICB9OwogICAgICAgICAgICAgICAgICAgICAgICByZWFkZXIucmVhZEFzVGV4dChmaWxlLCAndXRmLTgnKTsKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICB9KTsKICAgICAgICAgICAgICAgIGlucHV0LmNsaWNrKCk7CiAgICAgICAgICAgIH07CgogICAgICAgICAgICBkaWFsb2cucXVlcnlTZWxlY3RvcignLmltcG9ydC1rZXl3b3JkcycpLmFkZEV2ZW50TGlzdGVuZXIoJ2NsaWNrJywgKGUpID0+IHsKICAgICAgICAgICAgICAgIGUuc3RvcFByb3BhZ2F0aW9uKCk7CiAgICAgICAgICAgICAgICBpbXBvcnRLZXl3b3JkcygpOwogICAgICAgICAgICB9KTsKCiAgICAgICAgICAgIHVwZGF0ZUxpc3QoKTsKICAgICAgICB9CgogICAgICAgIHNob3dSZXNvbHV0aW9uRGlhbG9nKCkgewogICAgICAgICAgICBjb25zdCBjdXJyZW50UmVzb2x1dGlvbiA9IHRoaXMuY29uZmlnLmdldCgnb25seVJlc29sdXRpb24nKS5yZXNvbHV0aW9uOwogICAgICAgICAgICBjb25zdCByZXNvbHV0aW9ucyA9IFsnNEsnLCAnMksnLCAnMTA4MFAnLCAnNzIwUCcsICc1NDBQJ107CgogICAgICAgICAgICBjb25zdCBjb250ZW50ID0gYAogICAgICAgICAgICAgICAgPGRpdiBzdHlsZT0ibWFyZ2luLWJvdHRvbTogMTVweDsiPgogICAgICAgICAgICAgICAgICAgIDxsYWJlbCBzdHlsZT0iY29sb3I6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC43KTsgZm9udC1zaXplOiAxMnB4OyBkaXNwbGF5OiBibG9jazsgbWFyZ2luLWJvdHRvbTogNXB4OyI+CiAgICAgICAgICAgICAgICAgICAgICAgIOmAieaLqeimgeetm+mAieeahOWIhui+qOeOhwogICAgICAgICAgICAgICAgICAgIDwvbGFiZWw+CiAgICAgICAgICAgICAgICAgICAgPGRpdiBzdHlsZT0icG9zaXRpb246IHJlbGF0aXZlOyI+CiAgICAgICAgICAgICAgICAgICAgICAgIDxzZWxlY3QgY2xhc3M9InJlc29sdXRpb24tc2VsZWN0IgogICAgICAgICAgICAgICAgICAgICAgICAgICAgc3R5bGU9IndpZHRoOiAxMDAlOyBwYWRkaW5nOiA4cHg7IGJhY2tncm91bmQ6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC4xKTsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBjb2xvcjogd2hpdGU7IGJvcmRlcjogMXB4IHNvbGlkIHJnYmEoMjU1LCAyNTUsIDI1NSwgMC4zKTsgYm9yZGVyLXJhZGl1czogNHB4OwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGFwcGVhcmFuY2U6IG5vbmU7IGN1cnNvcjogcG9pbnRlcjsiPgogICAgICAgICAgICAgICAgICAgICAgICAgICAgJHtyZXNvbHV0aW9ucy5tYXAocmVzID0+CiAgICAgICAgICAgICAgICBgPG9wdGlvbiB2YWx1ZT0iJHtyZXN9IiBzdHlsZT0iYmFja2dyb3VuZDogcmdiYSgwLCAwLCAwLCAwLjkpOyBjb2xvcjogd2hpdGU7IiAke2N1cnJlbnRSZXNvbHV0aW9uID09PSByZXMgPyAnc2VsZWN0ZWQnIDogJyd9PiR7cmVzfTwvb3B0aW9uPmAKICAgICAgICAgICAgKS5qb2luKCcnKX0KICAgICAgICAgICAgICAgICAgICAgICAgPC9zZWxlY3Q+CiAgICAgICAgICAgICAgICAgICAgICAgIDxzcGFuIHN0eWxlPSJwb3NpdGlvbjogYWJzb2x1dGU7IHJpZ2h0OiAxMHB4OyB0b3A6IDUwJTsgdHJhbnNmb3JtOiB0cmFuc2xhdGVZKC01MCUpOwogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIHBvaW50ZXItZXZlbnRzOiBub25lOyBjb2xvcjogcmdiYSgyNTUsIDI1NSwgMjU1LCAwLjUpOyI+4pa8PC9zcGFuPgogICAgICAgICAgICAgICAgICAgIDwvZGl2PgogICAgICAgICAgICAgICAgPC9kaXY+CgogICAgICAgICAgICAgICAgPGRpdiBzdHlsZT0iY29sb3I6IHJnYmEoMjU1LCAyNTUsIDI1NSwgMC41KTsgZm9udC1zaXplOiAxMXB4OyBtYXJnaW4tYm90dG9tOiAxMHB4OyI+CiAgICAgICAgICAgICAgICAgICAg5o+Q56S677ya5Y+q5pKt5pS+5YyF5ZCr5omA6YCJ5YiG6L6o546H5YWz6ZSu5a2X55qE6KeG6aKR77yM5rKh5pyJ5om+5Yiw5YiZ6Ieq5Yqo6Lez6L+HCiAgICAgICAgICAgICAgICA8L2Rpdj4KICAgICAgICAgICAgYDsKCiAgICAgICAgICAgIGNvbnN0IGRpYWxvZyA9IFVJRmFjdG9yeS5jcmVhdGVEaWFsb2coJ3Jlc29sdXRpb24tZGlhbG9nJywgJ+WIhui+qOeOh+etm+mAieiuvue9ricsIGNvbnRlbnQsICgpID0+IHsKICAgICAgICAgICAgICAgIGNvbnN0IHJlc29sdXRpb25TZWxlY3QgPSBkaWFsb2cucXVlcnlTZWxlY3RvcignLnJlc29sdXRpb24tc2VsZWN0Jyk7CiAgICAgICAgICAgICAgICBjb25zdCByZXNvbHV0aW9uID0gcmVzb2x1dGlvblNlbGVjdC52YWx1ZTsKCiAgICAgICAgICAgICAgICB0aGlzLmNvbmZpZy5zYXZlVGFyZ2V0UmVzb2x1dGlvbihyZXNvbHV0aW9uKTsKICAgICAgICAgICAgICAgIHRoaXMudXBkYXRlUmVzb2x1dGlvblRleHQoKTsKICAgICAgICAgICAgICAgIHRoaXMubm90aWZpY2F0aW9uTWFuYWdlci5zaG93TWVzc2FnZShg4pqZ77iPIOWIhui+qOeOh+etm+mAiTog5bey6K6+5Li6ICR7cmVzb2x1dGlvbn1gKTsKICAgICAgICAgICAgICAgIHJldHVybiB0cnVlOwogICAgICAgICAgICB9KTsKICAgICAgICB9CiAgICB9CgogICAgLy8gPT09PT09PT09PSBBSeajgOa1i+WZqCA9PT09PT09PT09CiAgICBjbGFzcyBBSURldGVjdG9yIHsKICAgICAgICBjb25zdHJ1Y3Rvcih2aWRlb0NvbnRyb2xsZXIsIGNvbmZpZykgewogICAgICAgICAgICB0aGlzLnZpZGVvQ29udHJvbGxlciA9IHZpZGVvQ29udHJvbGxlcjsKICAgICAgICAgICAgdGhpcy5jb25maWcgPSBjb25maWc7CiAgICAgICAgICAgIHRoaXMuQVBJX1VSTCA9ICdodHRwOi8vbG9jYWxob3N0OjExNDM0L2FwaS9nZW5lcmF0ZSc7CiAgICAgICAgICAgIHRoaXMuY2hlY2tTY2hlZHVsZSA9IFswLCAxMDAwLCAyNTAwLCA0MDAwLCA2MDAwLCA4MDAwXTsKICAgICAgICAgICAgdGhpcy5yZXNldCgpOwogICAgICAgIH0KCiAgICAgICAgcmVzZXQoKSB7CiAgICAgICAgICAgIHRoaXMuY3VycmVudENoZWNrSW5kZXggPSAwOwogICAgICAgICAgICB0aGlzLmNoZWNrUmVzdWx0cyA9IFtdOwogICAgICAgICAgICB0aGlzLmNvbnNlY3V0aXZlWWVzID0gMDsKICAgICAgICAgICAgdGhpcy5jb25zZWN1dGl2ZU5vID0gMDsKICAgICAgICAgICAgdGhpcy5oYXNTa2lwcGVkID0gZmFsc2U7CiAgICAgICAgICAgIHRoaXMuc3RvcENoZWNraW5nID0gZmFsc2U7CiAgICAgICAgICAgIHRoaXMuaGFzTGlrZWQgPSBmYWxzZTsKICAgICAgICAgICAgdGhpcy5pc1Byb2Nlc3NpbmcgPSBmYWxzZTsKICAgICAgICB9CgogICAgICAgIHNob3VsZENoZWNrKHZpZGVvUGxheVRpbWUpIHsKICAgICAgICAgICAgcmV0dXJuICF0aGlzLmlzUHJvY2Vzc2luZyAmJgogICAgICAgICAgICAgICAgIXRoaXMuc3RvcENoZWNraW5nICYmCiAgICAgICAgICAgICAgICAhdGhpcy5oYXNTa2lwcGVkICYmCiAgICAgICAgICAgICAgICB0aGlzLmN1cnJlbnRDaGVja0luZGV4IDwgdGhpcy5jaGVja1NjaGVkdWxlLmxlbmd0aCAmJgogICAgICAgICAgICAgICAgdmlkZW9QbGF5VGltZSA+PSB0aGlzLmNoZWNrU2NoZWR1bGVbdGhpcy5jdXJyZW50Q2hlY2tJbmRleF07CiAgICAgICAgfQoKICAgICAgICBhc3luYyBwcm9jZXNzVmlkZW8odmlkZW9FbCkgewogICAgICAgICAgICBpZiAodGhpcy5pc1Byb2Nlc3NpbmcgfHwgdGhpcy5zdG9wQ2hlY2tpbmcgfHwgdGhpcy5oYXNTa2lwcGVkKSByZXR1cm47CiAgICAgICAgICAgIHRoaXMuaXNQcm9jZXNzaW5nID0gdHJ1ZTsKCiAgICAgICAgICAgIHRyeSB7CiAgICAgICAgICAgICAgICBjb25zdCBiYXNlNjRJbWFnZSA9IGF3YWl0IHRoaXMuY2FwdHVyZVZpZGVvRnJhbWUodmlkZW9FbCk7CiAgICAgICAgICAgICAgICBjb25zdCBhaVJlc3BvbnNlID0gYXdhaXQgdGhpcy5jYWxsQUkoYmFzZTY0SW1hZ2UpOwogICAgICAgICAgICAgICAgdGhpcy5oYW5kbGVSZXNwb25zZShhaVJlc3BvbnNlKTsKICAgICAgICAgICAgICAgIHRoaXMuY3VycmVudENoZWNrSW5kZXgrKzsKICAgICAgICAgICAgfSBjYXRjaCAoZXJyb3IpIHsKICAgICAgICAgICAgICAgIGNvbnNvbGUuZXJyb3IoJ0FJ5Yik5pat5Yqf6IO95Ye66ZSZOicsIGVycm9yKTsKICAgICAgICAgICAgICAgIC8vIOaYvuekuumUmeivr+aPkOekugogICAgICAgICAgICAgICAgVUlGYWN0b3J5LnNob3dFcnJvckRpYWxvZygpOwogICAgICAgICAgICAgICAgLy8g5YWz6ZetQUnllpzlpb3mqKHlvI8KICAgICAgICAgICAgICAgIHRoaXMuY29uZmlnLnNldEVuYWJsZWQoJ2FpUHJlZmVyZW5jZScsIGZhbHNlKTsKICAgICAgICAgICAgICAgIFVJTWFuYWdlci51cGRhdGVUb2dnbGVCdXR0b25zKCdhaS1wcmVmZXJlbmNlLWJ1dHRvbicsIGZhbHNl",
-        "KTsKICAgICAgICAgICAgICAgIHRoaXMuc3RvcENoZWNraW5nID0gdHJ1ZTsKICAgICAgICAgICAgfSBmaW5hbGx5IHsKICAgICAgICAgICAgICAgIHRoaXMuaXNQcm9jZXNzaW5nID0gZmFsc2U7CiAgICAgICAgICAgIH0KICAgICAgICB9CgogICAgICAgIGFzeW5jIGNhcHR1cmVWaWRlb0ZyYW1lKHZpZGVvRWwpIHsKICAgICAgICAgICAgY29uc3QgY2FudmFzID0gZG9jdW1lbnQuY3JlYXRlRWxlbWVudCgnY2FudmFzJyk7CiAgICAgICAgICAgIGNvbnN0IG1heFNpemUgPSA1MDA7CiAgICAgICAgICAgIGNvbnN0IGFzcGVjdFJhdGlvID0gdmlkZW9FbC52aWRlb1dpZHRoIC8gdmlkZW9FbC52aWRlb0hlaWdodDsKCiAgICAgICAgICAgIGxldCB0YXJnZXRXaWR0aCwgdGFyZ2V0SGVpZ2h0OwogICAgICAgICAgICBpZiAodmlkZW9FbC52aWRlb1dpZHRoID4gdmlkZW9FbC52aWRlb0hlaWdodCkgewogICAgICAgICAgICAgICAgdGFyZ2V0V2lkdGggPSBNYXRoLm1pbih2aWRlb0VsLnZpZGVvV2lkdGgsIG1heFNpemUpOwogICAgICAgICAgICAgICAgdGFyZ2V0SGVpZ2h0ID0gTWF0aC5yb3VuZCh0YXJnZXRXaWR0aCAvIGFzcGVjdFJhdGlvKTsKICAgICAgICAgICAgfSBlbHNlIHsKICAgICAgICAgICAgICAgIHRhcmdldEhlaWdodCA9IE1hdGgubWluKHZpZGVvRWwudmlkZW9IZWlnaHQsIG1heFNpemUpOwogICAgICAgICAgICAgICAgdGFyZ2V0V2lkdGggPSBNYXRoLnJvdW5kKHRhcmdldEhlaWdodCAqIGFzcGVjdFJhdGlvKTsKICAgICAgICAgICAgfQoKICAgICAgICAgICAgY2FudmFzLndpZHRoID0gdGFyZ2V0V2lkdGg7CiAgICAgICAgICAgIGNhbnZhcy5oZWlnaHQgPSB0YXJnZXRIZWlnaHQ7CgogICAgICAgICAgICBjb25zdCBjdHggPSBjYW52YXMuZ2V0Q29udGV4dCgnMmQnKTsKICAgICAgICAgICAgY3R4LmRyYXdJbWFnZSh2aWRlb0VsLCAwLCAwLCB0YXJnZXRXaWR0aCwgdGFyZ2V0SGVpZ2h0KTsKCiAgICAgICAgICAgIHJldHVybiBjYW52YXMudG9EYXRhVVJMKCdpbWFnZS9qcGVnJywgMC44KS5zcGxpdCgnLCcpWzFdOwogICAgICAgIH0KCiAgICAgICAgYXN5bmMgY2FsbEFJKGJhc2U2NEltYWdlKSB7CiAgICAgICAgICAgIGNvbnN0IGNvbnRlbnQgPSB0aGlzLmNvbmZpZy5nZXQoJ2FpUHJlZmVyZW5jZScpLmNvbnRlbnQ7CiAgICAgICAgICAgIGNvbnN0IG1vZGVsID0gdGhpcy5jb25maWcuZ2V0KCdhaVByZWZlcmVuY2UnKS5tb2RlbDsKCiAgICAgICAgICAgIGNvbnN0IHJlc3BvbnNlID0gYXdhaXQgZmV0Y2godGhpcy5BUElfVVJMLCB7CiAgICAgICAgICAgICAgICBtZXRob2Q6ICdQT1NUJywKICAgICAgICAgICAgICAgIGhlYWRlcnM6IHsgJ0NvbnRlbnQtVHlwZSc6ICdhcHBsaWNhdGlvbi9qc29uJyB9LAogICAgICAgICAgICAgICAgYm9keTogSlNPTi5zdHJpbmdpZnkoewogICAgICAgICAgICAgICAgICAgIG1vZGVsOiBtb2RlbCwKICAgICAgICAgICAgICAgICAgICBwcm9tcHQ6IGDov5nmmK8ke2NvbnRlbnR95ZCXP+WbnuetlOOAjuaYr+OAj+aIluiAheOAjuS4jeaYr+OAjyzkuI3opoHor7Tku7vkvZXlpJrkvZnnmoTlrZfnrKZgLAogICAgICAgICAgICAgICAgICAgIGltYWdlczogW2Jhc2U2NEltYWdlXSwKICAgICAgICAgICAgICAgICAgICBzdHJlYW06IGZhbHNlCiAgICAgICAgICAgICAgICB9KQogICAgICAgICAgICB9KTsKCiAgICAgICAgICAgIGlmICghcmVzcG9uc2Uub2spIHsKICAgICAgICAgICAgICAgIHRocm93IG5ldyBFcnJvcihgQUnor7fmsYLlpLHotKU6ICR7cmVzcG9uc2Uuc3RhdHVzfWApOwogICAgICAgICAgICB9CgogICAgICAgICAgICBjb25zdCByZXN1bHQgPSBhd2FpdCByZXNwb25zZS5qc29uKCk7CiAgICAgICAgICAgIHJldHVybiByZXN1bHQucmVzcG9uc2U/LnRyaW0oKTsKICAgICAgICB9CgogICAgICAgIGhhbmRsZVJlc3BvbnNlKGFpUmVzcG9uc2UpIHsKICAgICAgICAgICAgY29uc3QgY29udGVudCA9IHRoaXMuY29uZmlnLmdldCgnYWlQcmVmZXJlbmNlJykuY29udGVudDsKICAgICAgICAgICAgdGhpcy5jaGVja1Jlc3VsdHMucHVzaChhaVJlc3BvbnNlKTsKICAgICAgICAgICAgY29uc29sZS5sb2coYEFJ5qOA5rWL57uT5p6cWyR7dGhpcy5jaGVja1Jlc3VsdHMubGVuZ3RofV3vvJoke2FpUmVzcG9uc2V9YCk7CgogICAgICAgICAgICBpZiAoYWlSZXNwb25zZSA9PT0gJ+aYrycpIHsKICAgICAgICAgICAgICAgIHRoaXMuY29uc2VjdXRpdmVZZXMrKzsKICAgICAgICAgICAgICAgIHRoaXMuY29uc2VjdXRpdmVObyA9IDA7CiAgICAgICAgICAgIH0gZWxzZSB7CiAgICAgICAgICAgICAgICB0aGlzLmNvbnNlY3V0aXZlWWVzID0gMDsKICAgICAgICAgICAgICAgIHRoaXMuY29uc2VjdXRpdmVObysrOwogICAgICAgICAgICB9CgogICAgICAgICAgICBpZiAodGhpcy5jb25zZWN1dGl2ZU5vID49IDEpIHsKICAgICAgICAgICAgICAgIHRoaXMuaGFzU2tpcHBlZCA9IHRydWU7CiAgICAgICAgICAgICAgICB0aGlzLnN0b3BDaGVja2luZyA9IHRydWU7CiAgICAgICAgICAgICAgICB0aGlzLnZpZGVvQ29udHJvbGxlci5za2lwKGDwn6SWIEFJ562b6YCJOiDpnZ4nJHtjb250ZW50fSdgKTsKICAgICAgICAgICAgfSBlbHNlIGlmICh0aGlzLmNvbnNlY3V0aXZlWWVzID49IDIpIHsKICAgICAgICAgICAgICAgIGNvbnNvbGUubG9nKGDjgJDlgZzmraLmo4DmtYvjgJHov57nu60y5qyh5Yik5a6a5Li6JHtjb250ZW50fe+8jOWuieW/g+ingueci2ApOwogICAgICAgICAgICAgICAgdGhpcy5zdG9wQ2hlY2tpbmcgPSB0cnVlOwoKICAgICAgICAgICAgICAgIC8vIOajgOafpeaYr+WQpuW8gOWQr+S6huiHquWKqOeCuei1nuWKn+iDvQogICAgICAgICAgICAgICAgY29uc3QgYXV0b0xpa2VFbmFibGVkID0gdGhpcy5jb25maWcuZ2V0KCdhaVByZWZlcmVuY2UnKS5hdXRvTGlrZTsKICAgICAgICAgICAgICAgIGlmICghdGhpcy5oYXNMaWtlZCAmJiBhdXRvTGlrZUVuYWJsZWQpIHsKICAgICAgICAgICAgICAgICAgICB0aGlzLnZpZGVvQ29udHJvbGxlci5saWtlKCk7CiAgICAgICAgICAgICAgICAgICAgdGhpcy5oYXNMaWtlZCA9IHRydWU7CiAgICAgICAgICAgICAgICB9IGVsc2UgaWYgKCFhdXRvTGlrZUVuYWJsZWQpIHsKICAgICAgICAgICAgICAgICAgICBjb25zb2xlLmxvZygn44CQ6Ieq5Yqo54K56LWe44CR5Yqf6IO95bey5YWz6Zet77yM6Lez6L+H54K56LWeJyk7CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIH0KICAgICAgICB9CiAgICB9CgogICAgLy8gPT09PT09PT09PSDop4bpopHmo4DmtYvnrZbnlaUgPT09PT09PT09PQogICAgY2xhc3MgVmlkZW9EZXRlY3Rpb25TdHJhdGVnaWVzIHsKICAgICAgICBjb25zdHJ1Y3Rvcihjb25maWcsIHZpZGVvQ29udHJvbGxlciwgbm90aWZpY2F0aW9uTWFuYWdlcikgewogICAgICAgICAgICB0aGlzLmNvbmZpZyA9IGNvbmZpZzsKICAgICAgICAgICAgdGhpcy52aWRlb0NvbnRyb2xsZXIgPSB2aWRlb0NvbnRyb2xsZXI7CiAgICAgICAgICAgIHRoaXMubm90aWZpY2F0aW9uTWFuYWdlciA9IG5vdGlmaWNhdGlvbk1hbmFnZXI7CiAgICAgICAgICAgIHRoaXMucmVzb2x1dGlvblNraXBwZWQgPSBmYWxzZTsKICAgICAgICB9CgogICAgICAgIHJlc2V0KCkgewogICAgICAgICAgICB0aGlzLnJlc29sdXRpb25Ta2lwcGVkID0gZmFsc2U7CiAgICAgICAgfQoKICAgICAgICBjaGVja0FkKGNvbnRhaW5lcikgewogICAgICAgICAgICBpZiAoIXRoaXMuY29uZmlnLmlzRW5hYmxlZCgnc2tpcEFkJykpIHJldHVybiBmYWxzZTsKCiAgICAgICAgICAgIGNvbnN0IGFkSW5kaWNhdG9yID0gY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoU0VMRUNUT1JTLmFkSW5kaWNhdG9yKTsKICAgICAgICAgICAgaWYgKGFkSW5kaWNhdG9yKSB7CiAgICAgICAgICAgICAgICB0aGlzLnZpZGVvQ29udHJvbGxlci5za2lwKCfij63vuI8g6Ieq5Yqo6Lez6L+HOiDlub/lkYrop4bpopEnKTsKICAgICAgICAgICAgICAgIHJldHVybiB0cnVlOwogICAgICAgICAgICB9CiAgICAgICAgICAgIHJldHVybiBmYWxzZTsKICAgICAgICB9CgogICAgICAgIGNoZWNrQmxvY2tlZEFjY291bnQoY29udGFpbmVyKSB7CiAgICAgICAgICAgIGlmICghdGhpcy5jb25maWcuaXNFbmFibGVkKCdibG9ja0tleXdvcmRzJykpIHJldHVybiBmYWxzZTsKCiAgICAgICAgICAgIGNvbnN0IGJsb2NrQ29uZmlnID0gdGhpcy5jb25maWcuZ2V0KCdibG9ja0tleXdvcmRzJyk7CiAgICAgICAgICAgIGNvbnN0IGtleXdvcmRzID0gYmxvY2tDb25maWcua2V5d29yZHM7CiAgICAgICAgICAgIGNvbnN0IHByZXNzUkVuYWJsZWQgPSBibG9ja0NvbmZpZy5wcmVzc1I7CiAgICAgICAgICAgIGNvbnN0IGJsb2NrTmFtZSA9IGJsb2NrQ29uZmlnLmJsb2NrTmFtZTsKICAgICAgICAgICAgY29uc3QgYmxvY2tEZXNjID0gYmxvY2tDb25maWcuYmxvY2tEZXNjOwogICAgICAgICAgICBjb25zdCBibG9ja1RhZ3MgPSBibG9ja0NvbmZpZy5ibG9ja1RhZ3M7CgogICAgICAgICAgICAvLyDlpoLmnpzkuInkuKrmo4DmtYvpgInpobnpg73msqHlvIDlkK/vvIznm7TmjqXov5Tlm54KICAgICAgICAgICAgaWYgKCFibG9ja05hbWUgJiYgIWJsb2NrRGVzYyAmJiAhYmxvY2tUYWdzKSByZXR1cm4gZmFsc2U7CgogICAgICAgICAgICBsZXQgbWF0Y2hlZEtleXdvcmQgPSBudWxsOwogICAgICAgICAgICBsZXQgbWF0Y2hUeXBlID0gJyc7CgogICAgICAgICAgICAvLyDmo4DmtYvlkI3np7DvvIjotKblj7fmmLXnp7DvvIkKICAgICAgICAgICAgaWYgKGJsb2NrTmFtZSAmJiAhbWF0Y2hlZEtleXdvcmQpIHsKICAgICAgICAgICAgICAgIGNvbnN0IGFjY291bnRFbCA9IGNvbnRhaW5lci5xdWVyeVNlbGVjdG9yKFNFTEVDVE9SUy5hY2NvdW50TmFtZSk7CiAgICAgICAgICAgICAgICBjb25zdCBhY2NvdW50TmFtZSA9IGFjY291bnRFbD8udGV4dENvbnRlbnQudHJpbSgpOwogICAgICAgICAgICAgICAgaWYgKGFjY291bnROYW1lKSB7CiAgICAgICAgICAgICAgICAgICAgbWF0Y2hlZEtleXdvcmQgPSBrZXl3b3Jkcy5maW5kKGt3ID0+IGFjY291bnROYW1lLmluY2x1ZGVzKGt3KSk7CiAgICAgICAgICAgICAgICAgICAgaWYgKG1hdGNoZWRLZXl3b3JkKSBtYXRjaFR5cGUgPSAn5ZCN56ewJzsKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfQoKICAgICAgICAgICAgLy8g5qOA5rWL566A5LuL77yI6KeG6aKR5o+P6L+w5paH5qGI77yM5o6S6Zmk5qCH562+77yJCiAgICAgICAgICAgIGlmIChibG9ja0Rlc2MgJiYgIW1hdGNoZWRLZXl3b3JkKSB7CiAgICAgICAgICAgICAgICBjb25zdCBkZXNjRWwgPSBjb250YWluZXIucXVlcnlTZWxlY3RvcihTRUxFQ1RPUlMudmlkZW9EZXNjKTsKICAgICAgICAgICAgICAgIGlmIChkZXNjRWwpIHsKICAgICAgICAgICAgICAgICAgICAvLyDojrflj5bnuq/mlofmnKzvvIznhLblkI7np7vpmaQgI3h4eCDmoIfnrb4KICAgICAgICAgICAgICAgICAgICBjb25zdCBkZXNjVGV4dCA9IGRlc2NFbC50ZXh0Q29udGVudC5yZXBsYWNlKC8jXFMrL2csICcnKS50cmltKCk7CiAgICAgICAgICAgICAgICAgICAgaWYgKGRlc2NUZXh0KSB7CiAgICAgICAgICAgICAgICAgICAgICAgIG1hdGNoZWRLZXl3b3JkID0ga2V5d29yZHMuZmluZChrdyA9PiBkZXNjVGV4dC5pbmNsdWRlcyhrdykpOwogICAgICAgICAgICAgICAgICAgICAgICBpZiAobWF0Y2hlZEtleXdvcmQpIG1hdGNoVHlwZSA9ICfnroDku4snOwogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfQoKICAgICAgICAgICAgLy8g5qOA5rWL5qCH562+77yII+ivnemimOagh+etvu+8iQogICAgICAgICAgICBpZiAoYmxvY2tUYWdzICYmICFtYXRjaGVkS2V5d29yZCkgewogICAgICAgICAgICAgICAgY29uc3QgZGVzY0VsID0gY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoU0VMRUNUT1JTLnZpZGVvRGVzYyk7CiAgICAgICAgICAgICAgICBpZiAoZGVzY0VsKSB7CiAgICAgICAgICAgICAgICAgICAgLy8g5o+Q5Y+W5omA5pyJICN4eHgg5qCH562+CiAgICAgICAgICAgICAgICAgICAgY29uc3QgdGFncyA9IGRlc2NFbC50ZXh0Q29udGVudC5tYXRjaCgvI1xTKy9nKSB8fCBbXTsKICAgICAgICAgICAgICAgICAgICBjb25zdCB0YWdzVGV4dCA9IHRhZ3Muam9pbignICcpOwogICAgICAgICAg",
-        "ICAgICAgICAgIGlmICh0YWdzVGV4dCkgewogICAgICAgICAgICAgICAgICAgICAgICBtYXRjaGVkS2V5d29yZCA9IGtleXdvcmRzLmZpbmQoa3cgPT4gdGFnc1RleHQuaW5jbHVkZXMoa3cpKTsKICAgICAgICAgICAgICAgICAgICAgICAgaWYgKG1hdGNoZWRLZXl3b3JkKSBtYXRjaFR5cGUgPSAn5qCH562+JzsKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIH0KCiAgICAgICAgICAgIC8vIOWmguaenOWMuemFjeWIsOWFs+mUruWtl++8jOaJp+ihjOi3s+i/h+aTjeS9nAogICAgICAgICAgICBpZiAobWF0Y2hlZEtleXdvcmQpIHsKICAgICAgICAgICAgICAgIGlmIChwcmVzc1JFbmFibGVkKSB7CiAgICAgICAgICAgICAgICAgICAgLy8g5aaC5p6c5byA5ZCv5LqG5oyJUumUruWKn+iDve+8jOaMiVLplK7vvIjop4bpopHkvJrnm7TmjqXmtojlpLHvvIkKICAgICAgICAgICAgICAgICAgICB0aGlzLnZpZGVvQ29udHJvbGxlci5wcmVzc1IoKTsKICAgICAgICAgICAgICAgIH0gZWxzZSB7CiAgICAgICAgICAgICAgICAgICAgLy8g5aaC5p6c5rKh5byA5ZCvUumUruWKn+iDve+8jOWImeS9v+eUqOS4i+mUrui3s+i/hwogICAgICAgICAgICAgICAgICAgIHRoaXMudmlkZW9Db250cm9sbGVyLnNraXAoYPCfmqsg5bGP6JS9JHttYXRjaFR5cGV9OiDlhbPplK7lrZciJHttYXRjaGVkS2V5d29yZH0iYCk7CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICByZXR1cm4gdHJ1ZTsKICAgICAgICAgICAgfQogICAgICAgICAgICByZXR1cm4gZmFsc2U7CiAgICAgICAgfQoKICAgICAgICBjaGVja1Jlc29sdXRpb24oY29udGFpbmVyKSB7CiAgICAgICAgICAgIGlmICghdGhpcy5jb25maWcuaXNFbmFibGVkKCdhdXRvSGlnaFJlcycpICYmICF0aGlzLmNvbmZpZy5pc0VuYWJsZWQoJ29ubHlSZXNvbHV0aW9uJykpIHJldHVybiBmYWxzZTsKCiAgICAgICAgICAgIGNvbnN0IHByaW9yaXR5T3JkZXIgPSBbIjRLIiwgIjJLIiwgIjEwODBQIiwgIjcyMFAiLCAiNTQwUCIsICLmmbrog70iXTsKICAgICAgICAgICAgY29uc3Qgb3B0aW9ucyA9IEFycmF5LmZyb20oY29udGFpbmVyLnF1ZXJ5U2VsZWN0b3JBbGwoU0VMRUNUT1JTLnJlc29sdXRpb25PcHRpb25zKSkKICAgICAgICAgICAgICAgIC5tYXAoZWwgPT4gewogICAgICAgICAgICAgICAgICAgIGNvbnN0IHRleHQgPSBlbC50ZXh0Q29udGVudC50cmltKCkudG9VcHBlckNhc2UoKTsKICAgICAgICAgICAgICAgICAgICByZXR1cm4gewogICAgICAgICAgICAgICAgICAgICAgICBlbGVtZW50OiBlbCwKICAgICAgICAgICAgICAgICAgICAgICAgdGV4dCwKICAgICAgICAgICAgICAgICAgICAgICAgcHJpb3JpdHk6IHByaW9yaXR5T3JkZXIuZmluZEluZGV4KHAgPT4gdGV4dC5pbmNsdWRlcyhwKSkKICAgICAgICAgICAgICAgICAgICB9OwogICAgICAgICAgICAgICAgfSkKICAgICAgICAgICAgICAgIC5maWx0ZXIob3B0ID0+IG9wdC5wcmlvcml0eSAhPT0gLTEpCiAgICAgICAgICAgICAgICAuc29ydCgoYSwgYikgPT4gYS5wcmlvcml0eSAtIGIucHJpb3JpdHkpOwoKICAgICAgICAgICAgLy8g5Y+q55yL5oyH5a6a5YiG6L6o546H5qih5byP77ya5Y+q6YCJ5oup5oyH5a6a5YiG6L6o546H77yM5rKh5pyJ5bCx6Lez6L+HCiAgICAgICAgICAgIGlmICh0aGlzLmNvbmZpZy5pc0VuYWJsZWQoJ29ubHlSZXNvbHV0aW9uJykpIHsKICAgICAgICAgICAgICAgIGNvbnN0IHRhcmdldFJlc29sdXRpb24gPSB0aGlzLmNvbmZpZy5nZXQoJ29ubHlSZXNvbHV0aW9uJykucmVzb2x1dGlvbi50b1VwcGVyQ2FzZSgpOwogICAgICAgICAgICAgICAgY29uc3QgaGFzVGFyZ2V0ID0gb3B0aW9ucy5zb21lKG9wdCA9PiBvcHQudGV4dC5pbmNsdWRlcyh0YXJnZXRSZXNvbHV0aW9uKSk7CiAgICAgICAgICAgICAgICBpZiAoIWhhc1RhcmdldCkgewogICAgICAgICAgICAgICAgICAgIGlmICghdGhpcy5yZXNvbHV0aW9uU2tpcHBlZCkgewogICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnZpZGVvQ29udHJvbGxlci5za2lwKGDwn5O6IOWIhui+qOeOh+etm+mAie+8mumdniAke3RhcmdldFJlc29sdXRpb259IOWIhui+qOeOh2ApOwogICAgICAgICAgICAgICAgICAgICAgICB0aGlzLnJlc29sdXRpb25Ta2lwcGVkID0gdHJ1ZTsKICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgcmV0dXJuIHRydWU7CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICBjb25zdCB0YXJnZXRPcHRpb24gPSBvcHRpb25zLmZpbmQob3B0ID0+IG9wdC50ZXh0LmluY2x1ZGVzKHRhcmdldFJlc29sdXRpb24pKTsKICAgICAgICAgICAgICAgIGlmICh0YXJnZXRPcHRpb24gJiYgIXRhcmdldE9wdGlvbi5lbGVtZW50LmNsYXNzTGlzdC5jb250YWlucygic2VsZWN0ZWQiKSkgewogICAgICAgICAgICAgICAgICAgIHRhcmdldE9wdGlvbi5lbGVtZW50LmNsaWNrKCk7CiAgICAgICAgICAgICAgICAgICAgdGhpcy5ub3RpZmljYXRpb25NYW5hZ2VyLnNob3dNZXNzYWdlKGDwn5O6IOWIhui+qOeOhzog5bey5YiH5o2i6IezICR7dGFyZ2V0UmVzb2x1dGlvbn1gKTsKICAgICAgICAgICAgICAgICAgICByZXR1cm4gdHJ1ZTsKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIHJldHVybiBmYWxzZTsKICAgICAgICAgICAgfQoKICAgICAgICAgICAgLy8g5Y6f5pyJ55qE5pyA6auY5YiG6L6o546H6YC76L6RCiAgICAgICAgICAgIGlmICh0aGlzLmNvbmZpZy5pc0VuYWJsZWQoJ2F1dG9IaWdoUmVzJykpIHsKICAgICAgICAgICAgICAgIGlmIChvcHRpb25zLmxlbmd0aCA+IDAgJiYgIW9wdGlvbnNbMF0uZWxlbWVudC5jbGFzc0xpc3QuY29udGFpbnMoInNlbGVjdGVkIikpIHsKICAgICAgICAgICAgICAgICAgICBjb25zdCBiZXN0T3B0aW9uID0gb3B0aW9uc1swXTsKICAgICAgICAgICAgICAgICAgICBiZXN0T3B0aW9uLmVsZW1lbnQuY2xpY2soKTsKICAgICAgICAgICAgICAgICAgICBjb25zdCByZXNvbHV0aW9uVGV4dCA9IGJlc3RPcHRpb24uZWxlbWVudC50ZXh0Q29udGVudC50cmltKCk7CiAgICAgICAgICAgICAgICAgICAgdGhpcy5ub3RpZmljYXRpb25NYW5hZ2VyLnNob3dNZXNzYWdlKGDwn5O6IOWIhui+qOeOhzog5bey5YiH5o2i6Iez5pyA6auY5qGjICR7cmVzb2x1dGlvblRleHR9YCk7CgogICAgICAgICAgICAgICAgICAgIGlmIChiZXN0T3B0aW9uLnRleHQuaW5jbHVkZXMoIjRLIikpIHsKICAgICAgICAgICAgICAgICAgICAgICAgdGhpcy5jb25maWcuc2V0RW5hYmxlZCgnYXV0b0hpZ2hSZXMnLCBmYWxzZSk7CiAgICAgICAgICAgICAgICAgICAgICAgIFVJTWFuYWdlci51cGRhdGVUb2dnbGVCdXR0b25zKCdhdXRvLWhpZ2gtcmVzb2x1dGlvbi1idXR0b24nLCBmYWxzZSk7CiAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMubm90aWZpY2F0aW9uTWFuYWdlci5zaG93TWVzc2FnZSgi8J+TuiDliIbovqjnjoc6IOW3sumUgeWumjRL77yM6Ieq5Yqo5YiH5o2i5bey5YWz6ZetIik7CiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIHJldHVybiB0cnVlOwogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgICAgIHJldHVybiBmYWxzZTsKICAgICAgICB9CiAgICB9CgogICAgLy8gPT09PT09PT09PSDkuLvlupTnlKjnqIvluo8gPT09PT09PT09PQogICAgY2xhc3MgRG91eWluRW5oYW5jZXIgewogICAgICAgIGNvbnN0cnVjdG9yKCkgewogICAgICAgICAgICB0aGlzLm5vdGlmaWNhdGlvbk1hbmFnZXIgPSBuZXcgTm90aWZpY2F0aW9uTWFuYWdlcigpOwogICAgICAgICAgICB0aGlzLmNvbmZpZyA9IG5ldyBDb25maWdNYW5hZ2VyKCk7CiAgICAgICAgICAgIHRoaXMudmlkZW9Db250cm9sbGVyID0gbmV3IFZpZGVvQ29udHJvbGxlcih0aGlzLm5vdGlmaWNhdGlvbk1hbmFnZXIpOwogICAgICAgICAgICB0aGlzLnVpTWFuYWdlciA9IG5ldyBVSU1hbmFnZXIodGhpcy5jb25maWcsIHRoaXMudmlkZW9Db250cm9sbGVyLCB0aGlzLm5vdGlmaWNhdGlvbk1hbmFnZXIpOwogICAgICAgICAgICB0aGlzLmFpRGV0ZWN0b3IgPSBuZXcgQUlEZXRlY3Rvcih0aGlzLnZpZGVvQ29udHJvbGxlciwgdGhpcy5jb25maWcpOwogICAgICAgICAgICB0aGlzLnN0cmF0ZWdpZXMgPSBuZXcgVmlkZW9EZXRlY3Rpb25TdHJhdGVnaWVzKHRoaXMuY29uZmlnLCB0aGlzLnZpZGVvQ29udHJvbGxlciwgdGhpcy5ub3RpZmljYXRpb25NYW5hZ2VyKTsKCiAgICAgICAgICAgIHRoaXMubGFzdFZpZGVvVXJsID0gJyc7CiAgICAgICAgICAgIHRoaXMudmlkZW9TdGFydFRpbWUgPSAwOwogICAgICAgICAgICB0aGlzLnNwZWVkTW9kZVNraXBwZWQgPSBmYWxzZTsKICAgICAgICAgICAgdGhpcy5sYXN0U2tpcHBlZExpdmVVcmwgPSAnJzsKICAgICAgICAgICAgdGhpcy5pc0N1cnJlbnRseVNraXBwaW5nID0gZmFsc2U7CiAgICAgICAgICAgIHRoaXMuY3VycmVudFNwZWVkRHVyYXRpb24gPSBudWxsOwogICAgICAgICAgICB0aGlzLmN1cnJlbnRTcGVlZE1vZGUgPSB0aGlzLmNvbmZpZy5nZXQoJ3NwZWVkTW9kZScpLm1vZGU7CgogICAgICAgICAgICB0aGlzLmluaXQoKTsKICAgICAgICB9CgogICAgICAgIGluaXQoKSB7CiAgICAgICAgICAgIHRoaXMuaW5qZWN0U3R5bGVzKCk7CgogICAgICAgICAgICBkb2N1bWVudC5hZGRFdmVudExpc3RlbmVyKCdrZXlkb3duJywgKGUpID0+IHsKICAgICAgICAgICAgICAgIGlmIChlLnRhcmdldC50YWdOYW1lID09PSAnSU5QVVQnIHx8IGUudGFyZ2V0LnRhZ05hbWUgPT09ICdURVhUQVJFQScgfHwgZS50YXJnZXQuaXNDb250ZW50RWRpdGFibGUpIHsKICAgICAgICAgICAgICAgICAgICByZXR1cm47CiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgaWYgKGUua2V5ID09PSAnPScpIHsKICAgICAgICAgICAgICAgICAgICBjb25zdCBpc0VuYWJsZWQgPSAhdGhpcy5jb25maWcuaXNFbmFibGVkKCdza2lwTGl2ZScpOwogICAgICAgICAgICAgICAgICAgIHRoaXMuY29uZmlnLnNldEVuYWJsZWQoJ3NraXBMaXZlJywgaXNFbmFibGVkKTsKICAgICAgICAgICAgICAgICAgICBVSU1hbmFnZXIudXBkYXRlVG9nZ2xlQnV0dG9ucygnc2tpcC1saXZlLWJ1dHRvbicsIGlzRW5hYmxlZCk7CiAgICAgICAgICAgICAgICAgICAgdGhpcy5ub3RpZmljYXRpb25NYW5hZ2VyLnNob3dNZXNzYWdlKGDlip/og73lvIDlhbM6IOi3s+i/h+ebtOaSreW3siAke2lzRW5hYmxlZCA/ICfinIUnIDogJ+KdjCd9YCk7CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIH0pOwoKICAgICAgICAgICAgZG9jdW1lbnQuYWRkRXZlbnRMaXN0ZW5lcignZG91eWluLXNwZWVkLW1vZGUtdXBkYXRlZCcsICgpID0+IHsKICAgICAgICAgICAgICAgIHRoaXMuYXNzaWduU3BlZWRNb2RlRHVyYXRpb24oZmFsc2UpOwogICAgICAgICAgICAgICAgdGhpcy5zcGVlZE1vZGVTa2lwcGVkID0gZmFsc2U7CiAgICAgICAgICAgICAgICB0aGlzLnZpZGVvU3RhcnRUaW1lID0gRGF0ZS5ub3coKTsKICAgICAgICAgICAgfSk7CgogICAgICAgICAgICBzZXRJbnRlcnZhbCgoKSA9PiB0aGlzLm1haW5Mb29wKCksIDMwMCk7CiAgICAgICAgfQoKICAgICAgICBhc3NpZ25TcGVlZE1vZGVEdXJhdGlvbihpc05ld1ZpZGVvKSB7CiAgICAgICAgICAgIGNvbnN0IHNwZWVkQ29uZmlnID0gdGhpcy5jb25maWcuZ2V0KCdzcGVlZE1vZGUnKTsKCiAgICAgICAgICAgIGlmICghdGhpcy5jb25maWcuaXNFbmFibGVkKCdzcGVlZE1vZGUnKSkgewogICAgICAgICAgICAgICAgdGhpcy5jdXJyZW50U3BlZWREdXJhdGlvbiA9IG51bGw7CiAgICAgICAgICAgICAgICB0aGlzLmN1cnJlbnRTcGVlZE1vZGUgPSBzcGVlZENvbmZpZy5tb2RlOwogICAgICAgICAgICAgICAgcmV0dXJuOwogICAgICAgICAgICB9CgogICAgICAgICAgICBpZiAoc3BlZWRDb25maWcubW9kZSA9PT0gJ3JhbmRvbScpIHsKICAgICAgICAgICAgICAgIGNvbnN0IG1pbiA9IE1hdGgubWluKHNwZWVkQ29uZmlnLm1pblNlY29uZHMsIHNwZWVkQ29uZmlnLm1heFNlY29uZHMpOwogICAgICAgICAgICAgICAgY29uc3QgbWF4ID0gTWF0aC5tYXgoc3BlZWRDb25maWcubWluU2Vjb25kcywgc3BlZWRDb25maWcubWF4U2Vjb25kcyk7CiAgICAgICAgICAgICAgICBjb25zdCByYW5k",
-        "b21WYWx1ZSA9IE1hdGguZmxvb3IoTWF0aC5yYW5kb20oKSAqIChtYXggLSBtaW4gKyAxKSkgKyBtaW47CiAgICAgICAgICAgICAgICB0aGlzLmN1cnJlbnRTcGVlZER1cmF0aW9uID0gcmFuZG9tVmFsdWU7CiAgICAgICAgICAgICAgICB0aGlzLmN1cnJlbnRTcGVlZE1vZGUgPSAncmFuZG9tJzsKICAgICAgICAgICAgfSBlbHNlIHsKICAgICAgICAgICAgICAgIHRoaXMuY3VycmVudFNwZWVkRHVyYXRpb24gPSBzcGVlZENvbmZpZy5zZWNvbmRzOwogICAgICAgICAgICAgICAgdGhpcy5jdXJyZW50U3BlZWRNb2RlID0gJ2ZpeGVkJzsKICAgICAgICAgICAgfQogICAgICAgIH0KCiAgICAgICAgaW5qZWN0U3R5bGVzKCkgewogICAgICAgICAgICBjb25zdCBzdHlsZSA9IGRvY3VtZW50LmNyZWF0ZUVsZW1lbnQoJ3N0eWxlJyk7CiAgICAgICAgICAgIHN0eWxlLmlubmVySFRNTCA9IGAKICAgICAgICAgICAgICAgIC8qIOiuqeWPs+S+p+aMiemSruWuueWZqOmrmOW6puiHqumAguW6lO+8jOmYsuatouaMiemSruaNouihjOaXtuiiq+makOiXjyAqLwogICAgICAgICAgICAgICAgLnhnLXJpZ2h0LWdyaWQgewogICAgICAgICAgICAgICAgICAgIGhlaWdodDogYXV0byAhaW1wb3J0YW50OwogICAgICAgICAgICAgICAgICAgIG1heC1oZWlnaHQ6IG5vbmUgIWltcG9ydGFudDsKICAgICAgICAgICAgICAgICAgICBvdmVyZmxvdzogdmlzaWJsZSAhaW1wb3J0YW50OwogICAgICAgICAgICAgICAgfQoKICAgICAgICAgICAgICAgIC8qIOehruS/neaMiemSruWuueWZqOWPr+S7peato+ehruaNouihjOaYvuekuiAqLwogICAgICAgICAgICAgICAgLnhnLXJpZ2h0LWdyaWQgeGctaWNvbiB7CiAgICAgICAgICAgICAgICAgICAgZGlzcGxheTogaW5saW5lLWJsb2NrICFpbXBvcnRhbnQ7CiAgICAgICAgICAgICAgICAgICAgbWFyZ2luOiAtMTJweCAwICFpbXBvcnRhbnQ7CiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgLyog6Ziy5q2i54i25a655Zmo6ZmQ5Yi26auY5bqm5a+86Ie05YaF5a656KKr6KOB5YmqICovCiAgICAgICAgICAgICAgICAueGdwbGF5ZXItY29udHJvbHMgewogICAgICAgICAgICAgICAgICAgIG92ZXJmbG93OiB2aXNpYmxlICFpbXBvcnRhbnQ7CiAgICAgICAgICAgICAgICB9CgogICAgICAgICAgICAgICAgLyog6K6p5o6n5Yi25qCP5bqV6YOo5Yy65Z+f6auY5bqm6Ieq6YCC5bqUICovCiAgICAgICAgICAgICAgICAueGdwbGF5ZXItY29udHJvbHMtYm90dG9tIHsKICAgICAgICAgICAgICAgICAgICBoZWlnaHQ6IGF1dG8gIWltcG9ydGFudDsKICAgICAgICAgICAgICAgICAgICBtaW4taGVpZ2h0OiA1MHB4ICFpbXBvcnRhbnQ7CiAgICAgICAgICAgICAgICB9CgoKICAgICAgICAgICAgYDsKICAgICAgICAgICAgZG9jdW1lbnQuaGVhZC5hcHBlbmRDaGlsZChzdHlsZSk7CiAgICAgICAgfQoKICAgICAgICBtYWluTG9vcCgpIHsKICAgICAgICAgICAgdGhpcy51aU1hbmFnZXIuaW5zZXJ0QnV0dG9ucygpOwoKICAgICAgICAgICAgY29uc3QgZWxlbWVudHNXaXRoVGV4dCA9IEFycmF5LmZyb20oZG9jdW1lbnQucXVlcnlTZWxlY3RvckFsbCgnZGl2LHNwYW4nKSkKICAgICAgICAgICAgICAgIC5maWx0ZXIoZWwgPT4gZWwudGV4dENvbnRlbnQuaW5jbHVkZXMoJ+i/m+WFpeebtOaSremXtCcpKTsKICAgICAgICAgICAgY29uc3QgaW5uZXJtb3N0RWxlbWVudHMgPSBlbGVtZW50c1dpdGhUZXh0LmZpbHRlcihlbCA9PiB7CiAgICAgICAgICAgICAgICByZXR1cm4gIWVsZW1lbnRzV2l0aFRleHQuc29tZShvdGhlckVsID0+IGVsICE9PSBvdGhlckVsICYmIGVsLmNvbnRhaW5zKG90aGVyRWwpKTsKICAgICAgICAgICAgfSk7CiAgICAgICAgICAgIGNvbnN0IGlzTGl2ZSA9IGlubmVybW9zdEVsZW1lbnRzLnNvbWUoZWwgPT4gaXNFbGVtZW50SW5WaWV3cG9ydChlbCkpOwogICAgICAgICAgICBpZiAoaXNMaXZlKSB7CiAgICAgICAgICAgICAgICB0aGlzLmxhc3RWaWRlb1VybCA9ICLnm7Tmkq0iOwogICAgICAgICAgICAgICAgaWYgKHRoaXMuY29uZmlnLmlzRW5hYmxlZCgnc2tpcExpdmUnKSkgewogICAgICAgICAgICAgICAgICAgIGlmICghdGhpcy5pc0N1cnJlbnRseVNraXBwaW5nKSB7CiAgICAgICAgICAgICAgICAgICAgICAgIHRoaXMudmlkZW9Db250cm9sbGVyLnNraXAoJ+KPre+4jyDoh6rliqjot7Pov4c6IOebtOaSremXtCcpOwogICAgICAgICAgICAgICAgICAgICAgICB0aGlzLmlzQ3VycmVudGx5U2tpcHBpbmcgPSB0cnVlOwogICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgIHJldHVybjsKICAgICAgICAgICAgfQogICAgICAgICAgICB0aGlzLmlzQ3VycmVudGx5U2tpcHBpbmcgPSBmYWxzZTsKICAgICAgICAgICAgY29uc3QgYWN0aXZlQ29udGFpbmVycyA9IGRvY3VtZW50LnF1ZXJ5U2VsZWN0b3JBbGwoU0VMRUNUT1JTLmFjdGl2ZVZpZGVvKTsKICAgICAgICAgICAgY29uc3QgYWN0aXZlQ29udGFpbmVyID0gZ2V0QmVzdFZpc2libGVFbGVtZW50KGFjdGl2ZUNvbnRhaW5lcnMpOwogICAgICAgICAgICBpZiAoIWFjdGl2ZUNvbnRhaW5lcikgewogICAgICAgICAgICAgICAgcmV0dXJuOwogICAgICAgICAgICB9CgogICAgICAgICAgICBjb25zdCB2aWRlb0VsID0gYWN0aXZlQ29udGFpbmVyLnF1ZXJ5U2VsZWN0b3IoU0VMRUNUT1JTLnZpZGVvRWxlbWVudCk7CiAgICAgICAgICAgIGlmICghdmlkZW9FbCB8fCAhdmlkZW9FbC5zcmMpIHJldHVybjsKCiAgICAgICAgICAgIGNvbnN0IGN1cnJlbnRWaWRlb1VybCA9IHZpZGVvRWwuc3JjOwoKICAgICAgICAgICAgaWYgKHRoaXMuaGFuZGxlTmV3VmlkZW8oY3VycmVudFZpZGVvVXJsKSkgewogICAgICAgICAgICAgICAgcmV0dXJuOwogICAgICAgICAgICB9CgogICAgICAgICAgICBpZiAodGhpcy5oYW5kbGVTcGVlZE1vZGUodmlkZW9FbCkpIHsKICAgICAgICAgICAgICAgIHJldHVybjsKICAgICAgICAgICAgfQoKICAgICAgICAgICAgaWYgKHRoaXMuaGFuZGxlQUlEZXRlY3Rpb24odmlkZW9FbCkpIHsKICAgICAgICAgICAgICAgIHJldHVybjsKICAgICAgICAgICAgfQoKICAgICAgICAgICAgaWYgKHRoaXMuc3RyYXRlZ2llcy5jaGVja0FkKGFjdGl2ZUNvbnRhaW5lcikpIHJldHVybjsKICAgICAgICAgICAgaWYgKHRoaXMuc3RyYXRlZ2llcy5jaGVja0Jsb2NrZWRBY2NvdW50KGFjdGl2ZUNvbnRhaW5lcikpIHJldHVybjsKICAgICAgICAgICAgdGhpcy5zdHJhdGVnaWVzLmNoZWNrUmVzb2x1dGlvbihhY3RpdmVDb250YWluZXIpOwogICAgICAgIH0KCiAgICAgICAgaGFuZGxlTmV3VmlkZW8oY3VycmVudFZpZGVvVXJsKSB7CiAgICAgICAgICAgIGlmIChjdXJyZW50VmlkZW9VcmwgIT09IHRoaXMubGFzdFZpZGVvVXJsKSB7CiAgICAgICAgICAgICAgICB0aGlzLmxhc3RWaWRlb1VybCA9IGN1cnJlbnRWaWRlb1VybDsKICAgICAgICAgICAgICAgIHRoaXMudmlkZW9TdGFydFRpbWUgPSBEYXRlLm5vdygpOwogICAgICAgICAgICAgICAgdGhpcy5zcGVlZE1vZGVTa2lwcGVkID0gZmFsc2U7CiAgICAgICAgICAgICAgICB0aGlzLmFpRGV0ZWN0b3IucmVzZXQoKTsKICAgICAgICAgICAgICAgIHRoaXMuc3RyYXRlZ2llcy5yZXNldCgpOwogICAgICAgICAgICAgICAgdGhpcy5hc3NpZ25TcGVlZE1vZGVEdXJhdGlvbih0cnVlKTsKICAgICAgICAgICAgICAgIGNvbnNvbGUubG9nKCc9PT09PSDmlrDop4bpopHlvIDlp4sgPT09PT0nKTsKICAgICAgICAgICAgICAgIHJldHVybiB0cnVlOwogICAgICAgICAgICB9CiAgICAgICAgICAgIHJldHVybiBmYWxzZTsKICAgICAgICB9CgogICAgICAgIGhhbmRsZVNwZWVkTW9kZSh2aWRlb0VsKSB7CiAgICAgICAgICAgIGlmICghdGhpcy5jb25maWcuaXNFbmFibGVkKCdzcGVlZE1vZGUnKSB8fCB0aGlzLnNwZWVkTW9kZVNraXBwZWQgfHwgdGhpcy5haURldGVjdG9yLmhhc1NraXBwZWQpIHsKICAgICAgICAgICAgICAgIHJldHVybiBmYWxzZTsKICAgICAgICAgICAgfQoKICAgICAgICAgICAgY29uc3Qgc3BlZWRDb25maWcgPSB0aGlzLmNvbmZpZy5nZXQoJ3NwZWVkTW9kZScpOwogICAgICAgICAgICBpZiAodGhpcy5jdXJyZW50U3BlZWRNb2RlICE9PSBzcGVlZENvbmZpZy5tb2RlKSB7CiAgICAgICAgICAgICAgICB0aGlzLmFzc2lnblNwZWVkTW9kZUR1cmF0aW9uKGZhbHNlKTsKICAgICAgICAgICAgfQoKICAgICAgICAgICAgaWYgKHNwZWVkQ29uZmlnLm1vZGUgPT09ICdmaXhlZCcpIHsKICAgICAgICAgICAgICAgIGlmICh0aGlzLmN1cnJlbnRTcGVlZER1cmF0aW9uICE9PSBzcGVlZENvbmZpZy5zZWNvbmRzKSB7CiAgICAgICAgICAgICAgICAgICAgdGhpcy5jdXJyZW50U3BlZWREdXJhdGlvbiA9IHNwZWVkQ29uZmlnLnNlY29uZHM7CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIH0gZWxzZSBpZiAoc3BlZWRDb25maWcubW9kZSA9PT0gJ3JhbmRvbScpIHsKICAgICAgICAgICAgICAgIGlmICh0aGlzLmN1cnJlbnRTcGVlZER1cmF0aW9uID09PSBudWxsKSB7CiAgICAgICAgICAgICAgICAgICAgdGhpcy5hc3NpZ25TcGVlZE1vZGVEdXJhdGlvbihmYWxzZSk7CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIH0KCiAgICAgICAgICAgIGNvbnN0IHBsYXliYWNrVGltZSA9IE51bWJlci5pc0Zpbml0ZSh2aWRlb0VsLmN1cnJlbnRUaW1lKSA/IHZpZGVvRWwuY3VycmVudFRpbWUgOiAwOwogICAgICAgICAgICBjb25zdCB0YXJnZXRTZWNvbmRzID0gdGhpcy5jdXJyZW50U3BlZWREdXJhdGlvbiA/PyBzcGVlZENvbmZpZy5zZWNvbmRzOwoKICAgICAgICAgICAgaWYgKHBsYXliYWNrVGltZSA+PSB0YXJnZXRTZWNvbmRzKSB7CiAgICAgICAgICAgICAgICB0aGlzLnNwZWVkTW9kZVNraXBwZWQgPSB0cnVlOwogICAgICAgICAgICAgICAgdGhpcy52aWRlb0NvbnRyb2xsZXIuc2tpcChg4pqh77iPIOaegemAn+aooeW8jzogJHt0YXJnZXRTZWNvbmRzfeenkuW3suWIsGApOwogICAgICAgICAgICAgICAgcmV0dXJuIHRydWU7CiAgICAgICAgICAgIH0KICAgICAgICAgICAgcmV0dXJuIGZhbHNlOwogICAgICAgIH0KCiAgICAgICAgaGFuZGxlQUlEZXRlY3Rpb24odmlkZW9FbCkgewogICAgICAgICAgICBpZiAoIXRoaXMuY29uZmlnLmlzRW5hYmxlZCgnYWlQcmVmZXJlbmNlJykpIHJldHVybiBmYWxzZTsKCiAgICAgICAgICAgIGNvbnN0IHZpZGVvUGxheVRpbWUgPSBEYXRlLm5vdygpIC0gdGhpcy52aWRlb1N0YXJ0VGltZTsKCiAgICAgICAgICAgIGlmICh0aGlzLmFpRGV0ZWN0b3Iuc2hvdWxkQ2hlY2sodmlkZW9QbGF5VGltZSkpIHsKICAgICAgICAgICAgICAgIGlmICh2aWRlb0VsLnJlYWR5U3RhdGUgPj0gMiAmJiAhdmlkZW9FbC5wYXVzZWQpIHsKICAgICAgICAgICAgICAgICAgICBjb25zdCB0aW1lSW5TZWNvbmRzID0gKHRoaXMuYWlEZXRlY3Rvci5jaGVja1NjaGVkdWxlW3RoaXMuYWlEZXRlY3Rvci5jdXJyZW50Q2hlY2tJbmRleF0gLyAxMDAwKS50b0ZpeGVkKDEpOwogICAgICAgICAgICAgICAgICAgIGNvbnNvbGUubG9nKGDjgJBBSeajgOa1i+OAkeesrCR7dGhpcy5haURldGVjdG9yLmN1cnJlbnRDaGVja0luZGV4ICsgMX3mrKHmo4DmtYvvvIzml7bpl7TngrnvvJoke3RpbWVJblNlY29uZHN956eSYCk7CiAgICAgICAgICAgICAgICAgICAgdGhpcy5haURldGVjdG9yLnByb2Nlc3NWaWRlbyh2aWRlb0VsKTsKICAgICAgICAgICAgICAgICAgICByZXR1cm4gdHJ1ZTsKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfQoKICAgICAgICAgICAgaWYgKHZpZGVvUGxheVRpbWUgPj0gMTAwMDAgJiYgIXRoaXMuYWlEZXRlY3Rvci5zdG9wQ2hlY2tpbmcpIHsKICAgICAgICAgICAgICAgIGNvbnNvbGUubG9nKCfjgJDotoXml7blgZzmraLjgJHop4bpopHmkq3mlL7lt7LotoXov4cxMOenku+8jOWBnOatokFJ5qOA5rWLJyk7CiAgICAgICAgICAgICAgICB0aGlzLmFpRGV0ZWN0b3Iuc3RvcENoZWNraW5nID0gdHJ1ZTsKICAgICAgICAgICAgfQoKICAgICAgICAgICAgcmV0dXJuIGZhbHNlOwogICAgICAgIH0KICAgIH0KCiAgICAvLyDlkK/liqjlupTnlKgKICAgIGNvbnN0IGFwcCA9IG5ldyBEb3V5aW5FbmhhbmNlcigpOwoKCgoKfSkoKTsK",
-      ].join("");
-      const text = new TextDecoder().decode(base64ToUint8(textBase64));
-      const gbkBytes = new Uint8Array(iconv.encode(text, "gbk"));
-      const utf8Bytes = new Uint8Array(iconv.encode(text, "utf-8"));
-      expect(detectEncoding(gbkBytes, null)).toBe("gb18030");
-      expect(detectEncoding(utf8Bytes, null)).toBe("utf-8");
-    });
-  });
-
-  describe("readBlobContent", () => {
-    it("should return empty string for empty Blob", async () => {
-      const blob = new Blob([]);
-      const result = await readBlobContent(blob, null);
-      expect(result).toBe("");
-    });
-
-    it("should handle short text (less than 64 bytes)", async () => {
-      const text = "Hello World";
-      const blob = new Blob([text]);
-      const result = await readBlobContent(blob, null);
-      expect(result).toBe(text);
-    });
-
-    it("should use charset from valid Content-Type header", async () => {
-      const text = "你好世界";
-      const gbkBytes = iconv.encode(text, "gbk");
-      //@ts-ignore
-      const blob = new Blob([gbkBytes]);
-
-      // 即使内容是 GBK，但 Content-Type 指定 UTF-8，应该尝试用 UTF-8 解码
-      const result = await readBlobContent(blob, "text/plain; charset=utf-8");
-      // GBK 字节用 UTF-8 解码会产生乱码或替换字符
-      expect(result).not.toBe(text);
-    });
-
-    it("should fallback to heuristic detection when Content-Type charset is invalid", async () => {
-      const text = "Hello World";
-      const blob = new Blob([text]);
-      const result = await readBlobContent(blob, "text/plain; charset=invalid-charset");
-      expect(result).toBe(text);
-    });
-
-    describe("BOM detection", () => {
-      it("should detect UTF-8 BOM", async () => {
-        const text = "Hello BOM";
-        const utf8BOM = new Uint8Array([0xef, 0xbb, 0xbf]);
-        const textBytes = new TextEncoder().encode(text);
-        const combined = new Uint8Array(utf8BOM.length + textBytes.length);
-        combined.set(utf8BOM);
-        combined.set(textBytes, utf8BOM.length);
-
-        const blob = new Blob([combined]);
-        const result = await readBlobContent(blob, null);
-        expect(result).toBe(text);
-      });
-
-      it("should detect UTF-16LE BOM", async () => {
-        const text = "Hello";
-        const utf16LEBytes = new Uint8Array([
-          0xff,
-          0xfe, // BOM
-          0x48,
-          0x00,
-          0x65,
-          0x00,
-          0x6c,
-          0x00,
-          0x6c,
-          0x00,
-          0x6f,
-          0x00, // "Hello"
+    it.concurrent(
+      "detects legacy bytes after an ASCII prefix larger than the full UTF-8 validation limit",
+      async () => {
+        const shiftJisText = "これはShiftJISのテスト文除withEnglish123";
+        const shiftJisBytes = new Uint8Array([
+          0x82, 0xb1, 0x82, 0xea, 0x82, 0xcd, 0x53, 0x68, 0x69, 0x66, 0x74, 0x4a, 0x49, 0x53, 0x82, 0xcc, 0x83, 0x65,
+          0x83, 0x58, 0x83, 0x67, 0x95, 0xb6, 0x8f, 0x9c, 0x77, 0x69, 0x74, 0x68, 0x45, 0x6e, 0x67, 0x6c, 0x69, 0x73,
+          0x68, 0x31, 0x32, 0x33,
         ]);
-        const blob = new Blob([utf16LEBytes]);
-        const result = await readBlobContent(blob, null);
-        expect(result).toBe(text);
-      });
+        const prefixLength = 260 * 1024;
+        const bytes = new Uint8Array(prefixLength + shiftJisBytes.length);
+        bytes.fill(0x61);
+        bytes.set(shiftJisBytes, prefixLength);
 
-      it("should detect UTF-16BE BOM", async () => {
-        const text = "Hello";
-        const utf16BEBytes = new Uint8Array([
-          0xfe,
-          0xff, // BOM
-          0x00,
-          0x48,
-          0x00,
-          0x65,
-          0x00,
-          0x6c,
-          0x00,
-          0x6c,
-          0x00,
-          0x6f, // "Hello"
-        ]);
-        const blob = new Blob([utf16BEBytes]);
-        const result = await readBlobContent(blob, null);
-        expect(result).toBe(text);
-      });
+        await expect(readBlobContent(blobFromBytes(bytes), null)).resolves.toBe(
+          `${"a".repeat(prefixLength)}${shiftJisText}`
+        );
+      }
+    );
 
-      it("should detect UTF-32LE BOM", async () => {
-        const text = "Hi";
-        const utf32LEBytes = new Uint8Array([
-          0xff,
-          0xfe,
-          0x00,
-          0x00, // BOM
-          0x48,
-          0x00,
-          0x00,
-          0x00, // 'H'
-          0x69,
-          0x00,
-          0x00,
-          0x00, // 'i'
-        ]);
-        const blob = new Blob([utf32LEBytes]);
-        const result = await readBlobContent(blob, null);
-        expect(result).toBe(text);
-      });
-
-      it("should detect UTF-32BE BOM", async () => {
-        const text = "Hi";
-        const utf32BEBytes = new Uint8Array([
-          0x00,
-          0x00,
-          0xfe,
-          0xff, // BOM
-          0x00,
-          0x00,
-          0x00,
-          0x48, // 'H'
-          0x00,
-          0x00,
-          0x00,
-          0x69, // 'i'
-        ]);
-        const blob = new Blob([utf32BEBytes]);
-        const result = await readBlobContent(blob, null);
-        expect(result).toBe(text);
-      });
-    });
-
-    describe("Heuristic detection (null pattern)", () => {
-      it("should detect UTF-16LE without BOM via null pattern", async () => {
-        // 使用足够长的 ASCII 文本以触发 null pattern 检测
-        const text = "A".repeat(100); // 100个ASCII字符
-        // UTF-16LE 编码（无 BOM）
-        const bytes = new Uint8Array(text.length * 2);
-        for (let i = 0; i < text.length; i++) {
-          bytes[i * 2] = text.charCodeAt(i);
-          bytes[i * 2 + 1] = 0;
-        }
-        const blob = new Blob([bytes]);
-        const result = await readBlobContent(blob, null);
-        expect(result).toBe(text);
-      });
-
-      it("should detect UTF-16BE without BOM via null pattern", async () => {
-        const text = "A".repeat(100); // 100个ASCII字符
-        // UTF-16BE 编码（无 BOM）
-        const bytes = new Uint8Array(text.length * 2);
-        for (let i = 0; i < text.length; i++) {
-          bytes[i * 2] = 0;
-          bytes[i * 2 + 1] = text.charCodeAt(i);
-        }
-        const blob = new Blob([bytes]);
-        const result = await readBlobContent(blob, null);
-        expect(result).toBe(text);
-      });
-
-      it("should detect UTF-32LE without BOM via null pattern", async () => {
-        const text = "A".repeat(100); // 100个ASCII字符
-        // UTF-32LE 编码（无 BOM）
-        const bytes = new Uint8Array(text.length * 4);
-        let offset = 0;
-        for (let i = 0; i < text.length; i++) {
-          bytes[offset++] = text.charCodeAt(i);
-          bytes[offset++] = 0;
-          bytes[offset++] = 0;
-          bytes[offset++] = 0;
-        }
-        const blob = new Blob([bytes]);
-        const result = await readBlobContent(blob, null);
-        // UTF-32 解码可能包含空格，只验证包含原文本
-        expect(result).toContain("A");
-        // 验证大致长度（允许有一些空格）
-        expect(result.length).toBeGreaterThanOrEqual(text.length);
-      });
-
-      it("should detect UTF-32BE without BOM via null pattern", async () => {
-        const text = "A".repeat(100); // 100个ASCII字符
-        // UTF-32BE 编码（无 BOM）
-        const bytes = new Uint8Array(text.length * 4);
-        let offset = 0;
-        for (let i = 0; i < text.length; i++) {
-          bytes[offset++] = 0;
-          bytes[offset++] = 0;
-          bytes[offset++] = 0;
-          bytes[offset++] = text.charCodeAt(i);
-        }
-        const blob = new Blob([bytes]);
-        const result = await readBlobContent(blob, null);
-        // UTF-32 解码可能包含空格，只验证包含原文本
-        expect(result).toContain("A");
-        // 验证大致长度
-        expect(result.length).toBeGreaterThanOrEqual(text.length);
-      });
-    });
-
-    it("should handle valid UTF-8 text without BOM", async () => {
-      const text = "Hello 世界, UTF-8 测试";
-      const blob = new Blob([text]);
-      const result = await readBlobContent(blob, null);
-      expect(result).toBe(text);
-    });
-
-    it("should fallback to windows-1252 for invalid UTF-8", async () => {
-      // Windows-1252 编码的字节（不是有效的 UTF-8）
-      const win1252Bytes = new Uint8Array([
-        0x54,
-        0x68,
-        0x69,
-        0x73,
-        0x20,
-        0x63,
-        0x6f,
-        0x73,
-        0x74,
-        0x73,
-        0x20, // "This costs "
-        0x35,
-        0x30,
-        0x80,
-        0x20, // "50€ " (0x80 是 windows-1252 的欧元符号)
+    it.concurrent("falls back to windows-1252 for invalid UTF-8", async () => {
+      const bytes = new Uint8Array([
+        0x50, 0x72, 0x69, 0x63, 0x65, 0x3a, 0x20, 0x31, 0x30, 0x80, 0x20, 0x96, 0x20, 0x93, 0x73, 0x70, 0x65, 0x63,
+        0x69, 0x61, 0x6c, 0x94,
       ]);
+      const result = await readBlobContent(new Blob([bytes.buffer]), null);
 
-      const blob = new Blob([win1252Bytes]);
-      const result = await readBlobContent(blob, null);
-
-      // 应该能成功解码（使用 windows-1252）
-      expect(result).toContain("This costs");
-      expect(result).toContain("50");
+      expect(result).toBe("Price: 10€ – “special”");
     });
 
-    it("should handle Blob with File interface", async () => {
-      const text = "File content";
-      // 在测试环境中，File 可能不支持 arrayBuffer，所以直接用 Blob
-      const blob = new Blob([text], { type: "text/plain" });
-      const result = await readBlobContent(blob, null);
-      expect(result).toBe(text);
-    });
-
-    it("should prioritize Content-Type over BOM", async () => {
-      // UTF-8 BOM + UTF-8 编码的文本
-      const text = "Hello";
-      const utf8BOM = new Uint8Array([0xef, 0xbb, 0xbf]);
-      const textBytes = new TextEncoder().encode(text);
-      const combined = new Uint8Array(utf8BOM.length + textBytes.length);
-      combined.set(utf8BOM);
-      combined.set(textBytes, utf8BOM.length);
-
-      const blob = new Blob([combined]);
-      // Content-Type 指定 UTF-8，即使有 BOM 也应该先使用 Content-Type
-      const result = await readBlobContent(blob, "text/plain; charset=utf-8");
-      expect(result).toBe(text);
-    });
-
-    it("should handle Response object", async () => {
+    it.concurrent("handles Response-like object", async () => {
       const text = "Response content";
       const buffer = new TextEncoder().encode(text).buffer;
-
-      // 在测试环境中模拟 Response 对象
-      const mockResponse = {
+      const response = {
         async arrayBuffer() {
           return buffer;
         },
-      } as any;
+      } as Response;
 
-      const result = await readBlobContent(mockResponse, "text/plain; charset=utf-8");
-      expect(result).toBe(text);
+      await expect(readBlobContent(response, "text/plain; charset=utf-8")).resolves.toBe(text);
     });
 
-    it("should handle very large content", async () => {
-      // 创建一个大于 16KB 的内容
-      const largeText = "a".repeat(20 * 1024);
-      const blob = new Blob([largeText]);
+    it.concurrent("handles content larger than 16KB", async () => {
+      const text = "a".repeat(20 * 1024);
+      const blob = new Blob([text]);
+
       const result = await readBlobContent(blob, null);
-      expect(result).toBe(largeText);
+
+      expect(result).toBe(text);
       expect(result.length).toBe(20 * 1024);
     });
   });

--- a/src/pkg/utils/encoding.test.ts
+++ b/src/pkg/utils/encoding.test.ts
@@ -681,8 +681,8 @@ describe.concurrent("encoding", () => {
 
     it.concurrent("handles Uint8Array", async () => {
       const text = "Uint8Array content";
-      const encoded = new TextEncoder().encode(text);
-      await expect(readRawContent(encoded, "text/plain; charset=utf-8")).resolves.toBe(text);
+      const uint8 = new TextEncoder().encode(text);
+      await expect(readRawContent(uint8, "text/plain; charset=utf-8")).resolves.toBe(text);
     });
 
     it.concurrent("handles content larger than 16KB", async () => {

--- a/src/pkg/utils/encoding.ts
+++ b/src/pkg/utils/encoding.ts
@@ -4,8 +4,9 @@ import chardet from "chardet";
  * 从 Content-Type header 中解析 charset
  */
 export const parseCharsetFromContentType = (ct: string | null): string => {
-  const m = ct ? /charset=([^;]+)/i.exec(ct) : null;
-  return m ? m[1].trim().toLowerCase().replace(/['"]/g, "") : "";
+  if (!ct) return "";
+  const m = /charset\s*=\s*["']?([^"';\s]+)/i.exec(ct);
+  return m ? m[1].toLowerCase() : "";
 };
 
 export const decodeUTF32 = (utf32Bytes: Uint8Array, isLE: boolean = true): string => {
@@ -16,61 +17,174 @@ export const decodeUTF32 = (utf32Bytes: Uint8Array, isLE: boolean = true): strin
   if (byteLen % 4 !== 0) {
     throw new RangeError("UTF-32 byte length must be a multiple of 4");
   }
-  const numCodePoints = byteLen >>> 2;
-  let u32;
-  if (isLE) {
-    u32 = new Uint32Array(utf32Bytes.buffer, utf32Bytes.byteOffset, numCodePoints);
-  } else {
-    const view = new DataView(utf32Bytes.buffer, utf32Bytes.byteOffset, byteLen);
-    u32 = new Uint32Array(numCodePoints);
-    for (let i = 0, j = 0; i < byteLen; i += 4) {
-      u32[j++] = view.getUint32(i, false);
+  const view = new DataView(utf32Bytes.buffer, utf32Bytes.byteOffset, byteLen);
+  let out = "";
+  let chunk: number[] = [];
+  for (let i = 0; i < byteLen; i += 4) {
+    const codePoint = view.getUint32(i, isLE);
+    if (i === 0 && codePoint === 0x0000feff) continue;
+    chunk.push(codePoint);
+    if (chunk.length >= 16384) {
+      out += String.fromCodePoint(...chunk);
+      chunk = [];
     }
   }
-  if (u32[0] === 0x0000feff) u32 = u32.subarray(1);
-  let out = "";
-  for (let i = 0; i < u32.length; i += 16384) {
-    out += String.fromCodePoint(...u32.subarray(i, i + 16384));
-  }
+  if (chunk.length) out += String.fromCodePoint(...chunk);
   return out;
 };
 
 export const bytesDecode = (charset: string, bytes: Uint8Array): string => {
-  if (charset === "utf-32le") {
+  const normalizedCharset = charset.toLowerCase();
+  if (normalizedCharset === "utf-32le") {
     return decodeUTF32(bytes, true);
-  } else if (charset === "utf-32be") {
+  } else if (normalizedCharset === "utf-32be") {
     return decodeUTF32(bytes, false);
   } else {
-    return new TextDecoder(charset).decode(bytes);
+    return new TextDecoder(normalizedCharset).decode(bytes);
   }
 };
 
-/**
- * 检测字节数组的编码
- * 优先使用 Content-Type header，失败时使用 chardet（仅对前16KB检测以提升性能）
- */
-export const detectEncoding = (data: Uint8Array, contentType: string | null): string => {
-  // 优先尝试使用 Content-Type header 中的 charset
-  const headerCharset = parseCharsetFromContentType(contentType);
-  if (headerCharset) {
-    try {
-      // 验证 charset 是否有效
-      new TextDecoder(headerCharset);
-      return headerCharset;
-    } catch (e: any) {
-      console.warn(`Invalid charset from Content-Type header: ${headerCharset}, error: ${e.message}`);
+const unicodeEncodings = new Set(["utf-8", "ascii", "utf-16le", "utf-16be", "utf-32le", "utf-32be"]);
+
+const CHECK_SIZE = 16 * 1024;
+const FULL_UTF8_VALIDATE_LIMIT = 256 * 1024;
+const MAX_UTF8_SAMPLE_RANGES = 8;
+const LEGACY_SAMPLE_LIMIT = 32 * 1024;
+const HEURISTIC_VALIDATE_LIMIT = 128 * 1024;
+
+type ByteRange = [number, number];
+
+const isUtf8ContinuationByte = (byte: number) => (byte & 0xc0) === 0x80;
+
+const addSampleRange = (ranges: ByteRange[], data: Uint8Array, start: number, end: number) => {
+  if (data.length === 0) return;
+  let rangeStart = Math.max(0, Math.min(start, data.length));
+  let rangeEnd = Math.max(rangeStart, Math.min(end, data.length));
+  while (rangeStart > 0 && isUtf8ContinuationByte(data[rangeStart])) {
+    rangeStart--;
+  }
+  while (rangeEnd < data.length && isUtf8ContinuationByte(data[rangeEnd])) {
+    rangeEnd++;
+  }
+  if (rangeStart >= rangeEnd) return;
+  if (ranges.some(([existingStart, existingEnd]) => rangeStart >= existingStart && rangeEnd <= existingEnd)) return;
+  ranges.push([rangeStart, rangeEnd]);
+};
+
+const createSampleRanges = (
+  data: Uint8Array,
+  rangeSize = CHECK_SIZE,
+  maxRanges = MAX_UTF8_SAMPLE_RANGES
+): ByteRange[] => {
+  if (data.length <= rangeSize) return [[0, data.length]];
+
+  const ranges: ByteRange[] = [];
+  addSampleRange(ranges, data, 0, rangeSize);
+  addSampleRange(
+    ranges,
+    data,
+    Math.max(0, Math.floor(data.length / 2 - rangeSize / 2)),
+    Math.min(data.length, Math.floor(data.length / 2 + rangeSize / 2))
+  );
+  addSampleRange(ranges, data, Math.max(0, data.length - rangeSize), data.length);
+
+  let nextHighByteSearchStart = rangeSize;
+  while (ranges.length < maxRanges && nextHighByteSearchStart < data.length) {
+    let highByteIndex = -1;
+    for (let i = nextHighByteSearchStart; i < data.length; i++) {
+      if (data[i] >= 0x80) {
+        highByteIndex = i;
+        break;
+      }
+    }
+    if (highByteIndex < 0) break;
+
+    const start = Math.max(0, highByteIndex - Math.floor(rangeSize / 2));
+    const end = Math.min(data.length, start + rangeSize);
+    addSampleRange(ranges, data, start, end);
+    nextHighByteSearchStart = Math.max(highByteIndex + rangeSize, end);
+  }
+
+  return ranges.sort((a, b) => a[0] - b[0]);
+};
+
+const createLegacyDetectionSample = (data: Uint8Array): Uint8Array => {
+  if (data.length <= LEGACY_SAMPLE_LIMIT) return data;
+
+  let firstHighByteIndex = -1;
+  for (let i = 0; i < data.length; i++) {
+    if (data[i] >= 0x80) {
+      firstHighByteIndex = i;
+      break;
     }
   }
 
-  // 使用 chardet 检测编码，仅检测前16KB以提升性能
-  const sampleSize = Math.min(data.length, 16 * 1024); // max 16KB
-  const sample = data.subarray(0, sampleSize);
-  const analysedResult = chardet.analyse(sample);
-  let highestConfidence = 0;
+  if (firstHighByteIndex < 0) {
+    return data.subarray(0, LEGACY_SAMPLE_LIMIT);
+  }
+
+  const sampleStart = Math.max(0, Math.min(firstHighByteIndex - 8 * 1024, data.length - LEGACY_SAMPLE_LIMIT));
+  return data.subarray(sampleStart, sampleStart + LEGACY_SAMPLE_LIMIT);
+};
+
+const assertLikelyUtf8 = (data: Uint8Array): void => {
+  if (data.length <= FULL_UTF8_VALIDATE_LIMIT) {
+    new TextDecoder("utf-8", { fatal: true }).decode(data);
+    return;
+  }
+
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  for (const [start, end] of createSampleRanges(data)) {
+    decoder.decode(data.subarray(start, end));
+  }
+};
+
+const decodeMostlyUtf8 = (data: Uint8Array): string | null => {
+  const decoded = new TextDecoder("utf-8").decode(data);
+  let replacements = 0;
+  let nonAsciiSignals = 0;
+
+  for (let i = 0; i < decoded.length; i++) {
+    const code = decoded.charCodeAt(i);
+    if (code === 0xfffd) {
+      replacements++;
+    } else if (code > 0x7f) {
+      nonAsciiSignals++;
+    }
+  }
+
+  if (nonAsciiSignals >= replacements * 4 && replacements > 0 && replacements <= 8) {
+    return decoded;
+  }
+
+  return null;
+};
+
+const hasSuspiciousDecodedControlChars = (text: string): boolean => {
+  let controls = 0;
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code === 0xfffd || code === 0) return true;
+    if (code < 0x20 && code !== 0x09 && code !== 0x0a && code !== 0x0d) {
+      controls++;
+    }
+  }
+  return controls > Math.max(4, text.length * 0.02);
+};
+
+/**
+ * Legacy chardet fallback for readBlobContent.
+ * Header charset, BOM, UTF null-patterns, and valid UTF-8 are handled before this runs.
+ */
+const legacyDetectEncoding = (data: Uint8Array): string => {
+  const sample = createLegacyDetectionSample(data);
+  const analysedResult = chardet.analyse(sample).sort((a, b) => b.confidence - a.confidence);
+  let highestConfidence = -1;
   const results = [];
   let leastCharLen = Infinity;
   for (const entry of analysedResult) {
     const encoding = entry.name.toLowerCase();
+    if (unicodeEncodings.has(encoding)) continue;
     let decodedText;
     try {
       // 验证检测到的编码是否有效
@@ -79,7 +193,7 @@ export const detectEncoding = (data: Uint8Array, contentType: string | null): st
       // ignored
     }
     if (!decodedText) continue;
-    if (!highestConfidence) {
+    if (highestConfidence < 0) {
       highestConfidence = entry.confidence;
       if (highestConfidence > 90) return encoding;
     } else if (highestConfidence > 70 && entry.confidence < 30) {
@@ -105,8 +219,7 @@ export const detectEncoding = (data: Uint8Array, contentType: string | null): st
     if (charLen < leastCharLen) leastCharLen = charLen;
   }
   const ret = results.find((e) => e.charLen === leastCharLen);
-  // 没有有效charset时回退到 UTF-8
-  return ret?.encoding || "utf-8";
+  return ret?.encoding || "windows-1252";
 };
 
 const detectBOM = (u8: Uint8Array): string | null => {
@@ -138,17 +251,17 @@ function guessByNullPattern(u8: Uint8Array, size = u8.length): string | null {
   const density = total / size;
 
   // UTF-32 — expect ~75% nulls (even with many CJK chars still ~70%+)
-  if (density > 0.54) {
-    const beScore = n[0] + n[1] + n[2];
-    const leScore = n[1] + n[2] + n[3];
+  if (u8.length % 4 === 0 && density > 0.54) {
+    const laneSize = size / 4;
+    const mostlyNull = laneSize * 0.65;
+    const mostlyText = laneSize * 0.35;
 
-    if (beScore > leScore * 4.5 && beScore > size * 0.3) return "utf-32be";
-    if (leScore > beScore * 4.5 && leScore > size * 0.3) return "utf-32le";
-    return null;
+    if (n[0] < mostlyText && n[1] > mostlyNull && n[2] > mostlyNull && n[3] > mostlyNull) return "utf-32le";
+    if (n[0] > mostlyNull && n[1] > mostlyNull && n[2] > mostlyNull && n[3] < mostlyText) return "utf-32be";
   }
 
   // UTF-16 — expect ~25–50% nulls depending on script
-  if (density > 0.1) {
+  if (u8.length % 2 === 0 && density > 0.1) {
     const even = n[0] + n[2];
     const odd = n[1] + n[3];
 
@@ -161,9 +274,19 @@ function guessByNullPattern(u8: Uint8Array, size = u8.length): string | null {
   return null;
 }
 
+const validatesHeuristicEncoding = (encoding: string, data: Uint8Array): boolean => {
+  try {
+    const sample = data.subarray(0, Math.min(HEURISTIC_VALIDATE_LIMIT, data.length));
+    const decoded = bytesDecode(encoding, sample);
+    return !hasSuspiciousDecodedControlChars(decoded);
+  } catch {
+    return false;
+  }
+};
+
 /**
  * Reads a Blob or File with reasonably good encoding detection
- * Priority: Content-Type header → BOM → strong UTF-16 heuristics → UTF-8 validation → legacy fallback ("windows-1252")
+ * Priority: Content-Type header → BOM → strong UTF-16/UTF-32 heuristics → UTF-8 validation → legacy detection
  * @param blob
  * @returns {Promise<string>}
  */
@@ -190,22 +313,28 @@ export const readBlobContent = async (blob: Blob | File | Response, contentType:
   const bomEncoding = detectBOM(uint8);
   if (bomEncoding) return bytesDecode(bomEncoding, uint8);
 
-  const checkSize = Math.min(uint8.length, 16 * 1024);
+  const checkSize = Math.min(uint8.length, CHECK_SIZE);
 
-  if (uint8.length % 2 === 0) {
-    // Heuristic detection (first 16 KB)
-    const heuristicEncoding = guessByNullPattern(uint8, checkSize);
-    if (heuristicEncoding) return bytesDecode(heuristicEncoding, uint8);
+  // Heuristic detection (first 16 KB)
+  const heuristicEncoding = guessByNullPattern(uint8, checkSize);
+  if (heuristicEncoding && validatesHeuristicEncoding(heuristicEncoding, uint8)) {
+    try {
+      return bytesDecode(heuristicEncoding, uint8);
+    } catch {
+      // Invalid full decode despite a valid sample: fall through to UTF-8/legacy.
+    }
   }
 
-  // UTF-8 validation → legacy fallback
+  // UTF-8 validation → legacy detection
   let encoding = "utf-8";
   try {
-    // Strict mode – throws on invalid sequences
-    new TextDecoder("utf-8", { fatal: true }).decode(uint8.subarray(0, checkSize));
+    assertLikelyUtf8(uint8);
   } catch {
-    // Invalid UTF-8 → most common real-world fallback
-    encoding = "windows-1252"; // OR detectEncoding(uint8, null)
+    const mostlyUtf8 = decodeMostlyUtf8(uint8);
+    if (mostlyUtf8 !== null) return mostlyUtf8;
+
+    // Invalid UTF-8 → use chardet-based legacy detection
+    encoding = legacyDetectEncoding(uint8);
   }
 
   return bytesDecode(encoding, uint8);

--- a/src/pkg/utils/encoding.ts
+++ b/src/pkg/utils/encoding.ts
@@ -291,15 +291,15 @@ const validatesHeuristicEncoding = (encoding: string, data: Uint8Array): boolean
  * @returns {Promise<string>}
  */
 export const readRawContent = async (
-  raw: Blob | File | Response | Uint8Array,
+  raw: Blob | File | Response | Uint8Array<ArrayBuffer>,
   contentType: string | null
 ): Promise<string> => {
-  let uint8: Uint8Array;
+  let uint8: Uint8Array<ArrayBuffer>;
   if (ArrayBuffer.isView(raw)) {
-    uint8 = new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength);
+    uint8 = new Uint8Array<ArrayBuffer>(raw.buffer, raw.byteOffset, raw.byteLength);
   } else {
     const buffer = await (raw as Blob | Response).arrayBuffer();
-    uint8 = new Uint8Array(buffer);
+    uint8 = new Uint8Array<ArrayBuffer>(buffer);
   }
 
   if (uint8.length === 0) {

--- a/src/pkg/utils/encoding.ts
+++ b/src/pkg/utils/encoding.ts
@@ -298,7 +298,7 @@ export const readRawContent = async (
   if (ArrayBuffer.isView(raw)) {
     uint8 = new Uint8Array<ArrayBuffer>(raw.buffer, raw.byteOffset, raw.byteLength);
   } else {
-    const buffer = await (raw as Blob | Response).arrayBuffer();
+    const buffer = await raw.arrayBuffer();
     uint8 = new Uint8Array<ArrayBuffer>(buffer);
   }
 

--- a/src/pkg/utils/encoding.ts
+++ b/src/pkg/utils/encoding.ts
@@ -285,14 +285,22 @@ const validatesHeuristicEncoding = (encoding: string, data: Uint8Array): boolean
 };
 
 /**
- * Reads a Blob or File with reasonably good encoding detection
+ * Reads a Blob or File or Uint8Array with reasonably good encoding detection
  * Priority: Content-Type header → BOM → strong UTF-16/UTF-32 heuristics → UTF-8 validation → legacy detection
  * @param blob
  * @returns {Promise<string>}
  */
-export const readBlobContent = async (blob: Blob | File | Response, contentType: string | null): Promise<string> => {
-  const buffer = await blob.arrayBuffer();
-  const uint8 = new Uint8Array(buffer);
+export const readRawContent = async (
+  raw: Blob | File | Response | Uint8Array,
+  contentType: string | null
+): Promise<string> => {
+  let uint8: Uint8Array;
+  if (ArrayBuffer.isView(raw)) {
+    uint8 = new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength);
+  } else {
+    const buffer = await (raw as Blob | Response).arrayBuffer();
+    uint8 = new Uint8Array(buffer);
+  }
 
   if (uint8.length === 0) {
     return "";

--- a/src/pkg/utils/encoding.ts
+++ b/src/pkg/utils/encoding.ts
@@ -57,13 +57,14 @@ type ByteRange = [number, number];
 const isUtf8ContinuationByte = (byte: number) => (byte & 0xc0) === 0x80;
 
 const addSampleRange = (ranges: ByteRange[], data: Uint8Array, start: number, end: number) => {
-  if (data.length === 0) return;
-  let rangeStart = Math.max(0, Math.min(start, data.length));
-  let rangeEnd = Math.max(rangeStart, Math.min(end, data.length));
+  const n = data.length;
+  if (n === 0) return;
+  let rangeStart = Math.max(0, Math.min(start, n));
+  let rangeEnd = Math.max(rangeStart, Math.min(end, n));
   while (rangeStart > 0 && isUtf8ContinuationByte(data[rangeStart])) {
     rangeStart--;
   }
-  while (rangeEnd < data.length && isUtf8ContinuationByte(data[rangeEnd])) {
+  while (rangeEnd < n && isUtf8ContinuationByte(data[rangeEnd])) {
     rangeEnd++;
   }
   if (rangeStart >= rangeEnd) return;
@@ -76,22 +77,20 @@ const createSampleRanges = (
   rangeSize = CHECK_SIZE,
   maxRanges = MAX_UTF8_SAMPLE_RANGES
 ): ByteRange[] => {
-  if (data.length <= rangeSize) return [[0, data.length]];
+  const n = data.length;
+  if (n <= rangeSize) return [[0, n]];
 
   const ranges: ByteRange[] = [];
+  const dk = n >>> 1;
+  const rk = rangeSize >>> 1;
   addSampleRange(ranges, data, 0, rangeSize);
-  addSampleRange(
-    ranges,
-    data,
-    Math.max(0, Math.floor(data.length / 2 - rangeSize / 2)),
-    Math.min(data.length, Math.floor(data.length / 2 + rangeSize / 2))
-  );
-  addSampleRange(ranges, data, Math.max(0, data.length - rangeSize), data.length);
+  addSampleRange(ranges, data, Math.max(0, dk - rk), Math.min(n, dk + rk));
+  addSampleRange(ranges, data, Math.max(0, n - rangeSize), n);
 
   let nextHighByteSearchStart = rangeSize;
-  while (ranges.length < maxRanges && nextHighByteSearchStart < data.length) {
+  while (ranges.length < maxRanges && nextHighByteSearchStart < n) {
     let highByteIndex = -1;
-    for (let i = nextHighByteSearchStart; i < data.length; i++) {
+    for (let i = nextHighByteSearchStart; i < n; i++) {
       if (data[i] >= 0x80) {
         highByteIndex = i;
         break;
@@ -99,7 +98,7 @@ const createSampleRanges = (
     }
     if (highByteIndex < 0) break;
 
-    const start = Math.max(0, highByteIndex - Math.floor(rangeSize / 2));
+    const start = Math.max(0, highByteIndex - rk);
     const end = Math.min(data.length, start + rangeSize);
     addSampleRange(ranges, data, start, end);
     nextHighByteSearchStart = Math.max(highByteIndex + rangeSize, end);
@@ -109,10 +108,11 @@ const createSampleRanges = (
 };
 
 const createLegacyDetectionSample = (data: Uint8Array): Uint8Array => {
-  if (data.length <= LEGACY_SAMPLE_LIMIT) return data;
+  const n = data.length;
+  if (n <= LEGACY_SAMPLE_LIMIT) return data;
 
   let firstHighByteIndex = -1;
-  for (let i = 0; i < data.length; i++) {
+  for (let i = 0; i < n; i++) {
     if (data[i] >= 0x80) {
       firstHighByteIndex = i;
       break;
@@ -123,7 +123,7 @@ const createLegacyDetectionSample = (data: Uint8Array): Uint8Array => {
     return data.subarray(0, LEGACY_SAMPLE_LIMIT);
   }
 
-  const sampleStart = Math.max(0, Math.min(firstHighByteIndex - 8 * 1024, data.length - LEGACY_SAMPLE_LIMIT));
+  const sampleStart = Math.max(0, Math.min(firstHighByteIndex - 8 * 1024, n - LEGACY_SAMPLE_LIMIT));
   return data.subarray(sampleStart, sampleStart + LEGACY_SAMPLE_LIMIT);
 };
 

--- a/src/pkg/utils/script.ts
+++ b/src/pkg/utils/script.ts
@@ -15,7 +15,7 @@ import { SUBSCRIBE_STATUS_ENABLE, SubscribeDAO } from "@App/app/repo/subscribe";
 import { extractCronExpr } from "./cron";
 import { parseUserConfig } from "./yaml";
 import { t as i18n_t } from "@App/locales/locales";
-import { readBlobContent } from "@App/pkg/utils/encoding";
+import { readRawContent } from "@App/pkg/utils/encoding";
 
 const HEADER_BLOCK = /\/\/[ \t]*==User(Script|Subscribe)==([\s\S]+?)\/\/[ \t]*==\/User\1==/m;
 const META_LINE = /\/\/[ \t]*@(\S+)[ \t]*(.*)$/gm;
@@ -58,7 +58,7 @@ export async function fetchScriptBody(url: string): Promise<string> {
   if (resp.headers.get("content-type")?.includes("text/html")) {
     throw new Error("url is html");
   }
-  const body = await readBlobContent(resp, resp.headers.get("content-type"));
+  const body = await readRawContent(resp, resp.headers.get("content-type"));
   return body;
 }
 


### PR DESCRIPTION

#1115  https://github.com/caigg188/LDStatusPro/releases/download/v3.5.2.4/LDStatusPro.user.js
#1425 https://github.com/dongdevcom/video-speed-controller/releases/download/v2.0.1/video-speed-controller.user.js

----

## 问题说明

修复 #1425。

原有编码处理逻辑中，安装页会自行调用 `detectEncoding` 与 `bytesDecode` 来解码下载后的脚本内容，而 `encoding.ts` 中也已经存在 `readBlobContent` 这一套较完整的 Blob/File 读取与编码检测流程。两套逻辑并存，容易造成不同入口的解码行为不一致，也使后续维护和扩展编码检测规则变得困难。

在 #1425 中，通过 GitHub Release URL 安装 userscript 时，响应内容可能没有明确提供 `charset`，例如只有 `application/octet-stream`。当脚本前段主要是 ASCII，而越南语、Emoji 等 UTF-8 字符出现在较靠后位置时，旧检测方式容易在样本不足的情况下把实际 UTF-8 内容误判为其他编码，导致安装页显示乱码。

## 修改内容

### 1. 整合安装页的脚本解码流程

将 `src/pages/install/App.tsx` 中原本手动执行的：

- `detectEncoding(chunksAll, contentType)`
- `bytesDecode(encode, chunksAll)`
- 解码失败后回退 UTF-8

改为统一调用 `readBlobContent`。

这样安装页不再维护独立的编码检测与回退逻辑，而是复用 `encoding.ts` 中统一的 Blob 内容读取机制，减少重复实现，并确保不同入口的解码行为一致。

### 2. 重构 `encoding.ts` 的检测优先级

本次将编码检测流程整理为更明确的优先级：

1. 优先使用有效的 `Content-Type charset`
2. 检测 BOM
3. 使用空字节分布启发式判断 UTF-16 / UTF-32
4. 对 UTF-8 做严格校验
5. 对“几乎有效的 UTF-8”保留 UTF-8 解码结果
6. 最后才进入 chardet legacy 编码检测

这样可以优先保护现代脚本中最常见的 UTF-8 内容，避免在没有 charset 的情况下过早依赖 chardet，降低 UTF-8 被误判为 legacy 编码的概率。

### 3. 改进 `Content-Type charset` 解析

增强 `parseCharsetFromContentType` 的解析能力：

- 支持 `charset = UTF-8` 这类带空格的写法
- 支持单引号或双引号包裹 charset
- 支持大小写不敏感的 `charset` 参数
- 避免把后续参数错误并入 charset

### 4. 改进 UTF-32 解码实现

重构 `decodeUTF32`：

- 使用 `DataView` 按端序读取 code point
- 正确支持 UTF-32LE / UTF-32BE
- 正确跳过 UTF-32 BOM
- 支持带非零 `byteOffset` 的 `Uint8Array.subarray`
- 分块调用 `String.fromCodePoint`，避免大文件一次性展开过多参数

同时 `bytesDecode` 会先规范化 charset 大小写，使 `UTF-32LE`、`UTF-32BE` 等写法也能被正确处理。

### 5. 改进大文件 UTF-8 检测策略

对于较大的内容，新增采样范围检测逻辑：

- 小文件直接做完整 UTF-8 严格校验
- 大文件采样开头、中间、结尾，以及包含高位字节的位置
- 采样边界会避开 UTF-8 continuation byte，避免从多字节字符中间截断造成误判

这可以覆盖 GitHub Release userscript 的常见情况：文件前段多为 metadata 或 ASCII 代码，真正的多语言文本或 Emoji 可能出现在文件后部。

### 6. 改进 legacy 编码回退逻辑

当 UTF-8 判断失败后，才进入 chardet-based legacy 检测，并改进以下行为：

- legacy 检测样本优先覆盖第一个高位字节附近，而不是固定只取文件开头
- 跳过已经由前置流程处理的 Unicode 编码候选
- 对启发式 UTF-16 / UTF-32 结果增加可疑控制字符校验
- 在没有可靠 legacy 结果时回退到 `windows-1252`

这能在保护 UTF-8 的同时，继续兼容 GBK、Big5、Shift_JIS 等 legacy 编码脚本。

### 7. 增加回归测试与边界测试

新增并扩充 `encoding.test.ts`，覆盖：

- `Content-Type charset` 解析
- UTF-8 / UTF-16 / UTF-32 解码
- UTF-32 BOM、非零 byteOffset、大内容分块解码
- 无 charset 的有效 UTF-8 内容
- GitHub Release 类似场景下的 UTF-8 越南语与 Emoji
- 多语言 UTF-8 内容，包括中文、日文、韩文、越南语、俄文、阿拉伯文、希腊文、希伯来文、泰文、印地文、拉丁重音字符与 Emoji
- 大文件 UTF-8 内容
- 采样边界跨越 Emoji 多字节字符
- 少量损坏字节但整体仍接近 UTF-8 的情况
- GBK、Big5、Shift_JIS 等 legacy CJK 编码
- 防止 legacy CJK 或带空字节内容被误判为 UTF-16 / UTF-32

## 影响范围

本次主要影响 `encoding.ts` 的编码检测与 Blob 内容读取逻辑，以及安装页读取远程 userscript 时的解码流程。

预期改善：

- 统一脚本安装页与通用 Blob/File 读取的解码行为
- 修复无 charset 的 GitHub Release userscript 中 UTF-8 文本被误判导致的乱码问题
- 提升 UTF-8、UTF-16、UTF-32 与 legacy CJK 编码检测的稳定性
- 降低后续维护编码检测逻辑的复杂度

## 风险说明

编码检测本身仍然依赖一定启发式判断，极端混合编码或伪文本二进制内容仍可能存在误判风险。本次通过更明确的检测优先级、UTF-8 严格校验、启发式结果验证和更完整的测试覆盖来降低风险。

## 测试

已增加并调整 `src/pkg/utils/encoding.test.ts` 相关测试，覆盖本次重构涉及的主要检测路径、回归场景与边界情况。