### PR TITLE
fix(filesystem): dedupe concurrent initial auth requests

### DIFF
--- a/packages/filesystem/auth.test.ts
+++ b/packages/filesystem/auth.test.ts
@@ -68,4 +68,38 @@ describe("AuthVerify", () => {
     ).resolves.toEqual(["new-access", "new-access", "new-access"]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("concurrent initial token verification should share one auth request and save once", async () => {
+    vi.useFakeTimers();
+    const createSpy = vi.spyOn(chrome.tabs, "create").mockImplementation(() => Promise.resolve({ id: 1 }) as any);
+    const originalGet = (chrome.tabs as any).get;
+    (chrome.tabs as any).get = vi.fn().mockRejectedValue(new Error("closed"));
+    const saveSpy = vi.spyOn(LocalStorageDAO.prototype, "saveValue");
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        code: 0,
+        data: {
+          token: {
+            access_token: "initial-access",
+            refresh_token: "initial-refresh",
+          },
+        },
+      }),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    try {
+      const auth = Promise.all([AuthVerify("onedrive"), AuthVerify("onedrive"), AuthVerify("onedrive")]);
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect(auth).resolves.toEqual(["initial-access", "initial-access", "initial-access"]);
+      expect(createSpy).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(saveSpy).toHaveBeenCalledTimes(1);
+      expect(saveSpy).toHaveBeenCalledWith(key, expect.objectContaining({ accessToken: "initial-access" }));
+    } finally {
+      (chrome.tabs as any).get = originalGet;
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/filesystem/auth.ts
+++ b/packages/filesystem/auth.ts
@@ -74,6 +74,7 @@ export type Token = {
   createtime: number;
 };
 const refreshTokenPromises: Partial<Record<NetDiskType, Promise<string>>> = {};
+const authTokenPromises: Partial<Record<NetDiskType, Promise<Token>>> = {};
 
 function refreshAccessToken(
   netDiskType: NetDiskType,
@@ -126,19 +127,30 @@ export async function AuthVerify(netDiskType: NetDiskType, invalid?: boolean) {
   }
   // token不存在,或者没有accessToken,重新获取
   if (!token || !token.accessToken) {
-    // 强制重新获取token
-    await NetDisk(netDiskType);
-    const resp = await GetNetDiskToken(netDiskType);
-    if (resp.code !== 0) {
-      throw new WarpTokenError(new Error(resp.msg));
+    if (!authTokenPromises[netDiskType]) {
+      const authPromise = (async () => {
+        // 强制重新获取token
+        await NetDisk(netDiskType);
+        const resp = await GetNetDiskToken(netDiskType);
+        if (resp.code !== 0) {
+          throw new WarpTokenError(new Error(resp.msg));
+        }
+        const newToken = {
+          accessToken: resp.data.token.access_token,
+          refreshToken: resp.data.token.refresh_token,
+          createtime: Date.now(),
+        };
+        await localStorageDAO.saveValue(key, newToken);
+        return newToken;
+      })().finally(() => {
+        if (authTokenPromises[netDiskType] === authPromise) {
+          delete authTokenPromises[netDiskType];
+        }
+      });
+      authTokenPromises[netDiskType] = authPromise;
     }
-    token = {
-      accessToken: resp.data.token.access_token,
-      refreshToken: resp.data.token.refresh_token,
-      createtime: Date.now(),
-    };
+    token = await authTokenPromises[netDiskType];
     invalid = false;
-    await localStorageDAO.saveValue(key, token);
   }
   // token未过期(一小时内)及有效则保留，不用刷新token
   const unexpired = Date.now() < token.createtime + 3600000;


### PR DESCRIPTION
## 概要

修复首次授权场景下，并发调用 `AuthVerify()` 时会重复触发授权流程的问题。

当本地不存在 token 或 token 缺少 `accessToken` 时，同一网盘类型的多个并发认证请求现在会复用同一个授权 Promise，避免重复打开授权页、重复请求 token、重复写入本地存储。

## 主要改动

- 新增 `authTokenPromises`，按网盘类型缓存首次授权中的 Promise
- 并发 `AuthVerify(netDiskType)` 在缺少 token 时复用同一次授权请求
- 授权成功后只保存一次 token
- 授权流程结束后清理对应的 pending Promise，避免影响后续认证
- 保留原有 refresh token 并发去重逻辑不变

## 修复的问题

在多个同步任务或多个文件系统操作几乎同时触发认证时，如果当前没有可用 token，之前每个请求都会各自执行：

- 打开授权页
- 请求 `GetNetDiskToken`
- 写入 token 到本地存储

这可能导致用户看到多个授权窗口，或者产生重复 token 请求。

本 PR 修复后，同一网盘类型的首次授权流程只会执行一次，其他并发请求等待同一个结果。

## 测试

新增单元测试覆盖：

- 并发首次认证时只打开一次授权页
- 只请求一次 token
- 只保存一次 token
- 所有并发调用都返回同一个 access token