### PR TITLE
fix(GM): add back `@run-at context-menu`

### DIFF
--- a/example/run-at_context-menu.js
+++ b/example/run-at_context-menu.js
@@ -1,0 +1,20 @@
+// ==UserScript==
+// @name         Context Menu Demo: Search Selection
+// @namespace    https://bbs.tampermonkey.net.cn/
+// @version      0.1.0
+// @description  Demo for @run-at context-menu
+// @author       You
+// @match        *://*/*
+// @run-at       context-menu
+// @grant        GM_openInTab
+// ==/UserScript==
+
+(function () {
+  'use strict';
+  const selectedText = window.getSelection().toString().trim();
+  if (!selectedText) {
+    alert("Please select some texts first.");
+    return;
+  }
+  GM_openInTab(`https://scriptcat.org/search?keyword=${encodeURIComponent(selectedText)}`)
+})();

--- a/src/app/service/content/exec_script.ts
+++ b/src/app/service/content/exec_script.ts
@@ -2,7 +2,7 @@ import LoggerCore from "@App/app/logger/core";
 import type Logger from "@App/app/logger/logger";
 import { createContext, createProxyContext } from "./create_context";
 import type { GMInfoEnv, ScriptFunc } from "./types";
-import { compileScript } from "./utils";
+import { compileScript, isContextMenuScript } from "./utils";
 import type { Message } from "@Packages/message/types";
 import type { ValueUpdateDataEncoded } from "./types";
 import { evaluateGMInfo } from "./gm_api/gm_info";
@@ -49,6 +49,10 @@ export default class ExecScript {
       this.scriptFunc = code;
     }
     const grantSet = new Set(scriptRes.metadata.grant || []);
+    if (isContextMenuScript(scriptRes.metadata)) {
+      grantSet.add("GM_registerMenuCommand");
+      grantSet.delete("none");
+    }
     if (grantSet.has("none")) {
       // 不注入任何GM api
       // ScriptCat行为：GM.info 和 GM_info 同时注入

--- a/src/app/service/content/utils.test.ts
+++ b/src/app/service/content/utils.test.ts
@@ -191,6 +191,23 @@ describe("utils", () => {
       expect(result).toBeDefined();
       expect(result).toContain("try {");
     });
+
+    it.concurrent("应该处理 @run-at context-menu", () => {
+      const scriptRes = createMockScriptRes({
+        name: 'ScriptCat\'s demo for "context-menu"',
+        code: "console.log(567); // testing",
+        metadata: {
+          "run-at": ["context-menu"],
+        },
+      });
+
+      const result = compileScriptCode(scriptRes);
+
+      expect(result).toBeDefined();
+      expect(result).toContain(
+        `GM_registerMenuCommand(("ScriptCat's demo for \\"context-menu\\""), ()=>{\nconsole.log(567); // testing\n}, {nested:false});\n`
+      );
+    });
   });
 
   describe("compileScript", () => {

--- a/src/app/service/content/utils.test.ts
+++ b/src/app/service/content/utils.test.ts
@@ -205,7 +205,7 @@ describe("utils", () => {
 
       expect(result).toBeDefined();
       expect(result).toContain(
-        `GM_registerMenuCommand(("ScriptCat's demo for \\"context-menu\\""), ()=>{\nlet GM_registerMenuCommand=GM.registerMenuCommand=undefined;console.log(567); // testing\n}, {nested:false});\n`
+        `GM_registerMenuCommand(("ScriptCat's demo for \\"context-menu\\""), ()=>{let GM_registerMenuCommand=window.GM_registerMenuCommand=GM.registerMenuCommand=undefined;\nconsole.log(567); // testing\n}, {nested:false});\n`
       );
     });
   });

--- a/src/app/service/content/utils.test.ts
+++ b/src/app/service/content/utils.test.ts
@@ -205,7 +205,7 @@ describe("utils", () => {
 
       expect(result).toBeDefined();
       expect(result).toContain(
-        `GM_registerMenuCommand(("ScriptCat's demo for \\"context-menu\\""), ()=>{\nconsole.log(567); // testing\n}, {nested:false});\n`
+        `GM_registerMenuCommand(("ScriptCat's demo for \\"context-menu\\""), ()=>{\nlet GM_registerMenuCommand=GM.registerMenuCommand=undefined;console.log(567); // testing\n}, {nested:false});\n`
       );
     });
   });

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -9,6 +9,7 @@ export type CompileScriptCodeResource = {
   name: string;
   code: string;
   require: Array<{ url: string; content: string }>;
+  isContextMenu: boolean;
 };
 
 // 参考了tm的实现
@@ -80,6 +81,7 @@ export function compileScriptCode(scriptRes: ScriptRunResource, scriptCode?: str
     name: scriptRes.name,
     code: scriptCode,
     require: requireArray,
+    isContextMenu: isContextMenuScript(scriptRes.metadata),
   });
 }
 
@@ -104,13 +106,17 @@ const addTryCatch = (code: string) =>
 export function compileScriptCodeByResource(resource: CompileScriptCodeResource): string {
   const requireCode = resource.require.map((r) => r.content).join("\n;");
   const preCode = requireCode; // 不需要 async 封装
-  const code = resource.code; // 需要 async 封装, 可top-level await
+  let code = resource.code; // 需要 async 封装, 可top-level await
   // context 和 name 以unnamed arguments方式导入。避免代码能直接以变量名存取
   // this = context: globalThis
   // arguments = [named: Object, scriptName: string]
   // 使用sandboxContext时，arguments[0]为undefined, this.$则为一次性Proxy变量，用于全域拦截context
   // 非沙盒环境时，先读取 arguments[0]，因此不会读取页面环境的 this.$
   // 在UserScripts API中，由于执行不是在物件导向里呼叫，使用arrow function的话会把this改变。须使用 .call(this) [ 或 .bind(this)() ]
+
+  if (resource.isContextMenu) {
+    code = `GM_registerMenuCommand((${JSON.stringify(resource.name)}), ()=>{\n${code}\n}, {nested:false});\n`;
+  }
 
   const joinedCode = [
     "with(arguments[0]||this.$){",
@@ -235,6 +241,10 @@ export function addStyleSheet(css: string): CSSStyleSheet {
 export function metadataBlankOrTrue(metadata: SCMetadata, key: string): boolean {
   const s = metadata[key]?.[0];
   return s === "" || s === "true";
+}
+
+export function isContextMenuScript(metadata: SCMetadata): boolean {
+  return metadata["run-at"]?.[0] === "context-menu";
 }
 
 export function isEarlyStartScript(metadata: SCMetadata): boolean {

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -115,7 +115,7 @@ export function compileScriptCodeByResource(resource: CompileScriptCodeResource)
   // 在UserScripts API中，由于执行不是在物件导向里呼叫，使用arrow function的话会把this改变。须使用 .call(this) [ 或 .bind(this)() ]
 
   if (resource.isContextMenu) {
-    code = `GM_registerMenuCommand((${JSON.stringify(resource.name)}), ()=>{\nlet GM_registerMenuCommand=GM.registerMenuCommand=undefined;${code}\n}, {nested:false});\n`;
+    code = `GM_registerMenuCommand((${JSON.stringify(resource.name)}), ()=>{let GM_registerMenuCommand=window.GM_registerMenuCommand=GM.registerMenuCommand=undefined;\n${code}\n}, {nested:false});\n`;
   }
 
   const joinedCode = [

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -115,7 +115,7 @@ export function compileScriptCodeByResource(resource: CompileScriptCodeResource)
   // 在UserScripts API中，由于执行不是在物件导向里呼叫，使用arrow function的话会把this改变。须使用 .call(this) [ 或 .bind(this)() ]
 
   if (resource.isContextMenu) {
-    code = `GM_registerMenuCommand((${JSON.stringify(resource.name)}), ()=>{\n${code}\n}, {nested:false});\n`;
+    code = `GM_registerMenuCommand((${JSON.stringify(resource.name)}), ()=>{\nlet GM_registerMenuCommand=GM.registerMenuCommand=undefined;${code}\n}, {nested:false});\n`;
   }
 
   const joinedCode = [

--- a/src/app/service/service_worker/permission_verify.ts
+++ b/src/app/service/service_worker/permission_verify.ts
@@ -12,6 +12,7 @@ import Queue from "@App/pkg/utils/queue";
 import { type TDeleteScript } from "../queue";
 import { openInCurrentTab } from "@App/pkg/utils/utils";
 import type GMApi from "./gm_api/gm_api";
+import { isContextMenuScript } from "../content/utils";
 
 export interface ConfirmParam {
   // 权限名
@@ -125,6 +126,9 @@ export default class PermissionVerify {
   ): Promise<boolean> {
     const { alias, link, confirm } = api.param;
     if (api.param.default) {
+      return true;
+    }
+    if (request.api === "GM_registerMenuCommand" && isContextMenuScript(request.script.metadata)) {
       return true;
     }
     // 没有其它条件,从metadata.grant中判断

--- a/src/app/service/service_worker/popup.ts
+++ b/src/app/service/service_worker/popup.ts
@@ -100,6 +100,7 @@ export class PopupService {
   // 将 ScriptMenu[] 转为 Chrome contextMenus.CreateProperties[]；同一 groupKey 仅保留一个实际显示项。
   genScriptMenuByTabMap(menuEntries: chrome.contextMenus.CreateProperties[], menu: ScriptMenu[]) {
     for (const { uuid, name, menus } of menu) {
+      let withLevel1 = false;
       const subMenuEntries = [] as chrome.contextMenus.CreateProperties[];
       let withMenuItem = false;
       const groupKeys = new Map<string, { name: string; mSeparator?: boolean; nested?: boolean }>();
@@ -128,6 +129,7 @@ export class PopupService {
         }
         if (nested) {
           createProperties.parentId = `scriptMenu_${uuid}`; // 上层是 `scriptMenu_${uuid}`
+          withLevel1 = true;
         } else {
           createProperties.parentId = `scriptMenu`;
         }
@@ -135,15 +137,15 @@ export class PopupService {
       }
       if (withMenuItem) {
         // 创建脚本菜单
-        menuEntries.push(
-          {
+        if (withLevel1) {
+          menuEntries.push({
             id: `scriptMenu_${uuid}`,
             title: name,
             contexts: ["all"],
             parentId: "scriptMenu",
-          },
-          ...subMenuEntries
-        );
+          });
+        }
+        menuEntries.push(...subMenuEntries);
       }
     }
   }

--- a/src/app/service/service_worker/popup.ts
+++ b/src/app/service/service_worker/popup.ts
@@ -100,7 +100,7 @@ export class PopupService {
   // 将 ScriptMenu[] 转为 Chrome contextMenus.CreateProperties[]；同一 groupKey 仅保留一个实际显示项。
   genScriptMenuByTabMap(menuEntries: chrome.contextMenus.CreateProperties[], menu: ScriptMenu[]) {
     for (const { uuid, name, menus } of menu) {
-      let withLevel1 = false;
+      let needsParentMenu = false;
       const subMenuEntries = [] as chrome.contextMenus.CreateProperties[];
       let withMenuItem = false;
       const groupKeys = new Map<string, { name: string; mSeparator?: boolean; nested?: boolean }>();
@@ -129,7 +129,7 @@ export class PopupService {
         }
         if (nested) {
           createProperties.parentId = `scriptMenu_${uuid}`; // 上层是 `scriptMenu_${uuid}`
-          withLevel1 = true;
+          needsParentMenu = true;
         } else {
           createProperties.parentId = `scriptMenu`;
         }
@@ -137,7 +137,7 @@ export class PopupService {
       }
       if (withMenuItem) {
         // 创建脚本菜单
-        if (withLevel1) {
+        if (needsParentMenu) {
           menuEntries.push({
             id: `scriptMenu_${uuid}`,
             title: name,

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -32,6 +32,7 @@ import type { CompileScriptCodeResource } from "../content/utils";
 import {
   compileInjectScriptByFlag,
   compileScriptCodeByResource,
+  isContextMenuScript,
   isEarlyStartScript,
   isInjectIntoContent,
   trimScriptInfo,
@@ -803,6 +804,7 @@ export class RuntimeService {
         name: result.name,
         code: originalCode?.code || "",
         require,
+        isContextMenu: isContextMenuScript(script.metadata),
       })
     );
   }


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

* Close #1038

## Screenshots / 截图

<!-- Screenshots / 截图-->

* Example: https://stackoverflow.com/questions/42800590/tampermonkey-right-click-menu

<img width="623" height="668" alt="Screenshot 2026-05-15 at 0 34 37" src="https://github.com/user-attachments/assets/4fc877d0-3950-4f8c-a11c-9daf8eda93d7" />

### ScriptCat

<img width="357" height="285" alt="Screenshot 2026-05-15 at 0 33 46" src="https://github.com/user-attachments/assets/06fb0651-4ba6-4141-9e05-cafc982f3e25" />


----

I mentioned the following before

* Note: `context-menu` is not the same as `GM_registerMenuCommand`. `GM_registerMenuCommand` will add the menu options to "popup" too, but `context-menu` just add the menu options to the context menu

But I don't think we need to do the same as TM. No downside for having the triggering in both right click and menu, especially the user might not have the right click on the touch screen device.