### PR TITLE
🐛 WebDAV verify 移除写探针，修复坚果云同步失败 (#1444)

### DIFF
--- a/packages/filesystem/webdav/webdav.test.ts
+++ b/packages/filesystem/webdav/webdav.test.ts
@@ -70,24 +70,19 @@ describe("WebDAVFileSystem", () => {
   });
 
   describe("verify", () => {
-    it("应当通过列目录、写入探针文件和清理探针完成验证", async () => {
+    it("应当通过 getQuota 与列目录完成只读校验", async () => {
       const fs = createTestFS(mockClient);
 
       await expect(fs.verify()).resolves.toBeUndefined();
       expect(mockClient.getQuota).toHaveBeenCalled();
       expect(mockClient.getDirectoryContents).toHaveBeenCalledWith("/");
-      expect(mockClient.createDirectory).toHaveBeenCalledWith(expect.stringMatching(/^\/\.scriptcat-verify-/));
-      expect(mockClient.putFileContents).toHaveBeenCalledWith(
-        expect.stringMatching(/^\/\.scriptcat-verify-.+\/probe\.txt$/),
-        ""
-      );
-      expect(mockClient.deleteFile).toHaveBeenCalledWith(
-        expect.stringMatching(/^\/\.scriptcat-verify-.+\/probe\.txt$/)
-      );
-      expect(mockClient.deleteFile).toHaveBeenCalledWith(expect.stringMatching(/^\/\.scriptcat-verify-/));
+      // 不应在 verify 阶段尝试写探针（坚果云等根目录不可写的服务会被误杀）
+      expect(mockClient.createDirectory).not.toHaveBeenCalled();
+      expect(mockClient.putFileContents).not.toHaveBeenCalled();
+      expect(mockClient.deleteFile).not.toHaveBeenCalled();
     });
 
-    it("应当在 401 时抛出 WarpTokenError 1", async () => {
+    it("应当在 getQuota 401 时抛出 WarpTokenError", async () => {
       (mockClient.getQuota as ReturnType<typeof vi.fn>).mockRejectedValue({
         response: { status: 401 },
         message: "Unauthorized",
@@ -97,7 +92,7 @@ describe("WebDAVFileSystem", () => {
       await expect(fs.verify()).rejects.toBeInstanceOf(WarpTokenError);
     });
 
-    it("应当在 401 时抛出 WarpTokenError 2", async () => {
+    it("应当在 getDirectoryContents 401 时抛出 WarpTokenError", async () => {
       (mockClient.getDirectoryContents as ReturnType<typeof vi.fn>).mockRejectedValue({
         response: { status: 401 },
         message: "Unauthorized",
@@ -107,7 +102,7 @@ describe("WebDAVFileSystem", () => {
       await expect(fs.verify()).rejects.toBeInstanceOf(WarpTokenError);
     });
 
-    it("应当在其他错误时抛出包含原始信息的 Error 1", async () => {
+    it("应当在 getQuota 其他错误时抛出包含原始信息的 Error", async () => {
       (mockClient.getQuota as ReturnType<typeof vi.fn>).mockRejectedValue({
         message: "Network error",
       });
@@ -116,28 +111,13 @@ describe("WebDAVFileSystem", () => {
       await expect(fs.verify()).rejects.toThrow("WebDAV verify failed: Network error");
     });
 
-    it("应当在其他错误时抛出包含原始信息的 Error 2", async () => {
+    it("应当在 getDirectoryContents 其他错误时抛出包含原始信息的 Error", async () => {
       (mockClient.getDirectoryContents as ReturnType<typeof vi.fn>).mockRejectedValue({
         message: "Network error",
       });
       const fs = createTestFS(mockClient);
 
       await expect(fs.verify()).rejects.toThrow("WebDAV verify failed: Network error");
-    });
-
-    it("应当在无法写入探针文件时验证失败并清理探针目录", async () => {
-      (mockClient.putFileContents as ReturnType<typeof vi.fn>).mockResolvedValue(false);
-      const fs = createTestFS(mockClient);
-
-      await expect(fs.verify()).rejects.toThrow("WebDAV verify failed: probe file write returned false");
-      expect(mockClient.deleteFile).toHaveBeenCalledWith(expect.stringMatching(/^\/\.scriptcat-verify-/));
-    });
-
-    it("应当在删除探针文件失败时验证失败", async () => {
-      (mockClient.deleteFile as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("Delete denied"));
-      const fs = createTestFS(mockClient);
-
-      await expect(fs.verify()).rejects.toThrow("WebDAV verify failed: Delete denied");
     });
   });
 

--- a/packages/filesystem/webdav/webdav.ts
+++ b/packages/filesystem/webdav/webdav.ts
@@ -53,40 +53,17 @@ export default class WebDAVFileSystem implements FileSystem {
   }
 
   async verify(): Promise<void> {
-    const verifyDir = joinPath(this.basePath, `.scriptcat-verify-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-    const verifyFile = joinPath(verifyDir, "probe.txt");
-    let dirCreated = false;
-    let fileCreated = false;
-
+    // 只做只读校验：凭据 + URL 可达性。
+    // 写权限不在此处探测——不同 basePath 写策略不同（坚果云等根目录不可写的服务会被误杀，见 #1444），
+    // 真正的写操作会在 backupToCloud / buildFileSystem 中由 createDir 立即触发并报错。
     try {
       await this.client.getQuota();
       await this.client.getDirectoryContents(this.basePath);
-      await this.client.createDirectory(verifyDir);
-      dirCreated = true;
-      const written = await this.client.putFileContents(verifyFile, "");
-      if (!written) {
-        throw new Error("probe file write returned false");
-      }
-      fileCreated = true;
-      await this.client.deleteFile(verifyFile);
-      fileCreated = false;
-      await this.client.deleteFile(verifyDir);
-      dirCreated = false;
     } catch (e: any) {
-      await this.cleanupVerifyProbe(verifyFile, verifyDir, fileCreated, dirCreated);
       if (e.response?.status === 401) {
         throw new WarpTokenError(e);
       }
       throw new Error(`WebDAV verify failed: ${e.message}`); // 保留原始信息
-    }
-  }
-
-  private async cleanupVerifyProbe(verifyFile: string, verifyDir: string, fileCreated: boolean, dirCreated: boolean) {
-    if (fileCreated) {
-      await this.client.deleteFile(verifyFile).catch(() => undefined);
-    }
-    if (dirCreated) {
-      await this.client.deleteFile(verifyDir).catch(() => undefined);
     }
   }
 


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

close #1444

### 问题

Beta 1.4.0.1300 中坚果云（jianguoyun）WebDAV 同步失败：
- URL 填 `https://dav.jianguoyun.com/dav/` → 备份/同步直接失败
- 改成 `https://dav.jianguoyun.com/dav/ScriptCat` 能跑，但会在已有的 `ScriptCat/` 下再嵌套创建 `ScriptCat/ScriptCat/`

### 根因

#1395 (commit 27006fee) 把 `WebDAV.verify()` 从单纯的 `getQuota()` 扩展为「列目录 + 在 `basePath` 写探针 `.scriptcat-verify-${Date.now()}-${Math.random().toString(36).slice(2)}` + 清理」。

坚果云对 WebDAV 文件/目录名有长度限制，会以 `sandbox name is too long` 拒绝这个探针目录名（`.scriptcat-verify-` + 13 位时间戳 + `-` + 11 位随机串 ≈ 43 字符），导致 `FileSystemFactory.create` 阶段 verify 就抛错，整个备份流程中断。

第二种 URL 之所以"看起来能用"，是 webdav client 的 base URL 已经指向 `ScriptCat/`，但紧跟着 `synchronize.ts:292` 又会 `createDir("ScriptCat") + openDir("ScriptCat")`，于是嵌套出了 `/ScriptCat/ScriptCat`。

### 修复

回退 verify 到只读校验：保留 `getQuota()` + `getDirectoryContents(basePath)`，移除 `createDirectory/putFileContents/deleteFile` 写探针。

理由：
1. 不同 WebDAV 服务对文件名/路径有各种隐性限制（坚果云是长度，其它服务可能是字符集、隐藏文件、配额前置等），verify 阶段在 `basePath` 写一个通用探针是脆弱设计。
2. 写权限不足并不会被静默吞掉——`backupToCloud`/`buildFileSystem` 紧接着会调用 `createDir("ScriptCat")`，权限/配额问题会在那里立即抛错，最多延后一两个 RTT。
3. 探针失败/网络中断时会在用户网盘根目录残留 `.scriptcat-verify-*` 垃圾，体验不好。

参见 #1395 下的回复。

## Screenshots / 截图

无 UI 变更。

## Test plan

- [x] `pnpm test -- --run packages/filesystem/webdav/webdav.test.ts` 全部通过（19/19）
- [x] `pnpm run typecheck` 通过
- [x] 用坚果云账号实际验证：URL `https://dav.jianguoyun.com/dav/`，备份后只生成 `/ScriptCat`