### PR TITLE
[MV2] 针对 WebExtensions API Changes (Firefox 149-152) 做修正

### DIFF
--- a/build/assets/template/background.html
+++ b/build/assets/template/background.html
@@ -2,13 +2,17 @@
 <html>
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Background</title>
   </head>
   <body>
     <iframe
       src="/src/sandbox.html"
       name="sandbox"
-      sandbox="allow-scripts"
-      style="display: none"
+      sandbox="allow-same-origin allow-scripts"
+      hidden
+      aria-hidden="true"
+      tabindex="-1"
     ></iframe>
   </body>
 </html>

--- a/build/assets/template/options.html
+++ b/build/assets/template/options.html
@@ -10,8 +10,10 @@
     <iframe
       src="/src/sandbox.html"
       name="sandbox"
-      sandbox="allow-scripts"
-      style="display: none"
+      sandbox="allow-same-origin allow-scripts"
+      hidden
+      aria-hidden="true"
+      tabindex="-1"
     ></iframe>
   </body>
   <style>

--- a/build/assets/template/sandbox.html
+++ b/build/assets/template/sandbox.html
@@ -2,18 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script>
-      // 某些版本浏览器会因为sandbox中引用了dexie执行此方法导致报错,这里mock一个假的
-      window.BroadcastChannel = function () {
-        return {
-          postMessage: function () {},
-          close: function () {},
-        };
-      };
-    </script>
-    <title>Document</title>
+    <title>Sandbox</title>
   </head>
   <body></body>
 </html>

--- a/build/pack.js
+++ b/build/pack.js
@@ -75,8 +75,8 @@ const chromeManifest = { ...manifest };
 delete chromeManifest.content_security_policy;
 
 delete firefoxManifest.sandbox;
-// firefoxManifest.content_security_policy 是为了支持动态组合的 ts.worker.js Blob URL
-firefoxManifest.content_security_policy = "script-src 'self' blob:; object-src 'self' blob:";
+// 配置 Firefox 的 CSP，以支持在 sandbox 中动态执行 background script 代码
+firefoxManifest.content_security_policy = "script-src 'self' blob: 'unsafe-eval'; object-src 'self' blob:";
 firefoxManifest.browser_specific_settings = {
   gecko: {
     id: `{${

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,8 +20,12 @@
   },
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
-      "js": ["src/content.js"],
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "src/content.js"
+      ],
       "run_at": "document_start",
       "all_frames": true
     }
@@ -40,6 +44,9 @@
     "webRequestBlocking"
   ],
   "sandbox": {
-    "pages": ["src/sandbox.html"]
-  }
+    "pages": [
+      "src/sandbox.html"
+    ]
+  },
+  "content_security_policy": "script-src 'self' blob: 'unsafe-eval'; object-src 'self' blob:"
 }


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

* 改 `<iframe>` 的烂代码
* 拿走没用的 `<script>` 烂代码
* 修正 `content_security_policy` 缺失的` 'unsafe-eval'`
* 兼容 Firefox 但不兼容 Chrome - 改 `sandbox="allow-scripts"` 为 `sandbox="allow-same-origin allow-scripts"`

注1： CSP 保留 blob, 因为我们还是会用 `URL.createObjectURL(...)`. 保留以避免出问题。
注2： options.html 那个 `sandbox.html` 的去留由 CodFrm 决定

## Screenshots / 截图

<!-- Screenshots / 截图-->


## WebExtensions API Changes (Firefox 149-152)

https://blog.mozilla.org/addons/2026/04/23/webextensions-api-changes-firefox-149-152/


|                  Firefox | Area                           | Change                                                                                                  | API / surface affected                                                                                                            | Status / behavior                                                                                                                                                     | Developer impact / migration notes                                                                                                                                                                                                | Extra discussion / context                                                                                                                                                                                         |
| -----------------------: | ------------------------------ | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
|                      149 | Security / extension documents | Deprecated dynamic code/CSS injection into `moz-extension:` documents                                   | `tabs.executeScript`, `tabs.insertCSS`, `tabs.removeCSS`, `scripting.executeScript`, `scripting.insertCSS`, `scripting.removeCSS` | Deprecated in Firefox 149; Nightly blocks it, Beta/Release warn; removal planned for 152. ([MDN Web Docs][2])                                                         | Use normal `<script>` tags, module imports, static scripts, or a `runtime.onMessage` listener in the extension document to trigger behavior. ([Mozilla Blog][1])                                                                  | Bugzilla frames this as a security regression/mitigation-bypass: Firefox 56+ unintentionally allowed extensions to run arbitrary strings in privileged extension contexts; Chrome did not. ([Bugzilla][3])         |
|                149 → 152 | Security / extension documents | Final removal of dynamic injection into `moz-extension:` documents                                      | Same APIs as above                                                                                                                | Removed in Firefox 152 Nightly/release notes; feature was deprecated in 149. ([MDN Web Docs][4])                                                                      | Same workaround: message an already-loaded extension-page script instead of injecting code/CSS into the extension document. ([MDN Web Docs][4])                                                                                   | Related Bugzilla discussion says Mozilla planned a warning-first rollout, then pref flip; protection was not yet enabled for release in the first fixed bug and tracked separately in bug 2015559. ([Bugzilla][3]) |
| 149 / related mitigation | Extension sandboxing           | `manifest.json` sandbox support discussed as replacement path for string execution                      | Manifest `sandbox` key                                                                                                            | Not listed as a shipped 149–152 release-note item, but directly tied to the executeScript removal work.                                                               | For extensions that used the `code` option because a normal `file` script was not enough, Mozilla planned sandbox support so string-based execution can happen in unprivileged extension documents. ([Bugzilla][5])               | Bugzilla whiteboard moved to design-approved and blocks finalization of the executeScript-in-extension-documents restriction. ([Bugzilla][5])                                                                      |
|                      149 | Popup behavior                 | `action.openPopup()` and `browserAction.openPopup()` no longer require a user gesture on desktop        | `action.openPopup`, `browserAction.openPopup`                                                                                     | Available in Firefox 149 Desktop. ([MDN Web Docs][2])                                                                                                                 | Popups can be opened from background events such as alarms, native messaging, or internal extension conditions, not only click handlers. ([Mozilla Blog][1])                                                                      | Bugzilla discussion says this was previously behind `extensions.openPopupWithoutUserGesture.enabled`; enabling by default required checking cross-browser behavior and adding rejection cases. ([Bugzilla][6])     |
|                      149 | Popup behavior                 | `openPopup({ windowId })` requires the target window to be focused                                      | `action.openPopup`, `browserAction.openPopup`, `windows.update`                                                                   | Firefox 149 behavior aligned with Chrome. ([MDN Web Docs][2])                                                                                                         | To open in an unfocused window, focus it first with `windows.update(windowId, { focused: true })`. ([MDN Web Docs][2])                                                                                                            | Bugzilla discussion says focusing an inactive window automatically was surprising and unsupported by Chrome, so Firefox should reject instead. ([Bugzilla][7])                                                     |
|                      149 | Action API compatibility       | Added top-level `tabId` parameter form for `action.isEnabled()` / `browserAction.isEnabled()`           | `action.isEnabled(tabId)`, `browserAction.isEnabled(tabId)`                                                                       | Firefox 149 release notes list the change; Bugzilla shows fixed for Firefox 149. ([MDN Web Docs][2])                                                                  | Improves Chrome compatibility and matches `action.enable(tabId)` / `action.disable(tabId)` style. ([Bugzilla][8])                                                                                                                 | Implementation was first backed out for mochitest failures, then relanded and resolved fixed for 149. ([Bugzilla][8])                                                                                              |
|                      149 | Split View / tabs              | Initial Split View exposure in WebExtensions                                                            | `tabs.Tab.splitViewId`, `tabs.query`, `tabs.onUpdated`, `tabs.move`, `tabs.remove`                                                | Firefox 149 adds initial support and documents behavior for move/remove operations involving split-view tabs. ([MDN Web Docs][2])                                     | Extensions can detect whether a tab is in Split View and react when it joins/leaves one. `splitViewId` is read-only. ([MDN Web Docs][9])                                                                                          | Bugzilla says the implementation added `splitViewId` to `tabs.Tab` and `tabs.onUpdated`; WECG API proposal was referenced. ([Bugzilla][10])                                                                        |
|                      149 | Content-script globals         | `structuredClone` behavior changed for content scripts                                                  | `structuredClone` in content scripts                                                                                              | Firefox changed object instantiation to the `this` realm; content scripts now get their own `structuredClone` shadowing `window.structuredClone`. ([MDN Web Docs][2]) | Compatibility safeguard for extensions sharing objects with page scripts. ([MDN Web Docs][2])                                                                                                                                     | Listed in MDN add-on developer notes, not emphasized in the Mozilla blog summary. ([MDN Web Docs][2])                                                                                                              |
|                149 → 152 | UI / icons                     | Automatic dark-theme CSS filter for `pageAction` SVG icons disabled/removed                             | `page_action.default_icon` SVGs; dark theme rendering                                                                             | Disabled in Firefox 149 Nightly; planned/removed for broader Firefox 152. ([MDN Web Docs][2])                                                                         | Extensions should provide adaptive SVGs using `prefers-color-scheme` or use `theme_icons` where appropriate. ([Mozilla Blog][1])                                                                                                  | Mozilla says the old grayscale/brightness filter could reduce contrast for multicolor icons and hurt visibility, citing Firefox Multi-Account Containers as an example. ([Mozilla Blog][1])                        |
|                      150 | Split View / tabs              | `tabs.move()` can swap tabs inside a split view                                                         | `tabs.move`                                                                                                                       | Firefox 150 updates split-view move behavior. ([MDN Web Docs][11])                                                                                                    | Extensions can reorder the two split-view tabs rather than seeing no movement. ([Bugzilla][12])                                                                                                                                   | Bugzilla notes browser UI treats split tabs as one unit, but the extension API can move tabs individually, so swapping should work; Chrome could already swap split-view tabs. ([Bugzilla][12])                    |
|                      150 | Split View / tabs              | `tabs.move()` can unsplit when split-view tabs are explicitly listed apart                              | `tabs.move`                                                                                                                       | Firefox 150 closes the split view when a move list places another tab between split-view tabs. ([MDN Web Docs][11])                                                   | This lets extensions express tab order explicitly; Firefox unsplits to preserve the requested relative order. ([Bugzilla][13])                                                                                                    | Bugzilla says a dedicated unsplit API is still future work, but this `tabs.move` case already has clear expected behavior. ([Bugzilla][13])                                                                        |
|                      150 | WebAuthn / passkeys            | Extension documents can assert a WebAuthn RP ID for host-permitted domains                              | `navigator.credentials.create()`, `navigator.credentials.get()`, manifest `host_permissions`                                      | Available in Firefox 150. ([MDN Web Docs][11])                                                                                                                        | Enables extensions to create/retrieve credentials for a service domain they have host permission for, rather than being limited to the extension origin. Servers must allowlist the extension origin format. ([MDN Web Docs][14]) | Bugzilla issue came from a real extension use case: a company extension needed to use WebAuthn credentials tied to its website/mobile app domain, but Firefox rejected custom RP IDs. ([Bugzilla][15])             |
|                      150 | WebAuthn / server validation   | Stable Firefox WebAuthn extension origin format introduced                                              | `clientDataJSON.origin`                                                                                                           | Firefox uses `moz-extension://<hash>` for WebAuthn extension-origin validation. ([MDN Web Docs][14])                                                                  | Servers validating extension-created credentials must accept Chrome’s `chrome-extension://<id>` and Firefox’s deterministic `moz-extension://<sha256-hash>` form. ([MDN Web Docs][14])                                            | MDN notes this is stable across users, unlike Firefox’s normal random `moz-extension://uuid` document URLs. ([MDN Web Docs][14])                                                                                   |
|                      150 | Modules / CSS import           | Fixed some JavaScript `import` calls failing to import CSS                                              | JavaScript `import` / CSS modules in add-on context                                                                               | Listed as resolved in Firefox 150 add-on developer notes. ([MDN Web Docs][11])                                                                                        | Reduces failures when extension code imports CSS through JS module flows.                                                                                                                                                         | This appears in MDN release notes but not the Mozilla blog summary. ([MDN Web Docs][11])                                                                                                                           |
|                      151 | Split View / tab groups        | `tabs.group()` and `tabs.ungroup()` correctly add/remove split view when one split-view tab is included | `tabs.group`, `tabs.ungroup`                                                                                                      | Firefox 151 Beta release notes; work in progress page, ships May 19, 2026. ([MDN Web Docs][16])                                                                       | Previously, these calls could fail or separate the split view; extension tab-group operations should now preserve/adjust split-view state correctly. ([MDN Web Docs][16])                                                         | This is part of continuing Split View integration after the initial 149 API exposure.                                                                                                                              |
|                      151 | Split View / tab groups        | `tabs.move()` correctly moves a split view to the right inside tab groups                               | `tabs.move`                                                                                                                       | Firefox 151 Beta release notes. ([MDN Web Docs][16])                                                                                                                  | Fixes earlier behavior where moving a split view only worked leftward or to the end of the tab list. ([MDN Web Docs][16])                                                                                                         | Mozilla blog summarizes this as Firefox 151 enabling extensions to move split views in tab groups. ([Mozilla Blog][1])                                                                                             |
|               152 target | Local file access              | File URL access becomes explicit opt-in                                                                 | `file://*/`, `<all_urls>`, content scripts on `file:` URLs, `extension.isAllowedFileSchemeAccess()`                               | Targeted for Firefox 152 in Mozilla blog; Bugzilla still showed open when crawled, with backend/UI patches attached. ([Mozilla Blog][1])                              | Having `<all_urls>` or `file://*/` is no longer enough; users must enable “Allow access to file URLs.” This applies to existing extensions too. ([Bugzilla][17])                                                                  | Bugzilla says file access is currently limited to content scripts, and the patch gates it on an internal permission plus UI control. ([Bugzilla][17])                                                              |
|         Future / related | Split View creation/removal    | Dedicated extension API to create or remove split views is still future work                            | Future Split View API                                                                                                             | Not shipped in 149–152; Mozilla says “more improvements are coming.” ([Mozilla Blog][1])                                                                              | For now, extensions can observe and move/split-effect via existing tab operations, but not directly create/remove split views via a dedicated API.                                                                                | Bugzilla tracks this separately as “Add extension API to create split views, or remove split views.” ([Bugzilla][18])                                                                                              |

[1]: https://blog.mozilla.org/addons/2026/04/23/webextensions-api-changes-firefox-149-152/ "WebExtensions API Changes (Firefox 149-152) - Mozilla Add-ons Community Blog"
[2]: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/149 "Firefox 149 release notes for developers - Mozilla | MDN"
[3]: https://bugzilla.mozilla.org/show_bug.cgi?id=2011234 "2011234 - Extensions can dynamically execute code in their moz-extension: documents with tabs/scripting.executeScript"
[4]: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/152 "Firefox 152 release notes for developers (Nightly) - Mozilla | MDN"
[5]: https://bugzilla.mozilla.org/show_bug.cgi?id=1685123 "1685123 - implement manifest sandbox support"
[6]: https://bugzil.la/1799344 "1799344 - Enable browserAction.openPopup without user interaction on all channels (Remove `extensions.openPopupWithoutUserGesture.enabled` preference)"
[7]: https://bugzil.la/2011516 "2011516 - action.openPopup() should reject if the window is not a foreground window"
[8]: https://bugzil.la/2013477 "2013477 - Support action.isEnabled(tabId) next to action.isEnabled(details)"
[9]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab "tabs.Tab - Mozilla | MDN"
[10]: https://bugzil.la/1993037 "1993037 - Expose splitViewId in tabs extension API"
[11]: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/150 "Firefox 150 release notes for developers (Stable) - Mozilla | MDN"
[12]: https://bugzil.la/2016762 "2016762 - tabs.move() cannot swap two tabs that are part of a split view"
[13]: https://bugzil.la/2022549 "2022549 - tabs.move() taking a list of tabs should unsplit a split view when its tabs are explicitly listed apart"
[14]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Use_the_web_authn_api "Use Web Authn API in web extensions - Mozilla | MDN"
[15]: https://bugzil.la/1956484 "1956484 - Allow web extensions to assert WebAuthn relying party identifiers of a web domain they have host permissions for"
[16]: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/151 "Firefox 151 release notes for developers (Beta) - Mozilla | MDN"
[17]: https://bugzilla.mozilla.org/show_bug.cgi?id=2034168 "2034168 - Add explicit permission for file:-access and implement extension.isAllowedFileSchemeAccess()"
[18]: https://bugzilla.mozilla.org/show_bug.cgi?id=2016928 "2016928 - Add extension API to create split views, or remove split views"
