### PR TITLE
Fix: 修正 Editor 的 CSS 布局

### DIFF
--- a/src/pages/options/routes/script/index.css
+++ b/src/pages/options/routes/script/index.css
@@ -11,6 +11,6 @@
 	border: 0;
 	width: 100%;
 	height: 100%;
-  contain: layout style;
+	contain: layout style;
 	box-sizing: border-box;
 }

--- a/src/pages/options/routes/script/index.css
+++ b/src/pages/options/routes/script/index.css
@@ -11,6 +11,6 @@
 	border: 0;
 	width: 100%;
 	height: 100%;
-	overflow: hidden;
+  contain: layout style;
 	box-sizing: border-box;
 }


### PR DESCRIPTION
现在的 css布局 已经不用 `overflow: hidden`
改为 `contain: layout style` 来避免效能问题

<img width="308" height="96" alt="Screenshot 2026-05-23 at 18 10 15" src="https://github.com/user-attachments/assets/18b8b5dd-c046-4dd8-ab1b-b26e639dfdb9" />
