### PR TITLE
fix(sandbox): 新增 `protoBaseDescs` 修正TM半沙盒的祖先类别继承

### DIFF
--- a/example/tests/sandbox_test.js
+++ b/example/tests/sandbox_test.js
@@ -577,6 +577,13 @@
     );
   });
 
+  await test("TM半沙盒：把祖先类别继承直接写在半沙盒上 (Issue #1462 PR #1463)", async () => {
+    assertSame(true, Object.hasOwn(unsafeWindow, "addEventListener"), "unsafeWindow 继承 Object.hasOwn");
+    assertSame(true, Reflect.has(unsafeWindow, "addEventListener"), "unsafeWindow 继承 Reflect.has");
+    assertSame(false, Object.hasOwn(window, "addEventListener"), "window 属性 Object.hasOwn");
+    assertSame(true, Reflect.has(window, "addEventListener"), "window 属性 Reflect.has");
+  });
+
   section("GM API 注入与命名空间");
 
   await test("GM_info、GM.info 与 unsafeWindow 正确暴露", () => {

--- a/example/tests/sandbox_test.js
+++ b/example/tests/sandbox_test.js
@@ -578,10 +578,12 @@
   });
 
   await test("TM半沙盒：把祖先类别继承直接写在半沙盒上 (Issue #1462 PR #1463)", async () => {
-    assertSame(true, Object.hasOwn(unsafeWindow, "addEventListener"), "unsafeWindow 继承 Object.hasOwn");
-    assertSame(true, Reflect.has(unsafeWindow, "addEventListener"), "unsafeWindow 继承 Reflect.has");
-    assertSame(false, Object.hasOwn(window, "addEventListener"), "window 属性 Object.hasOwn");
-    assertSame(true, Reflect.has(window, "addEventListener"), "window 属性 Reflect.has");
+    const trueWindow = unsafeWindow;
+    const sandboxWindow = window;
+    assertSame(false, Object.hasOwn(trueWindow, "addEventListener"), "unsafeWindow 继承 Object.hasOwn");
+    assertSame(true, Reflect.has(trueWindow, "addEventListener"), "unsafeWindow 继承 Reflect.has");
+    assertSame(true, Object.hasOwn(sandboxWindow, "addEventListener"), "window 属性 Object.hasOwn");
+    assertSame(true, Reflect.has(sandboxWindow, "addEventListener"), "window 属性 Reflect.has");
   });
 
   section("GM API 注入与命名空间");

--- a/src/app/service/content/create_context.test.ts
+++ b/src/app/service/content/create_context.test.ts
@@ -232,4 +232,9 @@ describe.concurrent("createProxyContext", () => {
     sandbox.onload = null;
     expect(removeEventListener).toHaveBeenCalledWith("load", eventObject);
   });
+
+  it.concurrent("TM半沙盒：把祖先类别继承直接写在半沙盒上 ( #1462 #1463 )", () => {
+    const sandbox = createProxyContext(createTestContext([]));
+    expect(Object.hasOwn(sandbox, "addEventListener")).toBe(true);
+  });
 });

--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -199,7 +199,15 @@ getAllPropertyDescriptors(global, ([key, desc]) => {
       descsCache.add(key); // 必须：子类属性覆盖父类属性
     } else if (!(key in initOwnDescs) && !Object.hasOwn(global, key)) {
       if (!protoBaseDescs[key]) {
-        protoBaseDescs[key] = { ...desc };
+        if (typeof value === "function") {
+          const boundValue = value.bind(global);
+          protoBaseDescs[key] = {
+            ...desc,
+            value: boundValue,
+          };
+        } else {
+          protoBaseDescs[key] = { ...desc };
+        }
       }
     }
   } else {

--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -173,6 +173,9 @@ const overridedDescs: Record<string, PropertyDescriptor> = Object.create(null);
 // 记录原生 onxxxxx 的 PropertyDescriptor
 const eventDescs: Record<string, PropertyDescriptor> = Object.create(null);
 
+// 在 USE_PSEUDO_WINDOW 情况下，由于没有 类的prototype, 父类的成员要手动传下去
+const protoBaseDescs: Record<string, PropertyDescriptor> = Object.create(null);
+
 // 包含物件本身及所有父类(不包含Object)的PropertyDescriptor
 // 主要是找出哪些 function值， setter/getter 需要替换 global window
 getAllPropertyDescriptors(global, ([key, desc]) => {
@@ -194,6 +197,10 @@ getAllPropertyDescriptors(global, ([key, desc]) => {
         value: boundValue,
       };
       descsCache.add(key); // 必须：子类属性覆盖父类属性
+    } else if (!(key in initOwnDescs) && !Object.hasOwn(global, key)) {
+      if (!protoBaseDescs[key]) {
+        protoBaseDescs[key] = { ...desc };
+      }
     }
   } else {
     if (desc.configurable && desc.get && desc.set && desc.enumerable && key.startsWith("on")) {
@@ -248,6 +255,7 @@ Object.defineProperty(PseudoWindowPrototype, "__proto__", {
 
 const sharedInitCopy = USE_PSEUDO_WINDOW
   ? Object.create(null, {
+      ...protoBaseDescs, // 较快的 @unwrap 注入时有机会改变 EventTarget.prototype
       ...Object.getOwnPropertyDescriptors(PseudoWindowPrototype),
       ...initOwnDescs,
       ...overridedDescs,


### PR DESCRIPTION
原本设计是 继承 Window 的
后来被扭曲成没 prototype 的 四不象 ( #700 a1a868dfe3199e666fe2bcb65cfb2ad0ad3d699b , #966 )
所以就需要这个 PR 了

---

## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

#1462 

~由于 window.prototype 为 undefined, 无法做一个假父类去做这件事~
~只能把东西写在 半沙盒里~
我想多了。TM半沙盒本来就是 `Object.hasOwn(window, "addEventListener") === true`

## Screenshots / 截图

<!-- Screenshots / 截图-->
