### PR TITLE
fix: 修正没有 search 造成的template 不匹配

### DIFF
--- a/src/pages/options/routes/script/ScriptEditor.tsx
+++ b/src/pages/options/routes/script/ScriptEditor.tsx
@@ -148,9 +148,9 @@ const emptyScript = async (template: string, hotKeys: any, target?: string) => {
                   const pageUrl = result?.activeTabUrl?.url;
                   if (pageUrl) {
                     try {
-                      const { protocol, pathname, hostname } = new URL(pageUrl);
+                      const { protocol, pathname, hostname, search } = new URL(pageUrl);
                       if (protocol && pathname && hostname) {
-                        retUrl = `${protocol}//${hostname}${pathname}`;
+                        retUrl = `${protocol}//${hostname}${pathname}${search.length > 1 ? search : ""}`;
                         if (protocol === "http:" || protocol === "https:") {
                           retIcon = `https://www.google.com/s2/favicons?sz=64&domain=${hostname}`;
                         }


### PR DESCRIPTION
打开以下网址
然后点 popup 的 新建脚本
不改 `@match`
直接储存，关掉，重载页面看看有没有匹配成功

```
https://docs.scriptcat.org/docs/use/use/#%E5%8A%A0%E8%BD%BD%E8%A7%A3%E5%8E%8B%E7%BC%A9%E6%96%B9%E5%BC%8F%E5%AE%89%E8%A3%85%E6%89%A9%E5%B1%95
```

```
https://docs.scriptcat.org/docs/use/use/?hello=abc
```

---

修正后，跟 TM 更一致了
