### PR TITLE
fix(mv2): [temporary workaround] privileged api leakage due to same-origin

### DIFF
--- a/src/runtime/content/exec_script.ts
+++ b/src/runtime/content/exec_script.ts
@@ -55,7 +55,22 @@ export default class ExecScript {
       this.scriptFunc = scriptFunc;
     } else {
       // 构建脚本资源
-      this.scriptFunc = compileScript(this.scriptRes.code);
+      const scriptType = this.scriptRes.type;
+      let scriptCode = this.scriptRes.code;
+      if ((scriptType === 2 || scriptType === 3) && scriptCode.length > 0) {
+        // background script / scheduled script
+        // we need to remove the access to chrome or browser in FirefoxMV2
+        // since sandbox manifest support is still missing.
+        const arr = scriptCode.split("\n");
+        for (let i = 0, l = arr.length; i < l; i++) {
+          const t = arr[i].trim();
+          if (!t || t.startsWith("//")) continue;
+          arr.splice(i, 0, "let chrome = {}, browser = undefined;")
+          scriptCode = arr.join("\n");
+          break;
+        }
+      }
+      this.scriptFunc = compileScript(scriptCode);
     }
     if (scriptRes.grantMap.none) {
       // 不注入任何GM api

--- a/src/runtime/content/exec_script.ts
+++ b/src/runtime/content/exec_script.ts
@@ -51,6 +51,7 @@ export default class ExecScript {
     });
     this.GM_info = GMApi.GM_info(this.scriptRes);
     this.proxyMessage = new ProxyMessageManager(message);
+    let isSandbox = false;
     if (scriptFunc) {
       this.scriptFunc = scriptFunc;
     } else {
@@ -58,6 +59,7 @@ export default class ExecScript {
       const scriptType = this.scriptRes.type;
       let scriptCode = this.scriptRes.code;
       if ((scriptType === 2 || scriptType === 3) && scriptCode.length > 0) {
+        isSandbox = true;
         // background script / scheduled script
         // we need to remove the access to chrome or browser in FirefoxMV2
         // since sandbox manifest support is still missing.
@@ -65,7 +67,10 @@ export default class ExecScript {
         for (let i = 0, l = arr.length; i < l; i++) {
           const t = arr[i].trim();
           if (!t || t.startsWith("//")) continue;
-          arr.splice(i, 0, "let chrome = {}, browser = undefined;")
+          const codeGen = (target: string, property: string, value: string): string => {
+            return `try { Object.defineProperty(${target}, "${property}", { get() { return ${value}; }, configurable: false }); } catch {}`;
+          };
+          arr.splice(i, 0, `let chrome = {}, browser = undefined, frameElement = null, parent = window, top = window; try { window.parent = window; } catch {} ${codeGen("window", "parent", "this")} ${codeGen("window", "top", "this")} ${codeGen("window", "chrome", "{}")} ${codeGen("window", "browser", "undefined")} ${codeGen("window", "frameElement", "null")}`)
           scriptCode = arr.join("\n");
           break;
         }
@@ -85,7 +90,8 @@ export default class ExecScript {
       this.proxyContent = proxyContext(
         global,
         this.sandboxContent,
-        thisContext
+        thisContext,
+        isSandbox
       );
     }
   }

--- a/src/runtime/content/utils.ts
+++ b/src/runtime/content/utils.ts
@@ -93,7 +93,8 @@ export function warpObject(thisContext: Object, ...context: Object[]) {
 export function proxyContext(
   global: any,
   context: any,
-  thisContext?: { [key: string]: any }
+  thisContext?: { [key: string]: any },
+  isSandbox: boolean = false
 ) {
   const special = Object.assign(writables);
   // 处理某些特殊的属性
@@ -131,10 +132,15 @@ export function proxyContext(
           return proxy;
         case "top":
         case "parent":
+          if (isSandbox) return proxy;
           if (global[name] === global.self) {
             return special.global || proxy;
           }
           return global[name];
+        // eslint-disable-next-line no-fallthrough
+        case "frameElement":
+          if (isSandbox) return null;
+        // eslint-disable-next-line no-fallthrough
         default:
           break;
       }
@@ -195,6 +201,10 @@ export function proxyContext(
         case "top":
         case "parent":
           return true;
+        // eslint-disable-next-line no-fallthrough
+        case "frameElement":
+          if (isSandbox) return true;
+        // eslint-disable-next-line no-fallthrough
         default:
           break;
       }
@@ -233,6 +243,13 @@ export function proxyContext(
         case "self":
         case "globalThis":
           return false;
+        case "top":
+        case "parent":
+          if (isSandbox) return false;
+        // eslint-disable-next-line no-fallthrough
+        case "frameElement":
+          if (isSandbox) return false;
+        // eslint-disable-next-line no-fallthrough
         default:
       }
       if (has(special, name)) {


### PR DESCRIPTION
See #1470  and #1448

We have no choice in MV2....

* https://github.com/w3c/webextensions/issues/637

---


## Summary

This PR adds a temporary Firefox MV2 workaround to reduce privileged API leakage caused by the same-origin sandbox setup used for background/scheduled scripts.

After #1448, Firefox MV2 needs `sandbox="allow-same-origin allow-scripts"` for compatibility, but that means the userscript execution context can still reach extension-origin globals. In particular, background scripts may access privileged APIs through `chrome`, `browser`, `parent`, `top`, or `frameElement`.

This change hardens the MV2 background/scheduled script runtime by shadowing and proxying those escape hatches.

## Changes

### `src/runtime/content/exec_script.ts`

- Detects background and scheduled scripts using `scriptRes.type === 2 || scriptRes.type === 3`.
- Enables a sandbox workaround flag for those script types.
- Rewrites the script source before compilation by inserting a prelude before the first real code line.
- The injected prelude shadows:
  - `chrome` as `{}`
  - `browser` as `undefined`
  - `frameElement` as `null`
  - `parent` as `window`
  - `top` as `window`
- Also attempts to redefine corresponding `window.*` properties with guarded `Object.defineProperty(...)` calls.
- Passes the sandbox flag into `proxyContext(...)`.

### `src/runtime/content/utils.ts`

- Adds an optional `isSandbox` argument to `proxyContext(...)`.
- When sandbox mode is enabled:
  - `top` and `parent` resolve to the sandbox proxy instead of the real parent/top window.
  - `frameElement` resolves to `null`.
  - `frameElement` is reported as present by the `has` trap.
  - assignments to `top`, `parent`, and `frameElement` are rejected.

## Motivation

Firefox MV2 currently lacks the sandbox manifest support needed for a cleaner isolation model. Because ScriptCat still needs to support Firefox MV2, this PR adds a runtime-level mitigation for the privileged API leakage described in #1470.

## Security impact

This reduces accidental or direct access from background/scheduled userscripts to privileged extension APIs in Firefox MV2 same-origin execution contexts.

The workaround covers common access paths:

- direct globals: `chrome`, `browser`, `parent`, `top`, `frameElement`
- `window.*` access
- proxy-context access
- `in` checks for sandboxed globals
- assignment attempts to protected globals

## Scope

This workaround applies only to script types `2` and `3`, which are treated here as background/scheduled scripts.

Normal content/page script execution should keep the previous proxy behavior.

## Limitations

This is a temporary workaround, not a full browser-level sandbox replacement.

It relies on source rewriting and proxy traps, so future changes to script compilation or execution context creation should verify that these protections still run before userscript code executes.

## Related

- Fixes / mitigates #1470
- Follow-up to #1448
- Related WECG discussion: https://github.com/w3c/webextensions/issues/637
- [Bug 1685123](https://bugzilla.mozilla.org/show_bug.cgi?id=1685123) 
implement manifest sandbox support

---

## Verification Background Script

```js
// ==UserScript==
// @name         New Userscript M9NO-1
// @namespace    https://docs.scriptcat.org/
// @version      0.1.0
// @description  try to take over the world!
// @author       You
// @background
// ==/UserScript==

const chrome_ = typeof chrome === "undefined" ? undefined : chrome;
const browser_ = typeof browser === "undefined" ? undefined : browser;

console.log("sandbox 1", {
    chrome: chrome_,
    browser: browser_,
    frameElement: frameElement,
    frameElementToWindow: frameElement?.ownerDocument.defaultView,
    parentIsWindow: parent === window,
    topIsWindow: top === window,
});

console.log("sandbox 2", {
    chrome: window.chrome,
    browser: window.browser,
    frameElement: window.frameElement,
    frameElementToWindow: window.frameElement?.ownerDocument.defaultView,
    parentIsWindow: window.parent === window,
    topIsWindow: window.top === window,
});

console.log("sandbox 3", {
    chrome: this.chrome,
    browser: this.browser,
    frameElement: this.frameElement,
    frameElementToWindow: this.frameElement?.ownerDocument.defaultView,
    parentIsWindow: this.parent === window,
    topIsWindow: this.top === window,
});


console.log("sandbox 1e", {
    chrome: eval("chrome"),
    browser: eval("browser"),
    frameElement: eval("frameElement"),
    frameElementToWindow: eval("frameElement?.ownerDocument.defaultView"),
    parentIsWindow: eval("parent === window"),
    topIsWindow: eval("top === window"),
});

console.log("sandbox 2e", {
    chrome: eval("window.chrome"),
    browser: eval("window.browser"),
    frameElement: eval("window.frameElement"),
    frameElementToWindow: eval("window.frameElement?.ownerDocument.defaultView"),
    parentIsWindow: eval("window.parent === window"),
    topIsWindow: eval("window.top === window"),
});

console.log("sandbox 3e", {
    chrome: eval("this.chrome"),
    browser: eval("this.browser"),
    frameElement: eval("this.frameElement"),
    frameElementToWindow: eval("this.frameElement?.ownerDocument.defaultView"),
    parentIsWindow: eval("this.parent === window"),
    topIsWindow: eval("this.top === window"),
});

return new Promise((resolve, reject) => {
    // Your code here...
    resolve();

});
```

<img width="1055" height="453" alt="Screenshot 2026-05-25 at 19 54 46" src="https://github.com/user-attachments/assets/35e5994a-8872-4766-a83f-835969e23993" />
