### PR TITLE
修复 sandbox iframe 使用 display: none 导致的问题

### DIFF
--- a/src/pages/offscreen.html
+++ b/src/pages/offscreen.html
@@ -4,8 +4,28 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Offscreen</title>
+    <style>
+      .sandbox-iframe {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        border: 0;
+        padding: 0;
+        margin: 0;
+        opacity: 0;
+        pointer-events: none;
+        overflow: hidden;
+        clip-path: inset(50%);
+      }
+    </style>
   </head>
   <body>
-    <iframe src="/src/sandbox.html" name="sandbox" style="display: none"></iframe>
+    <iframe 
+      src="/src/sandbox.html" 
+      name="sandbox" 
+      class="sandbox-iframe"
+      aria-hidden="true"
+      tabindex="-1"
+    ></iframe>
   </body>
 </html>


### PR DESCRIPTION
## 描述

本次修改调整了 sandbox iframe 的隐藏方式，避免直接使用 `display: none`。

之前 iframe 通过内联样式 `display: none` 隐藏，可能会影响 sandbox 页面的正常加载或通信行为。现在改为使用 CSS 类将 iframe 缩小到 1px、设置透明、禁用交互并裁剪显示区域，在视觉上隐藏 iframe 的同时，仍保留其正常存在于页面中的行为。

同时为 iframe 增加了 `aria-hidden="true"` 和 `tabindex="-1"`，避免其被辅助技术读取或通过键盘聚焦。

## 主要变更

- 移除 iframe 上的 `style="display: none"`
- 新增 `.sandbox-iframe` 样式用于视觉隐藏 iframe
- 为 iframe 添加 `aria-hidden="true"` 和 `tabindex="-1"`
- 保持 sandbox iframe 可正常加载和运行

## 测试

- [x] E2E 确认 sandbox iframe 能正常加载 & 相关脚本执行 / 通信功能正常 (window_message_test)