### PR TITLE
Security: Prototype pollution via untrusted YAML user-config keys

### DIFF
--- a/src/pkg/utils/yaml.ts
+++ b/src/pkg/utils/yaml.ts
@@ -9,7 +9,7 @@ export function parseUserConfig(code: string): UserConfig | undefined {
   }
 
   const configs = config[1].trim().split(/[-]{3,}/);
-  const ret: UserConfig = {};
+  const ret = Object.create(null) as UserConfig;
 
   const sortSet = new Set<string>();
 
@@ -20,6 +20,10 @@ export function parseUserConfig(code: string): UserConfig | undefined {
     }
     // 验证是否符合分组规范：group -> config -> properties
     for (const [groupKey, groupValue] of Object.entries(obj)) {
+      if (["__proto__", "constructor", "prototype"].includes(groupKey)) {
+        throw new Error(`UserConfig group "${groupKey}" is not a valid object.`);
+      }
+
       if (!groupValue || typeof groupValue !== "object") {
         // 如果分组值不是对象，说明不符合规范
         throw new Error(`UserConfig group "${groupKey}" is not a valid object.`);

--- a/src/pkg/utils/yaml.ts
+++ b/src/pkg/utils/yaml.ts
@@ -20,8 +20,10 @@ export function parseUserConfig(code: string): UserConfig | undefined {
     }
     // 验证是否符合分组规范：group -> config -> properties
     for (const [groupKey, groupValue] of Object.entries(obj)) {
-      if (["__proto__", "constructor", "prototype"].includes(groupKey)) {
-        throw new Error(`UserConfig group "${groupKey}" is not a valid object.`);
+      // Reject keys inherited from Object.prototype (e.g. __proto__, constructor,
+      // valueOf, toString) so untrusted userscript metadata can't pollute lookups.
+      if (Reflect.has(Object.prototype, groupKey)) {
+        throw new Error(`UserConfig key "${groupKey}" is not valid.`);
       }
 
       if (!groupValue || typeof groupValue !== "object") {


### PR DESCRIPTION
## Summary

Security: Prototype pollution via untrusted YAML user-config keys

## Problem

**Severity**: `Medium` | **File**: `src/pkg/utils/yaml.ts:L12`

parseUserConfig() copies YAML group names directly into a plain object (`ret[groupKey] = groupValue`). A malicious userscript can use special keys such as `__proto__`, `constructor`, or `prototype` to mutate object prototypes or interfere with later merges/lookups. Because this parser handles untrusted script metadata, this can become a cross-script integrity issue.

## Solution

Create the result object with `Object.create(null)` and reject dangerous keys (`__proto__`, `constructor`, `prototype`) before assignment. Prefer a schema-validated structure instead of copying arbitrary keys into a plain object.

## Changes

- `src/pkg/utils/yaml.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced