### PR TITLE
🐛 修复暗色模式下页面初次加载白屏闪烁的问题

### DIFF
--- a/e2e/theme-flash.spec.ts
+++ b/e2e/theme-flash.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "./fixtures";
+
+// issue #1497：暗色系统下页面初次加载时，JS 设置 arco-theme 前 var(--color-bg-2) 无定义，出现白屏闪烁。
+// 通过 CDP 禁用脚本执行来固定"首帧"（React 挂载前）状态，验证模板内联 CSS 的暗色兜底背景。
+test.describe("暗色模式首屏闪烁 (issue #1497)", () => {
+  // options.html / popup.html / install.html 分别对应 options、popup、template 三个 HTML 模板
+  for (const pageName of ["options.html", "popup.html", "install.html"]) {
+    test(`系统暗色模式下 ${pageName} 首帧应为暗色背景`, async ({ context, extensionId }) => {
+      const page = await context.newPage();
+      await page.emulateMedia({ colorScheme: "dark" });
+      const cdp = await context.newCDPSession(page);
+      await cdp.send("Emulation.setScriptExecutionDisabled", { value: true });
+      await page.goto(`chrome-extension://${extensionId}/src/${pageName}`);
+      const bg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+      expect(bg).toBe("rgb(35, 35, 36)");
+      await page.close();
+    });
+  }
+
+  test("系统亮色模式下 options.html 首帧不应为暗色背景", async ({ context, extensionId }) => {
+    const page = await context.newPage();
+    await page.emulateMedia({ colorScheme: "light" });
+    const cdp = await context.newCDPSession(page);
+    await cdp.send("Emulation.setScriptExecutionDisabled", { value: true });
+    await page.goto(`chrome-extension://${extensionId}/src/options.html`);
+    const bg = await page.evaluate(() => getComputedStyle(document.body).backgroundColor);
+    expect(bg).not.toBe("rgb(35, 35, 36)");
+    await page.close();
+  });
+});

--- a/src/pages/options.html
+++ b/src/pages/options.html
@@ -14,6 +14,12 @@
         background-color: var(--color-bg-2);
         color: var(--color-text-1);
       }
+      /* 暗色系统下，JS 设置 arco-theme 前的兜底背景，避免白屏闪烁 (issue #1497) */
+      @media (prefers-color-scheme: dark) {
+        body:not([arco-theme]) {
+          background-color: #232324;
+        }
+      }
     </style>
   </head>
   <body>

--- a/src/pages/popup.html
+++ b/src/pages/popup.html
@@ -17,6 +17,12 @@
         min-height: 150px;
         max-height: 500px;
       }
+      /* 暗色系统下，JS 设置 arco-theme 前的兜底背景，避免白屏闪烁 (issue #1497) */
+      @media (prefers-color-scheme: dark) {
+        body:not([arco-theme]) {
+          background-color: #232324;
+        }
+      }
     </style>
   </head>
 

--- a/src/pages/store/AppContext.test.tsx
+++ b/src/pages/store/AppContext.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { render, setupGlobalMocks } from "@Tests/test-utils";
+
+// AppProvider 挂载时根据 localStorage.lightMode 初始化主题。
+// body 上的 arco-theme 属性必须始终被显式设置（light 也不例外），
+// 模板内联 CSS 依赖 body:not([arco-theme]) 识别"主题未初始化"状态来做暗色兜底（issue #1497）。
+describe("AppContext 颜色主题初始化", () => {
+  beforeAll(() => {
+    setupGlobalMocks();
+  });
+
+  afterEach(() => {
+    localStorage.removeItem("lightMode");
+    document.body.removeAttribute("arco-theme");
+    document.documentElement.classList.remove("dark");
+  });
+
+  it("dark 模式下应在 body 上设置 arco-theme=dark", () => {
+    localStorage.lightMode = "dark";
+    render(<div />);
+    expect(document.body.getAttribute("arco-theme")).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("light 模式下应在 body 上显式设置 arco-theme=light，以区分主题未初始化状态", () => {
+    localStorage.lightMode = "light";
+    render(<div />);
+    expect(document.body.getAttribute("arco-theme")).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("auto 模式且系统为亮色时也应显式标记 arco-theme=light", () => {
+    localStorage.lightMode = "auto";
+    render(<div />);
+    expect(document.body.getAttribute("arco-theme")).toBe("light");
+  });
+});

--- a/src/pages/store/AppContext.tsx
+++ b/src/pages/store/AppContext.tsx
@@ -54,7 +54,9 @@ const setAppColorTheme = (theme: "light" | "dark" | "auto") => {
       break;
     case "light":
       document.documentElement.classList.remove("dark");
-      document.body.removeAttribute("arco-theme");
+      // 显式设置 light 而不是移除属性：模板内联 CSS 依赖 body:not([arco-theme])
+      // 识别"主题未初始化"状态来做暗色兜底，避免白屏闪烁 (issue #1497)
+      document.body.setAttribute("arco-theme", "light");
       fnPlaceHolder.setEditorTheme?.("vs");
       break;
   }

--- a/src/pages/template.html
+++ b/src/pages/template.html
@@ -16,6 +16,12 @@
         background-color: var(--color-bg-2);
         color: var(--color-text-1);
       }
+      /* 暗色系统下，JS 设置 arco-theme 前的兜底背景，避免白屏闪烁 (issue #1497) */
+      @media (prefers-color-scheme: dark) {
+        body:not([arco-theme]) {
+          background-color: #232324;
+        }
+      }
     </style>
   </head>
 


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

fix #1497

**问题**：暗色主题下，options / popup / install 等页面初次加载时会先白屏一闪。根因是 `arco-theme` 属性由 React 挂载时的 JS（`AppContext.tsx`）设置，在此之前模板内联样式里的 `var(--color-bg-2)` 无定义，body 回退为白色。

**方案**（结合 issue 中两边的讨论）：

1. 三个 HTML 模板（`options.html` / `popup.html` / `template.html`）的内联样式中增加系统暗色兜底，仅在主题尚未初始化时生效：

   ```css
   @media (prefers-color-scheme: dark) {
     body:not([arco-theme]) {
       background-color: #232324; /* arco-theme=dark 时 --color-bg-2 的默认值 */
     }
   }
   ```

2. `AppContext.tsx` 的 light 分支由 `removeAttribute("arco-theme")` 改为显式 `setAttribute("arco-theme", "light")`，使 `body:not([arco-theme])` 精确等价于"JS 尚未初始化主题"。这样**不需要 issue 里原始提案中的 `:has(#root:empty)`**（回应 @cyfung1031 对 `:has` 的性能顾虑），同时让 `index.css` 中已有的 `body[arco-theme='light']` 滚动条规则真正生效（此前是死代码）。

   > 注：评论中单独的 `html.dark` CSS 变量方案无法解决本问题——`class="dark"` 同样是 React 挂载时才由 JS 设置，JS 运行前依然白屏，因此必须依赖 `prefers-color-scheme` 媒体查询。

各场景行为：

| 用户主题设置 | 系统主题 | 首帧表现 |
|---|---|---|
| auto / dark | 暗色 | ✅ 暗色背景，无白闪 |
| auto / light | 亮色 | ✅ 白色背景（原有行为） |
| light | 暗色 | 首帧短暂暗色，挂载后转亮（CSS-only 方案的固有限制，issue 作者已认可） |
| dark | 亮色 | 仍有白闪（CSS 无法读取 localStorage；MV3 CSP 禁止内联脚本，无法在首帧前读取用户设置） |

**测试**：

- 新增 `e2e/theme-flash.spec.ts`：通过 CDP `Emulation.setScriptExecutionDisabled` 固定"React 挂载前"首帧状态，模拟系统暗色验证三个模板页面 body 背景为 `rgb(35, 35, 36)`，并验证亮色系统下无"黑闪"。修复前三个用例均失败（实测白色 `rgb(255, 255, 255)`），修复后通过。
- 新增 `src/pages/store/AppContext.test.tsx`：验证 light / dark / auto 模式下 `arco-theme` 属性均被显式设置。

验证结果：单测 959 全部通过；e2e 32 全部通过；`pnpm run lint` 0 错误。

## Screenshots / 截图

修复前（系统暗色、脚本执行前首帧，e2e 截图）：body 为白色；修复后同状态 body 为 `#232324`。