### PR TITLE
⚡️ perf(runtime): cache static page-load script data

### DIFF
--- a/src/app/service/service_worker/resource.ts
+++ b/src/app/service/service_worker/resource.ts
@@ -83,22 +83,9 @@ export class ResourceService {
     const ret: { [key: string]: Resource } = {};
     await Promise.allSettled(
       script.metadata[type].map(async (uri) => {
-        /** 资源键名 */
-        let resourceKey = uri;
-        /** 文件路径 */
-        let path: string | null = uri;
-        if (type === "resource") {
-          // @resource xxx https://...
-          const split = uri.split(/\s+/);
-          if (split.length === 2) {
-            resourceKey = split[0];
-            path = split[1].trim();
-          } else {
-            path = null;
-          }
-        }
+        const { resourceKey, path } = parseResourceMetadataItem(uri, type);
         if (path) {
-          if (uri.startsWith("file:///")) {
+          if (path.startsWith("file:///")) {
             // 如果是file://协议，则每次请求更新一下文件
             const res = await this.updateResource(script.uuid, path, type);
             ret[resourceKey] = res;
@@ -364,4 +351,25 @@ export class ResourceService {
       });
     });
   }
+}
+
+export function parseResourceMetadataItem(
+  uri: string,
+  type: ResourceType
+): { resourceKey: string; path: string | null } {
+  /** 资源键名 */
+  let resourceKey = uri;
+  /** 文件路径 */
+  let path: string | null = uri;
+  if (type === "resource") {
+    // @resource xxx https://...
+    const split = uri.split(/\s+/);
+    if (split.length === 2) {
+      resourceKey = split[0];
+      path = split[1].trim();
+    } else {
+      path = null;
+    }
+  }
+  return { resourceKey, path };
 }

--- a/src/app/service/service_worker/runtime.test.ts
+++ b/src/app/service/service_worker/runtime.test.ts
@@ -4,18 +4,19 @@ import { vi, describe, it, expect, beforeEach, type MockedFunction } from "vites
 import { randomUUID } from "crypto";
 import type { Script, ScriptRunResource } from "@App/app/repo/scripts";
 import { SCRIPT_STATUS_DISABLE, SCRIPT_STATUS_ENABLE, SCRIPT_TYPE_NORMAL } from "@App/app/repo/scripts";
-import { getCombinedMeta } from "./utils";
+import { buildScriptRunResourceBasic, getCombinedMeta, scriptURLPatternResults } from "./utils";
 import type { SystemConfig } from "@App/pkg/config/config";
 import type { Group } from "@Packages/message/server";
 import type { ServiceWorkerMessageSend, WindowMessageBody } from "@Packages/message/window_message";
 import type { IMessageQueue } from "@Packages/message/message_queue";
 import type { ValueService } from "./value";
 import type { ScriptService } from "./script";
-import type { ResourceService } from "./resource";
+import { ResourceService } from "./resource";
 import type { ScriptDAO } from "@App/app/repo/scripts";
 import { LocalStorageDAO } from "@App/app/repo/localStorage";
 import type { MessageConnect, TMessage } from "@Packages/message/types";
 import { obtainBlackList } from "@App/pkg/utils/utils";
+import type { CompiledResource, Resource, ResourceType } from "@App/app/repo/resource";
 
 initTestEnv();
 
@@ -387,5 +388,329 @@ describe.concurrent("RuntimeService - getPageScriptMatchingResultByUrl 脚本匹
       expect(blacklistResult2).toBe(true);
       expect(normalResult2).toBe(false);
     });
+  });
+});
+
+describe("RuntimeService - getScriptsForTab 页面加载静态资料缓存", () => {
+  const createMockScript = (overrides: Partial<Script> = {}): Script => ({
+    uuid: randomUUID(),
+    name: "test-script",
+    namespace: "test-namespace",
+    type: SCRIPT_TYPE_NORMAL,
+    status: SCRIPT_STATUS_ENABLE,
+    sort: 0,
+    runStatus: "running" as const,
+    createtime: 1,
+    updatetime: 1,
+    checktime: 1,
+    metadata: {
+      match: ["https://www.example.com/*"],
+    },
+    ...overrides,
+  });
+
+  const createResource = (
+    url: string,
+    type: ResourceType,
+    content: string,
+    sha512 = `${url}:${content}`
+  ): Resource => ({
+    url,
+    content,
+    base64: "base64",
+    hash: {
+      md5: "",
+      sha1: "",
+      sha256: "",
+      sha384: "",
+      sha512,
+    },
+    link: {},
+    type,
+    contentType: "text/plain",
+    createtime: 1,
+    updatetime: 1,
+  });
+
+  const createRuntimeHarness = () => {
+    const scripts = new Map<string, Script>();
+    const compiledResources = new Map<string, CompiledResource>();
+    const codes = new Map<string, string>();
+    const resources = new Map<string, Record<string, Resource>>();
+    const values = new Map<string, Record<string, unknown>>();
+    const localResources = new Map<string, Resource>();
+
+    const mockGroup = {
+      use: vi.fn().mockReturnThis(),
+      group: vi.fn().mockReturnThis(),
+      on: vi.fn(),
+    } as unknown as Group;
+    const mockSender = {
+      async init() {},
+      messageHandle(_data: WindowMessageBody) {},
+      async connect(_data: TMessage): Promise<MessageConnect> {
+        return {} as MessageConnect;
+      },
+      async sendMessage<T = any>(_data: TMessage): Promise<T> {
+        return {} as T;
+      },
+    } as ServiceWorkerMessageSend;
+    const mockMessageQueue = {
+      group: vi.fn().mockReturnValue(mockGroup),
+      subscribe: vi.fn(),
+      publish: vi.fn(),
+    } as unknown as IMessageQueue;
+    const mockSystemConfig = {
+      getBlacklist: vi.fn().mockReturnValue(""),
+      addListener: vi.fn(),
+    } as unknown as SystemConfig;
+    const mockValueService = {
+      getScriptValue: vi.fn(async (script: Script) => values.get(script.uuid) || {}),
+    } as unknown as ValueService;
+    const mockResourceService = {
+      getScriptResources: vi.fn(async (script: Script) => resources.get(script.uuid) || {}),
+      updateResource: vi.fn(async (_uuid: string, url: string) => localResources.get(url)!),
+    } as unknown as ResourceService;
+    const mockScriptDAO = {
+      gets: vi.fn(async (uuids: string[]) => uuids.map((uuid) => scripts.get(uuid))),
+      get: vi.fn(async (uuid: string) => scripts.get(uuid)),
+      all: vi.fn().mockResolvedValue([]),
+      scriptCodeDAO: {
+        get: vi.fn(async (uuid: string) => {
+          const code = codes.get(uuid);
+          return code ? { uuid, code } : undefined;
+        }),
+      },
+    } as unknown as ScriptDAO;
+
+    const runtime = new RuntimeService(
+      mockSystemConfig,
+      mockGroup,
+      mockSender,
+      mockMessageQueue,
+      mockValueService,
+      {} as ScriptService,
+      mockResourceService,
+      mockScriptDAO,
+      new LocalStorageDAO()
+    );
+    const compiledResourceDAO = {
+      gets: vi.fn(async (uuids: string[]) => uuids.map((uuid) => compiledResources.get(uuid))),
+      get: vi.fn(async (uuid: string) => compiledResources.get(uuid)),
+      save: vi.fn(),
+      all: vi.fn().mockResolvedValue([]),
+    };
+    runtime.compiledResourceDAO = compiledResourceDAO as any;
+    runtime.updateSites = vi.fn();
+
+    const addScript = (script: Script, code = "// code", resource: Record<string, Resource> = {}) => {
+      scripts.set(script.uuid, script);
+      codes.set(script.uuid, code);
+      resources.set(script.uuid, resource);
+      const scriptRes = buildScriptRunResourceBasic(script);
+      const patterns = scriptURLPatternResults(scriptRes);
+      if (!patterns) return;
+      compiledResources.set(script.uuid, {
+        name: script.name,
+        flag: scriptRes.flag,
+        uuid: script.uuid,
+        require: [],
+        matches: [],
+        includeGlobs: [],
+        excludeMatches: [],
+        excludeGlobs: [],
+        allFrames: true,
+        world: "MAIN",
+        runAt: "",
+        scriptUrlPatterns: patterns.scriptUrlPatterns,
+        originalUrlPatterns:
+          patterns.originalUrlPatterns === patterns.scriptUrlPatterns ? null : patterns.originalUrlPatterns,
+      });
+      runtime.applyScriptMatchInfo(scriptRes);
+    };
+
+    return {
+      runtime,
+      addScript,
+      scripts,
+      values,
+      resources,
+      localResources,
+      mockScriptDAO,
+      compiledResourceDAO,
+      mockValueService,
+      mockResourceService,
+    };
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(chrome.userScripts as any, "getScripts").mockResolvedValue([]);
+    vi.spyOn(chrome.userScripts as any, "update").mockResolvedValue(undefined);
+  });
+
+  it("连续页面加载应复用静态资料但每次重新读取 value", async () => {
+    const h = createRuntimeHarness();
+    const script = createMockScript();
+    h.values.set(script.uuid, { key: "A" });
+    h.addScript(script);
+
+    const first = await h.runtime.getScriptsForTab({ url: "https://www.example.com/a", tabId: 1, frameId: 0 });
+    h.values.set(script.uuid, { key: "B" });
+    const second = await h.runtime.getScriptsForTab({ url: "https://www.example.com/b", tabId: 1, frameId: 0 });
+
+    expect(first?.injectScriptList[0].value).toEqual({ key: "A" });
+    expect(second?.injectScriptList[0].value).toEqual({ key: "B" });
+    expect(h.mockScriptDAO.gets).toHaveBeenCalledTimes(1);
+    expect(h.compiledResourceDAO.gets).toHaveBeenCalledTimes(1);
+    expect(h.mockResourceService.getScriptResources).toHaveBeenCalledTimes(1);
+    expect(h.mockScriptDAO.scriptCodeDAO.get).toHaveBeenCalledTimes(1);
+    expect(h.mockValueService.getScriptValue).toHaveBeenCalledTimes(2);
+    expect(h.runtime.__internalGetPageLoadStaticCacheSizeForTest()).toBe(1);
+  });
+
+  it("部分命中缓存时仍保持 inject、content 与 scriptmenus 顺序", async () => {
+    const h = createRuntimeHarness();
+    const injectA = createMockScript({ name: "A", sort: 1 });
+    const contentB = createMockScript({
+      name: "B",
+      sort: 2,
+      metadata: { match: ["https://www.example.com/*"], "inject-into": ["content"] },
+    });
+    const injectC = createMockScript({ name: "C", sort: 3 });
+    h.addScript(injectA);
+    h.addScript(contentB);
+    h.addScript(injectC);
+
+    await h.runtime.getScriptsForTab({ url: "https://www.example.com/a", tabId: 1, frameId: 0 });
+    h.runtime.__internalClearPageLoadStaticCacheForTest([contentB.uuid]);
+    const second = await h.runtime.getScriptsForTab({ url: "https://www.example.com/b", tabId: 1, frameId: 0 });
+
+    expect(second?.injectScriptList.map((script) => script.name)).toEqual(["A", "C"]);
+    expect(second?.contentScriptList.map((script) => script.name)).toEqual(["B"]);
+    expect(second?.scriptmenus.map((script) => script.name)).toEqual(["A", "B", "C"]);
+    expect(h.mockScriptDAO.gets).toHaveBeenLastCalledWith([contentB.uuid]);
+  });
+
+  it("中间脚本被 run-in 或 noframes 过滤后剩余脚本顺序仍正确", async () => {
+    const h = createRuntimeHarness();
+    const first = createMockScript({ name: "A", sort: 1 });
+    const runInFiltered = createMockScript({
+      name: "B",
+      sort: 2,
+      metadata: { match: ["https://www.example.com/*"], "run-in": ["incognito-tabs"] },
+    });
+    const noframesFiltered = createMockScript({
+      name: "C",
+      sort: 3,
+      metadata: { match: ["https://www.example.com/*"], noframes: [""] },
+    });
+    const last = createMockScript({ name: "D", sort: 4 });
+    h.addScript(first);
+    h.addScript(runInFiltered);
+    h.addScript(noframesFiltered);
+    h.addScript(last);
+
+    const result = await h.runtime.getScriptsForTab({ url: "https://www.example.com/a", tabId: 1, frameId: 1 });
+
+    expect(result?.injectScriptList.map((script) => script.name)).toEqual(["A", "D"]);
+    expect(result?.scriptmenus.map((script) => script.name)).toEqual(["A", "D"]);
+  });
+
+  it("页面过滤语义应保持不变", async () => {
+    const h = createRuntimeHarness();
+    const enabled = createMockScript();
+    h.addScript(enabled);
+
+    h.runtime.isLoadScripts = false;
+    await expect(
+      h.runtime.getScriptsForTab({ url: "https://www.example.com/a", tabId: 1, frameId: 0 })
+    ).resolves.toBeNull();
+    h.runtime.isLoadScripts = true;
+
+    h.runtime.blacklist = obtainBlackList("https://www.example.com/*");
+    h.runtime.loadBlacklist();
+    await expect(
+      h.runtime.getScriptsForTab({ url: "https://www.example.com/a", tabId: 1, frameId: 0 })
+    ).resolves.toBeNull();
+    h.runtime.blacklist = [];
+    h.runtime.loadBlacklist();
+
+    await expect(
+      h.runtime.getScriptsForTab({ url: "https://www.no-match.com/a", tabId: 1, frameId: 0 })
+    ).resolves.toBeNull();
+
+    const disabledHarness = createRuntimeHarness();
+    disabledHarness.addScript(createMockScript({ status: SCRIPT_STATUS_DISABLE }));
+    await expect(
+      disabledHarness.runtime.getScriptsForTab({ url: "https://www.example.com/a", tabId: 1, frameId: 0 })
+    ).resolves.toBeNull();
+
+    const excludedHarness = createRuntimeHarness();
+    excludedHarness.addScript(
+      createMockScript({
+        selfMetadata: { exclude: ["https://www.example.com/*"] },
+      })
+    );
+    await expect(
+      excludedHarness.runtime.getScriptsForTab({ url: "https://www.example.com/a", tabId: 1, frameId: 0 })
+    ).resolves.toBeNull();
+  });
+
+  it("本地 file resource 命中缓存时应热刷新，hash 不变不更新注册，hash 变化更新返回资源和注册代码", async () => {
+    const h = createRuntimeHarness();
+    const script = createMockScript({
+      metadata: {
+        match: ["https://www.example.com/*"],
+        require: ["file:///tmp/require.js"],
+        "require-css": ["file:///tmp/style.css"],
+        resource: ["asset file:///tmp/local.txt"],
+      },
+    });
+    const initialResources = {
+      "file:///tmp/require.js": createResource("file:///tmp/require.js", "require", "require-v1", "require-v1"),
+      "file:///tmp/style.css": createResource("file:///tmp/style.css", "require-css", "style-v1", "style-v1"),
+      asset: createResource("file:///tmp/local.txt", "resource", "asset-v1", "asset-v1"),
+    };
+    h.localResources.set("file:///tmp/require.js", initialResources["file:///tmp/require.js"]);
+    h.localResources.set("file:///tmp/style.css", initialResources["file:///tmp/style.css"]);
+    h.localResources.set("file:///tmp/local.txt", initialResources.asset);
+    h.addScript(script, "console.log('script');", initialResources);
+
+    await h.runtime.getScriptsForTab({ url: "https://www.example.com/a", tabId: 1, frameId: 0 });
+    await h.runtime.getScriptsForTab({ url: "https://www.example.com/b", tabId: 1, frameId: 0 });
+
+    expect(h.mockResourceService.updateResource).toHaveBeenCalledTimes(3);
+    expect(chrome.userScripts.update).not.toHaveBeenCalled();
+
+    const changedRequire = createResource("file:///tmp/require.js", "require", "require-v2", "require-v2");
+    const changedAsset = createResource("file:///tmp/local.txt", "resource", "asset-v2", "asset-v2");
+    h.localResources.set("file:///tmp/require.js", changedRequire);
+    h.localResources.set("file:///tmp/local.txt", changedAsset);
+    vi.mocked(chrome.userScripts.getScripts as any).mockResolvedValue([{ id: script.uuid, js: [{ code: "old" }] }]);
+
+    const third = await h.runtime.getScriptsForTab({ url: "https://www.example.com/c", tabId: 1, frameId: 0 });
+
+    expect(third?.injectScriptList[0].resource["file:///tmp/require.js"].content).toBe("require-v2");
+    expect(third?.injectScriptList[0].resource.asset.content).toBe("asset-v2");
+    expect(chrome.userScripts.update).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(chrome.userScripts.update).mock.calls[0][0][0].js?.[0].code).toContain("require-v2");
+  });
+
+  it("命名 @resource 的 file:/// 路径应按解析后的路径触发刷新", async () => {
+    const service = new ResourceService({} as Group, {} as IMessageQueue);
+    const fileResource = createResource("file:///tmp/local.txt", "resource", "local");
+    const updateResource = vi.spyOn(service, "updateResource").mockResolvedValue(fileResource);
+    const getResource = vi.spyOn(service, "getResource").mockResolvedValue(undefined);
+
+    const result = await service.getResourceByType(
+      createMockScript({ metadata: { resource: ["asset file:///tmp/local.txt"] } }),
+      "resource",
+      false
+    );
+
+    expect(updateResource).toHaveBeenCalledWith(expect.any(String), "file:///tmp/local.txt", "resource");
+    expect(getResource).not.toHaveBeenCalled();
+    expect(result.asset.content).toBe("local");
   });
 });

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -40,7 +40,7 @@ import {
 import LoggerCore from "@App/app/logger/core";
 import PermissionVerify from "./permission_verify";
 import { type SystemConfig } from "@App/pkg/config/config";
-import { type ResourceService } from "./resource";
+import { parseResourceMetadataItem, type ResourceService } from "./resource";
 import { type LocalStorageDAO } from "@App/app/repo/localStorage";
 import Logger from "@App/app/logger/logger";
 import type { GMInfoEnv, ValueUpdateDataEncoded } from "../content/types";
@@ -62,6 +62,24 @@ const RuntimeRegisterCode = {
 } as const;
 
 type RuntimeRegisterCode = ValueOf<typeof RuntimeRegisterCode>;
+
+type PageLoadStaticScriptInfo = ScriptLoadInfo & {
+  scriptUrlPatterns: URLRuleEntry[];
+  originalUrlPatterns: URLRuleEntry[];
+};
+
+type PageLoadLocalResourceInfo = {
+  resourceKey: string;
+  url: string;
+  type: ResourceType;
+  sha512: string;
+};
+
+type PageLoadStaticCacheEntry = {
+  script: PageLoadStaticScriptInfo;
+  code: string;
+  localResources: PageLoadLocalResourceInfo[];
+};
 
 const runtimeGlobal = {
   registerState: RuntimeRegisterCode.UNSET,
@@ -135,6 +153,8 @@ export class RuntimeService {
 
   compiledResourceDAO: CompiledResourceDAO = new CompiledResourceDAO();
 
+  private pageLoadStaticCache = new Map<string, PageLoadStaticCacheEntry>();
+
   constructor(
     private systemConfig: SystemConfig,
     private group: Group,
@@ -157,6 +177,26 @@ export class RuntimeService {
       if (typeof this.initReady !== "boolean") await this.initReady;
       return next();
     });
+  }
+
+  private clearPageLoadStaticCache(uuids?: string[]) {
+    if (!uuids) {
+      this.pageLoadStaticCache.clear();
+      return;
+    }
+    for (const uuid of uuids) {
+      this.pageLoadStaticCache.delete(uuid);
+    }
+  }
+
+  /** Internal test hook: page-load static cache is not a product API. */
+  public __internalGetPageLoadStaticCacheSizeForTest() {
+    return this.pageLoadStaticCache.size;
+  }
+
+  /** Internal test hook: page-load static cache is not a product API. */
+  public __internalClearPageLoadStaticCacheForTest(uuids?: string[]) {
+    this.clearPageLoadStaticCache(uuids);
   }
 
   async initUserAgentData() {
@@ -350,6 +390,7 @@ export class RuntimeService {
     if (script.type !== SCRIPT_TYPE_NORMAL || script.status !== SCRIPT_STATUS_ENABLE) {
       throw new Error("Invalid Calling of updateResourceOnScriptChange");
     }
+    this.clearPageLoadStaticCache([script.uuid]);
     // 安装，启用，或earlyStartScript的value更新
     const ret = await this.buildAndSaveCompiledResourceFromScript(script, true);
     if (!ret) return;
@@ -419,6 +460,7 @@ export class RuntimeService {
 
     // 监听脚本开启
     this.mq.subscribe<TEnableScript[]>("enableScripts", async (data) => {
+      this.clearPageLoadStaticCache(data.map(({ uuid }) => uuid));
       const unregisteyUuids = [] as string[];
       for (const { uuid, enable } of data) {
         const script = await this.scriptDAO.get(uuid);
@@ -452,6 +494,7 @@ export class RuntimeService {
 
     // 监听脚本安装
     this.mq.subscribe<TInstallScript>("installScript", async (data) => {
+      this.clearPageLoadStaticCache([data.script.uuid]);
       const script = await this.scriptDAO.get(data.script.uuid);
       if (!script) {
         this.logger.error("script install failed, script not found", {
@@ -475,6 +518,7 @@ export class RuntimeService {
 
     // 监听脚本删除
     this.mq.subscribe<TDeleteScript[]>("deleteScripts", async (data) => {
+      this.clearPageLoadStaticCache(data.map(({ uuid }) => uuid));
       const unregisteyUuids = [] as string[];
       for (const { uuid } of data) {
         unregisteyUuids.push(uuid);
@@ -488,6 +532,7 @@ export class RuntimeService {
 
     // 监听脚本排序
     this.mq.subscribe<TSortedScript[]>("sortedScripts", async (scripts) => {
+      this.clearPageLoadStaticCache();
       const uuidSort = Object.fromEntries(scripts.map(({ uuid, sort }) => [uuid, sort]));
       this.scriptMatchEnable.setupSorter(uuidSort);
       this.scriptMatchDisable.setupSorter(uuidSort);
@@ -524,15 +569,18 @@ export class RuntimeService {
         // 隐身窗口不对注册了的脚本进行实际操作
         // 在pageLoad时，根据isLoadScripts进行判断
         this.isLoadScripts = enable && (await this.systemConfig.getEnableScriptNormal());
+        this.clearPageLoadStaticCache();
       });
       this.systemConfig.addListener("enable_script", async (enable) => {
         // 隐身窗口不对注册了的脚本进行实际操作
         // 当主窗口的enable改为false时，isLoadScripts也会更改为false
         this.isLoadScripts = enable && (await this.systemConfig.getEnableScriptIncognito());
+        this.clearPageLoadStaticCache();
       });
     } else {
       this.systemConfig.addListener("enable_script", async (enable) => {
         this.isLoadScripts = enable;
+        this.clearPageLoadStaticCache();
         await this.unregisterUserscripts();
         if (enable) {
           await this.registerUserscripts();
@@ -544,6 +592,7 @@ export class RuntimeService {
     this.systemConfig.addListener("blacklist", async (blacklist: string) => {
       this.blacklist = obtainBlackList(blacklist);
       this.loadBlacklist();
+      this.clearPageLoadStaticCache();
       await this.unregisterUserscripts();
       if (this.isUserScriptsAvailable && this.isLoadScripts) {
         // 重新注册用户脚本；注册是会用加入 blacklistExcludeMatches 和 blacklistExcludeGlobs
@@ -692,6 +741,7 @@ export class RuntimeService {
   }
 
   public loadBlacklist() {
+    this.clearPageLoadStaticCache();
     // 设置黑名单match
     const blacklist = this.blacklist; // 重用cache的blacklist阵列 (immutable)
 
@@ -1113,6 +1163,172 @@ export class RuntimeService {
       return { ok: false };
     }
   }
+
+  private clonePageLoadStaticScript(entry: PageLoadStaticCacheEntry): PageLoadStaticScriptInfo {
+    const resource = {} as PageLoadStaticScriptInfo["resource"];
+    for (const [key, res] of Object.entries(entry.script.resource)) {
+      resource[key] = { ...res, hash: { ...res.hash }, link: { ...res.link } };
+    }
+    return {
+      ...entry.script,
+      value: {},
+      resource,
+    };
+  }
+
+  private getPageLoadLocalResources(script: PageLoadStaticScriptInfo): PageLoadLocalResourceInfo[] {
+    const ret: PageLoadLocalResourceInfo[] = [];
+    for (const type of ["require", "require-css", "resource"] as const) {
+      const resourceList = script.metadata[type];
+      if (!resourceList) continue;
+      for (const uri of resourceList) {
+        const { resourceKey, path } = parseResourceMetadataItem(uri, type);
+        const resource = script.resource[resourceKey];
+        if (path?.startsWith("file:///") && resource) {
+          ret.push({
+            resourceKey,
+            url: path,
+            type,
+            sha512: resource.hash.sha512,
+          });
+        }
+      }
+    }
+    return ret;
+  }
+
+  private async buildPageLoadStaticCacheEntry(
+    script: Script,
+    compiledResource: CompiledResource
+  ): Promise<PageLoadStaticCacheEntry | undefined> {
+    const scriptRes_ = buildScriptRunResourceBasic(script);
+    const { scriptUrlPatterns, originalUrlPatterns } = compiledResource;
+    const scriptRes: PageLoadStaticScriptInfo = {
+      ...scriptRes_,
+      scriptUrlPatterns: scriptUrlPatterns,
+      originalUrlPatterns: originalUrlPatterns === null ? scriptUrlPatterns : originalUrlPatterns,
+      code: "",
+      value: {},
+      resource: {},
+      metadataStr: "",
+      userConfigStr: "",
+    };
+
+    if (scriptRes.status === SCRIPT_STATUS_DISABLE) {
+      return undefined;
+    }
+
+    const [resource, code] = await Promise.all([
+      this.resource.getScriptResources(scriptRes, false),
+      this.scriptDAO.scriptCodeDAO.get(scriptRes.uuid),
+    ]);
+
+    scriptRes.resource = resource;
+    for (const name of Object.keys(resource)) {
+      const res = scriptRes.resource[name];
+      if (res.content) {
+        res.base64 = undefined;
+      }
+    }
+
+    let scriptCode = "";
+    if (code) {
+      const metadataStr = getMetadataStr(code.code) || "";
+      const userConfigStr = getUserConfigStr(code.code) || "";
+      scriptRes.metadataStr = metadataStr;
+      scriptRes.userConfigStr = userConfigStr;
+      scriptRes.userConfig = parseUserConfig(userConfigStr);
+      scriptCode = code.code;
+    }
+
+    return {
+      script: scriptRes,
+      code: scriptCode,
+      localResources: this.getPageLoadLocalResources(scriptRes),
+    };
+  }
+
+  private async refreshPageLoadLocalResources(entry: PageLoadStaticCacheEntry): Promise<boolean> {
+    let resourceUpdated = false;
+    for (const localResource of entry.localResources) {
+      const updatedResource = await this.resource.updateResource(
+        entry.script.uuid,
+        localResource.url,
+        localResource.type
+      );
+      if (updatedResource.hash?.sha512 !== localResource.sha512) {
+        resourceUpdated = true;
+        localResource.sha512 = updatedResource.hash.sha512;
+        const resource = entry.script.resource[localResource.resourceKey];
+        if (resource) {
+          resource.content = updatedResource.content;
+          resource.contentType = updatedResource.contentType;
+          resource.createtime = updatedResource.createtime;
+          resource.hash = updatedResource.hash;
+          resource.link = updatedResource.link;
+          resource.type = updatedResource.type;
+          resource.updatetime = updatedResource.updatetime;
+        } else {
+          entry.script.resource[localResource.resourceKey] = { ...updatedResource, base64: undefined };
+        }
+      }
+    }
+    return resourceUpdated;
+  }
+
+  private async updateRegisteredScriptsForPageLoadResourceChanges(entries: PageLoadStaticCacheEntry[]) {
+    if (!entries.length) return;
+    const entriesByUUID = new Map(entries.map((entry) => [entry.script.uuid, entry]));
+    const scriptRegisterInfoList = (
+      await chrome.userScripts.getScripts({
+        ids: [...entriesByUUID.keys()],
+      })
+    ).filter((scriptRegisterInfo) => {
+      const entry = entriesByUUID.get(scriptRegisterInfo.id);
+      if (entry?.code) {
+        scriptRegisterInfo.js = [
+          {
+            code: compileInjectionCode(entry.script, entry.code, entry.script.scriptUrlPatterns),
+          },
+        ];
+        return true;
+      }
+      return false;
+    });
+    if (scriptRegisterInfoList.length) {
+      try {
+        await chrome.userScripts.update(scriptRegisterInfoList);
+      } catch (e) {
+        this.logger.error("update registered userscripts error", Logger.E(e));
+      }
+    }
+  }
+
+  private canRunPageLoadScript(scriptRes: PageLoadStaticScriptInfo, frameId: number | undefined) {
+    // 判断脚本是否开启
+    if (scriptRes.status === SCRIPT_STATUS_DISABLE) {
+      return false;
+    }
+    // 判断注入页面类型
+    if (scriptRes.metadata["run-in"]) {
+      const runIn = scriptRes.metadata["run-in"][0];
+      if (runIn !== "all") {
+        // 判断插件运行环境
+        const contextType = chrome.extension.inIncognitoContext ? "incognito-tabs" : "normal-tabs";
+        if (runIn !== contextType) {
+          return false;
+        }
+      }
+    }
+    // 如果是iframe,判断是否允许在iframe里运行
+    if (frameId) {
+      if (scriptRes.metadata.noframes) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   async getScriptsForTab({ url, frameId }: TTabInfo): Promise<TScriptsForTab> {
     if (!this.isLoadScripts) {
       return null;
@@ -1130,189 +1346,59 @@ export class RuntimeService {
     // 该网址没有任何脚本匹配，包括排除匹配
     if (!matchingResult.size) return null;
 
-    const enableScriptList = [] as (ScriptLoadInfo & { scriptUrlPatterns: URLRuleEntry[] })[];
-
     const uuids = [...matchingResult.keys()];
+    const enableScriptList = [] as PageLoadStaticScriptInfo[];
+    const missingUUIDs = uuids.filter((uuid) => !this.pageLoadStaticCache.has(uuid));
+    const missingUUIDSet = new Set(missingUUIDs);
 
-    const [scripts, compiledResources] = await Promise.all([
-      this.scriptDAO.gets(uuids),
-      this.compiledResourceDAO.gets(uuids),
-    ]);
-
-    const resourceChecks = {} as { [uuid: string]: Record<string, [string, ResourceType]> };
-
-    for (let idx = 0, l = uuids.length; idx < l; idx++) {
-      const uuid = uuids[idx];
-      const script = scripts[idx];
-      const compiledResource = compiledResources[idx];
-
-      if (!script || !compiledResource) continue;
-      const scriptRes_ = buildScriptRunResourceBasic(script);
-      const { scriptUrlPatterns, originalUrlPatterns } = compiledResource;
-
-      for (const [_key, res] of Object.entries(scriptRes_.resource)) {
-        if (res.url.startsWith("file:///")) {
-          const resourceCheck =
-            resourceChecks[uuid] || (resourceChecks[uuid] = {} as Record<string, [string, ResourceType]>);
-          resourceCheck[res.url] = [res.hash.sha512, res.type];
-        }
-      }
-
-      // 物件部份内容预设为空
-      const scriptRes = {
-        ...scriptRes_,
-        scriptUrlPatterns: scriptUrlPatterns,
-        originalUrlPatterns: originalUrlPatterns === null ? scriptUrlPatterns : originalUrlPatterns,
-        code: "",
-        value: {},
-        resource: {},
-        metadataStr: "",
-        userConfigStr: "",
-      };
-
-      // 判断脚本是否开启
-      if (scriptRes.status === SCRIPT_STATUS_DISABLE) {
-        continue;
-      }
-      // 判断注入页面类型
-      if (scriptRes.metadata["run-in"]) {
-        const runIn = scriptRes.metadata["run-in"][0];
-        if (runIn !== "all") {
-          // 判断插件运行环境
-          const contextType = chrome.extension.inIncognitoContext ? "incognito-tabs" : "normal-tabs";
-          if (runIn !== contextType) {
-            continue;
+    if (missingUUIDs.length) {
+      const [scripts, compiledResources] = await Promise.all([
+        this.scriptDAO.gets(missingUUIDs),
+        this.compiledResourceDAO.gets(missingUUIDs),
+      ]);
+      await Promise.all(
+        missingUUIDs.map(async (uuid, idx) => {
+          const script = scripts[idx];
+          const compiledResource = compiledResources[idx];
+          if (!script || !compiledResource) return;
+          const entry = await this.buildPageLoadStaticCacheEntry(script, compiledResource);
+          if (entry) {
+            this.pageLoadStaticCache.set(uuid, entry);
           }
-        }
+        })
+      );
+    }
+
+    const resourceUpdatedEntries: PageLoadStaticCacheEntry[] = [];
+    for (const uuid of uuids) {
+      const cacheEntry = this.pageLoadStaticCache.get(uuid);
+      if (!cacheEntry) continue;
+      if (!this.canRunPageLoadScript(cacheEntry.script, frameId)) continue;
+      if (
+        !missingUUIDSet.has(uuid) &&
+        cacheEntry.localResources.length &&
+        (await this.refreshPageLoadLocalResources(cacheEntry))
+      ) {
+        resourceUpdatedEntries.push(cacheEntry);
       }
-      // 如果是iframe,判断是否允许在iframe里运行
-      if (frameId) {
-        if (scriptRes.metadata.noframes) {
-          continue;
-        }
-      }
+      const scriptRes = this.clonePageLoadStaticScript(cacheEntry);
       enableScriptList.push(scriptRes);
     }
 
     // 没有任何启用脚本
     if (!enableScriptList.length) return null;
 
-    const scriptCodes = {} as Record<string, string>;
-    // 更新资源使用了file协议的脚本
-    const scriptsWithUpdatedResources = new Map<string, ScriptLoadInfo>();
-    for (const scriptRes of enableScriptList) {
-      const uuid = scriptRes.uuid;
-      const resourceCheck = resourceChecks[uuid];
-      if (resourceCheck) {
-        let resourceUpdated = false;
-        for (const [url, [sha512, type]] of Object.entries(resourceCheck)) {
-          const resourceList = scriptRes.metadata[type];
-          if (!resourceList) continue;
-          const updatedResource = await this.resource.updateResource(scriptRes.uuid, url, type);
-          if (updatedResource.hash?.sha512 !== sha512) {
-            for (const uri of resourceList) {
-              /** 资源键名 */
-              let resourceKey = uri;
-              /** 文件路径 */
-              let path: string | null = uri;
-              if (type === "resource") {
-                // @resource xxx https://...
-                const split = uri.split(/\s+/);
-                if (split.length === 2) {
-                  resourceKey = split[0];
-                  path = split[1].trim();
-                } else {
-                  path = null;
-                }
-              }
-              if (path === url) {
-                const r = scriptRes.resource[resourceKey];
-                if (r) {
-                  resourceUpdated = true;
-                  r.content = updatedResource.content;
-                  r.contentType = updatedResource.contentType;
-                  r.createtime = updatedResource.createtime;
-                  r.hash = updatedResource.hash;
-                  r.link = updatedResource.link;
-                  r.type = updatedResource.type;
-                  r.updatetime = updatedResource.updatetime;
-                }
-              }
-            }
-          }
-        }
-        if (resourceUpdated) {
-          scriptsWithUpdatedResources.set(scriptRes.uuid, scriptRes);
-          scriptCodes[scriptRes.uuid] = scriptRes.code || "";
-        }
-      }
-    }
+    await this.updateRegisteredScriptsForPageLoadResourceChanges(resourceUpdatedEntries);
 
-    const { value, resource, scriptDAO } = this;
+    const { value } = this;
     await Promise.all(
-      enableScriptList.flatMap((script) => [
+      enableScriptList.map((script) =>
         // 加载value
         value.getScriptValue(script!).then((value) => {
           script.value = value;
-        }),
-        // 加载resource
-        resource.getScriptResources(script, false).then((resource) => {
-          script.resource = resource;
-          for (const name of Object.keys(resource)) {
-            const res = script.resource[name];
-            // 删除base64以节省资源
-            // 如果有content就删除base64
-            if (res.content) {
-              res.base64 = undefined;
-            }
-          }
-        }),
-        // 加载code相关的信息
-        scriptDAO.scriptCodeDAO.get(script.uuid).then((code) => {
-          if (code) {
-            const metadataStr = getMetadataStr(code.code) || "";
-            const userConfigStr = getUserConfigStr(code.code) || "";
-            const userConfig = parseUserConfig(userConfigStr);
-            script.metadataStr = metadataStr;
-            script.userConfigStr = userConfigStr;
-            script.userConfig = userConfig;
-            if (scriptCodes[script.uuid] === "") {
-              scriptCodes[script.uuid] = code.code;
-            }
-          }
-        }),
-      ])
-    );
-
-    if (scriptsWithUpdatedResources.size) {
-      const scriptRegisterInfoList = (
-        await chrome.userScripts.getScripts({
-          ids: [...scriptsWithUpdatedResources.keys()],
         })
-      ).filter((scriptRegisterInfo) => {
-        const targetUUID = scriptRegisterInfo.id;
-        const scriptRes = scriptsWithUpdatedResources.get(targetUUID);
-        const scriptDAOCode = scriptCodes[targetUUID];
-        if (scriptRes && scriptDAOCode) {
-          const scriptInjectCode = compileInjectionCode(scriptRes, scriptDAOCode, scriptRes.scriptUrlPatterns!);
-          scriptRegisterInfo.js = [
-            {
-              code: scriptInjectCode,
-            },
-          ];
-          return true;
-        }
-        return false;
-      });
-      // 批量更新
-      if (scriptRegisterInfoList.length) {
-        try {
-          await chrome.userScripts.update(scriptRegisterInfoList);
-        } catch (e) {
-          this.logger.error("update registered userscripts error", Logger.E(e));
-        }
-      }
-    }
+      )
+    );
 
     // 发布给 Popup 的信息
     const scriptmenus = enableScriptList.map((script) => scriptToMenu(script));


### PR DESCRIPTION
主要是把 #1404 中某部份拆出来，然后关掉 #1404.
( #1404 有点过度复杂 ）

----

Also fix named file:// @resource refresh by checking the parsed resource path.

## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [ ] Changes tested / 已完成测试

## Description / 描述

<!-- Description / PR 描述 -->

### 核心改动：
- 为 `RuntimeService.getScriptsForTab` 增加页面加载专用静态资料缓存。
- 缓存 `compiled resource`、resource、script code、metadata/userConfig 字串和解析结果、URL patterns。
- `value.getScriptValue` 仍每次页面加载重新读取，不进入缓存。
- install/update/delete/enable/disable/sort、blacklist、全局启停等路径保守清理缓存。
- 本地 `file:///` resource 命中缓存时仍逐次刷新；hash 变化才更新返回 resource 和已注册 userScript。
- 修复命名 `@resource asset file:///...` 使用原始整行判断导致无法热刷新的问题，改为判断解析后的路径。

### 新增/调整测试：
- 静态资料复用与 value 实时性。
- value 更新后下一次页面加载返回新值。
- 部分缓存命中时顺序稳定。
- `run-in` / `noframes` 过滤后顺序稳定。
- 全局停用、blacklist、无匹配、disabled、自定义 exclude 等页面过滤语义。
- `@require file:///...`、`@require-css file:///...`、命名 `@resource file:///...` 热刷新和 userScript 更新。



## Screenshots / 截图

<!-- Screenshots / 截图-->
