### PR TITLE
✨ Chromium 148+ 扩展消息启用 structured_clone 序列化

### DIFF
--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -77,6 +77,8 @@ delete chromeManifest.background.scripts;
 firefoxManifest.optional_permissions = firefoxManifest.optional_permissions.filter((val) => val !== "background");
 delete firefoxManifest.background.service_worker;
 delete firefoxManifest.sandbox;
+// Firefox 的扩展消息默认即为 structured clone，该键仅 Chromium 148+ 识别
+delete firefoxManifest.message_serialization;
 firefoxManifest.browser_specific_settings = {
   gecko: {
     id: `{${

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,11 +10,10 @@
   },
   "background": {
     "service_worker": "src/service_worker.js",
-    "scripts": [
-      "src/service_worker.js"
-    ]
+    "scripts": ["src/service_worker.js"]
   },
   "incognito": "split",
+  "message_serialization": "structured_clone",
   "action": {
     "default_popup": "src/popup.html",
     "default_icon": {
@@ -44,26 +43,15 @@
     "declarativeNetRequest",
     "debugger"
   ],
-  "optional_permissions": [
-    "background",
-    "userScripts"
-  ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "optional_permissions": ["background", "userScripts"],
+  "host_permissions": ["<all_urls>"],
   "sandbox": {
-    "pages": [
-      "src/sandbox.html"
-    ]
+    "pages": ["src/sandbox.html"]
   },
   "web_accessible_resources": [
     {
-      "resources": [
-        "/src/install.html"
-      ],
-      "matches": [
-        "<all_urls>"
-      ]
+      "resources": ["/src/install.html"],
+      "matches": ["<all_urls>"]
     }
   ]
 }


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

close #1526

按 https://developer.chrome.com/blog/structured-clone-messaging ，在 manifest 加入 `"message_serialization": "structured_clone"`，使 Chromium 148+ 的扩展消息（`chrome.runtime` / `chrome.tabs` sendMessage 与 connect port）改用 structured clone 序列化，与 Firefox 的默认行为一致。

### 可行性分析

- **向下兼容**：Chromium < 148（本项目最低目标 chrome >= 120）不识别该键，继续使用 JSON 序列化，仅在 chrome://extensions 显示一条 "Unrecognized manifest key" 警告（与 `browser_specific_settings` 类键同性质，不影响加载）。
- **代码零改动即可启用**：受影响的通道只有 `ExtensionMessage` 与 `MessageQueue`（chrome.runtime/tabs 消息）。这些共享路径在 Firefox 上一直运行于 structured clone 语义下且工作正常，故 payload 均为 clone-safe。`WindowMessage` 与 `ServiceWorkerMessageSend` 本就走 postMessage（structured clone），`CustomEventMessage` 经 CustomEvent detail 直传对象，均不受该键影响。
- **无外部消息风险**：项目无 `externally_connectable` / `onMessageExternal`（不存在跨扩展序列化格式不匹配问题），无 nativeMessaging；消息 payload 中亦无依赖 `toJSON()` 的对象。
- **Firefox 打包**：Firefox 扩展消息默认即为 structured clone，该键对其无意义，`pack.js` 生成 Firefox manifest 时移除（与 `sandbox` 等 Chrome 特有键同样处理），避免 AMO 未知键警告。

### 收益

- 消除 Chrome（JSON）与 Firefox（structured clone）消息语义分歧这一整类跨浏览器差异；Chrome 上 SW ↔ Offscreen 往返也变为两个方向同为 structured clone（去程 `clients.postMessage` 本就是）。
- 大 payload（如 GM_xmlhttpRequest 的 base64 响应体）省去 JSON stringify/parse 开销。
- 为将来直接传递 `Blob`/`File`（GM_xhr、附件等）铺路 —— 需待最低支持版本 ≥ 148 或加特性检测后才能在代码中依赖。

### 已知行为变化（Chromium 148+）

用户脚本经消息通道传递非 JSON 值时的中途转换会改变：例如 `GM_setValue(k, new Date())` 原先在消息层被 JSON 转成 ISO 字符串，现在 Date 对象会原样到达 SW、再由 `chrome.storage`（JSON 存储）序列化。此行为与 Firefox 现状一致，且 value 本就要求 JSON-serializable。

### 测试

- `pnpm exec vitest run scripts/build-config.test.js`：9 passed。
- `node --check scripts/pack.js`、manifest JSON 解析、prettier、tsc（pre-commit）均通过。
- 未新增单元测试：改动为纯 manifest 配置，按 `docs/DEVELOP.md` "file-content assertion" 属应清理的无效测试类型。
- 顺带说明：`src/manifest.json` 此前未按 prettier 格式化，pre-commit 的 `prettier --check` 会拦截，故本次提交包含 prettier 机械格式化（数组折行合并）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
