### PR TITLE
📄 更新翻译术语文档并补充土耳其语规范

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -419,7 +419,7 @@ Script list and Logger can hold thousands of rows. Keep large lists responsive: 
 
 ### Text expansion (i18n)
 
-Copy is translated into 7 locales and German/Russian run ~30% longer than English. Layouts must **flex or truncate, never clip**: let labels wrap or `truncate` with a `title`/tooltip, give buttons/badges `min-w` room instead of fixed widths, and don't pin a control's width to its English string. Verify a long-locale on the tightest screens (mobile cards, the ActionBar). RTL is **not** a target for the current locale set.
+Copy is translated into 8 locales and German/Russian run ~30% longer than English. Layouts must **flex or truncate, never clip**: let labels wrap or `truncate` with a `title`/tooltip, give buttons/badges `min-w` room instead of fixed widths, and don't pin a control's width to its English string. Verify a long-locale on the tightest screens (mobile cards, the ActionBar). RTL is **not** a target for the current locale set.
 
 ---
 

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -179,7 +179,7 @@ jq -r '.testResults[] | .name as $file | .assertionResults[] | [.duration, $file
 
 ## i18n
 
-i18next, 7 locales (`src/locales/`: en-US, zh-CN, zh-TW, ja-JP, de-DE, vi-VN, ru-RU); extension strings in `src/assets/_locales/`. ESLint `react/jsx-no-literals: warn` enforces translation. Each locale is split by namespace into multiple `*.json` files (`common.json`, `popup.json`, `script.json`, …), re-exported via the locale's `index.ts` and merged in `src/locales/locales.ts`. `defaultNS` is `common`; keys in any other namespace need the `ns:` prefix (e.g. `t("script:tags")`). For localization, edit the relevant namespace `*.json` under `src/locales/<locale>/`; new locales must also be registered in `src/locales/locales.ts`.
+i18next, 8 locales (`src/locales/`: en-US, zh-CN, zh-TW, ja-JP, de-DE, vi-VN, ru-RU, tr-TR); extension strings in `src/assets/_locales/`. ESLint `react/jsx-no-literals: warn` enforces translation. Each locale is split by namespace into multiple `*.json` files (`common.json`, `popup.json`, `script.json`, …), re-exported via the locale's `index.ts` and merged in `src/locales/locales.ts`. `defaultNS` is `common`; keys in any other namespace need the `ns:` prefix (e.g. `t("script:tags")`). For localization, edit the relevant namespace `*.json` under `src/locales/<locale>/`; new locales must also be registered in `src/locales/locales.ts`.
 
 **Before translating, read [`docs/translation/README.md`](translation/README.md)** — the translation/localization guide (terminology rules + per-locale `terminology-<locale>.md` specs).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@
 | 文档 | 说明 |
 | --- | --- |
 | [`translation/README.md`](./translation/README.md) | 翻译 / 本地化指南(单一信息源):术语与修改规则、工作流、提取翻译提示词。**翻译前先读。** |
-| [`translation/README.md` 术语规范表](./translation/README.md#各语言术语规范--per-locale-terminology) | 各语言地区术语与界面文案规范 `terminology-<locale>.md`(en-US / zh-CN / zh-TW / ja-JP / ru-RU / de-DE / vi-VN)。 |
+| [`translation/README.md` 术语规范表](./translation/README.md#各语言术语规范--per-locale-terminology) | 8 个语言地区的术语与界面文案规范 `terminology-<locale>.md`(en-US / zh-CN / zh-TW / ja-JP / ru-RU / de-DE / vi-VN / tr-TR)。 |
 
 ## 贡献指南 / Contributing
 

--- a/docs/translation/README.md
+++ b/docs/translation/README.md
@@ -36,6 +36,7 @@
 | `ru-RU` | Русский | [terminology-ru-RU.md](./terminology-ru-RU.md) |
 | `de-DE` | Deutsch | [terminology-de-DE.md](./terminology-de-DE.md) |
 | `vi-VN` | Tiếng Việt | [terminology-vi-VN.md](./terminology-vi-VN.md) |
+| `tr-TR` | Türkçe | [terminology-tr-TR.md](./terminology-tr-TR.md) |
 
 > `en-US` 是运行时的回退语言（fallback），也是新翻译的模板。其措辞应被刻意校准而非将含糊或不通顺的英文直接传播到其他 locale。
 

--- a/docs/translation/terminology-de-DE.md
+++ b/docs/translation/terminology-de-DE.md
@@ -2,7 +2,7 @@
 
 Dieses Dokument definiert die Terminologie für die deutsche (`de-DE`) Benutzeroberfläche und Dokumentation von ScriptCat. Es dient dazu, Produktkonzepte eindeutig zu benennen, UI-Texte natürlich zu formulieren und technische Bezeichner bei künftigen Übersetzungen unverändert zu erhalten.
 
-Geprüfte Verwendungsquelle: `src/locales/de-DE/*.json`
+Geprüfte Verwendungsquellen: `src/locales/de-DE/*.json`, `docs/ARCHITECTURE.md`
 
 ## Grundsätze
 
@@ -27,15 +27,16 @@ Geprüfte Verwendungsquelle: `src/locales/de-DE/*.json`
 
 | Konzept | Bevorzugte Formulierung | Aktuelle Beispiel-Keys | Hinweise |
 | --- | --- | --- | --- |
-| ScriptCat browser extension | `ScriptCat-Erweiterung` | `start_guide_title`, `ext_update_notification` | Produktname als `ScriptCat` schreiben. |
-| generic user script | `Benutzerskript` | `create_user_script`, `guide_script_list_content` | Allgemeine Bezeichnung für ein Userscript. |
-| Tampermonkey-compatible script type | `Tampermonkey-Skript` | `script_status_tooltip` | Nicht zu einem allgemeinen Skripttyp verkürzen. |
-| page script | `Seitenskript` | `page_script`, `foreground_page_script_tooltip` | Skript, das auf angegebenen Seiten ausgeführt wird. |
+| ScriptCat browser extension | `ScriptCat-Erweiterung` | `welcome_title`, `ext_update_notification` | Produktname als `ScriptCat` schreiben. |
+| generic user script | `Benutzerskript` | `create_user_script`, `script_list_content` | Allgemeine Bezeichnung für ein Userscript. |
+| normal userscript type | `Benutzerskript` / aktuelle Kategorie `Normales Skript` | `create_user_script`, `script_list.sidebar.normal_script` | Nicht mit Hintergrund- oder geplanten Skripten zusammenführen. |
+| Tampermonkey compatibility | `Tampermonkey-kompatibles Benutzerskript` / `Tampermonkey-Skript` | `docs/ARCHITECTURE.md` | Nur verwenden, wenn die Kompatibilität gemeint ist; nicht als pauschalen Ersatz für `Benutzerskript`. |
+| page script | `Seitenskript` | `script_list_enable_content` | Bezeichnet im UI ein auf Seiten ausgeführtes Skript; nicht ungeprüft als Ersatz für die Kategorie `Normales Skript` verwenden. |
 | background script | `Hintergrundskript` | `create_background_script`, `background_script` | Produkttyp für Ausführung im Hintergrund. |
 | scheduled script | `Geplantes Skript` | `create_scheduled_script`, `scheduled_script` | Produkttyp für geplante Ausführung; nicht ohne Kontext in `Cron-Skript` umbenennen. |
 | script synchronization | `Skript-Synchronisation` | `script_sync`, `sync_status` | Bei Löschungen klarstellen, ob ein Löschstatus synchronisiert wird. |
-| subscription | `Abonnement` | `subscribe_url`, `install_subscribe`, `subscribe_import_progress` | `Abonnieren` nur für die Aktion verwenden. |
-| script gallery / market | `Skript-Galerie` / `Skript-Markt` | `script_gallery`, `guide_script_list_title` | Nach dem tatsächlichen Zielbereich benennen. |
+| subscription | `Abonnement` | `subscribe_url`, `subscribe`, `importpage.count_subscribes` | `Abonnieren` nur für die Aktion verwenden. |
+| script gallery / market | `Skript-Galerie` / `Skript-Markt` | `script_gallery`, `script_list_title` | Nach dem tatsächlichen Zielbereich benennen. |
 
 ## B. UI-Aktionen und Zustände
 
@@ -44,10 +45,10 @@ Geprüfte Verwendungsquelle: `src/locales/de-DE/*.json`
 | create | `Erstellen` | `create_script`, `create_background_script` | Mit Objekt verwenden, wenn ein Button sonst unklar wäre. |
 | save / save as | `Speichern` / `Speichern unter` | `save`, `save_as` | Standardformulierungen für Datei- und Einstellungsaktionen. |
 | import / export | `Importieren` / `Exportieren` | `import`, `export`, `import_file`, `export_file` | Als Aktionen verwenden; Nomen nur in zusammengesetzten Labels. |
-| install / update | `Installieren` / `Aktualisieren` | `install_script`, `update_script` | Zielobjekt ergänzen, falls erforderlich. |
+| install / update | `Installieren` / `Aktualisieren` | `script`, `update_script` | Zielobjekt ergänzen, falls erforderlich. |
 | run / runtime | `Ausführen` / `Laufzeit` | `run`, `runtime`, `log_title` | Für Ausführungsprotokolle ist `Ausführungsprotokoll` passend. |
 | enable / disable | `Aktivieren` / `Deaktivieren`; Zustände `Aktiviert` / `Deaktiviert` | `enable`, `disable`, `updatepage.enabled` | Nicht mit Öffnen/Schließen verwechseln. |
-| settings | `Einstellungen` | `settings`, `script_setting.title` | Für benutzerseitige Konfigurationen. |
+| settings | `Einstellungen` | `settings`, `script_setting` | Für benutzerseitige Konfigurationen. |
 | permission | `Berechtigung` | `permission`, `request_permission` | Für Zugriffsrechte und Abfragen. |
 | connect / sync | `Verbinden` / `Synchronisieren` | `connect`, `script_sync` | Verbindung und Datensynchronisation getrennt halten. |
 | directory | `Verzeichnis` | `open_directory`, `open_backup_dir` | Für Dateisystemfunktionen des Tools. |
@@ -59,7 +60,7 @@ Geprüfte Verwendungsquelle: `src/locales/de-DE/*.json`
 | --- | --- | --- | --- |
 | local / cloud | `Lokal` / `Cloud` | Für Quelle, Speicherort oder Synchronisationsziel verwenden; bei Bedarf Objekt ergänzen. | `local`, `cloud`, `source_local_script` |
 | panel / console | `Panel` / `Konsole` | Bedienoberfläche als `Panel`, Entwicklerausgabe als `Konsole` benennen. | `scheduled_script_description_title`, `build_success_message` |
-| source | `Quelle`, `Installationsquelle`, `Abonnementquelle` | Benennen, was die Quelle liefert. | `source`, `install_source`, `subscribe_source_tooltip` |
+| source | `Quelle`, `Installationsquelle`, `Abonnementquelle` | Benennen, was die Quelle liefert. | `source`, `importpage.col_source`, `source_subscribe_link` |
 | storage | `Speicher`, `Speicherplatz`, `Speicher-API` | Nach Datenablage, zugewiesenem Speicherplatz oder API unterscheiden. | `script_storage`, `script_operation_description`, `storage_api` |
 | sync deletion | `Löschstatus synchronisieren` / `Löschungen synchronisieren` | Erst nach Bestätigung des tatsächlichen Verhaltens vereinheitlichen. | `sync_delete`, `sync_delete_desc`, `notification.script_sync_delete` |
 
@@ -80,10 +81,8 @@ Die folgenden Einträge beschreiben bereits vorhandene Auffälligkeiten. Dieses 
 
 | Thema | Aktueller Stand | Empfohlene Richtung | Aktuelle Beispiel-Keys |
 | --- | --- | --- | --- |
-| browser tabs | Die Ausführungsumgebung enthält `Alle Bezeichnungen`, während Schließen-Aktionen `Tab` verwenden. | Falls `script_run_env` Browser-Tabs bezeichnet, durchgängig `Alle Tabs`, `Normale Tabs`, `Inkognito-Tabs` verwenden. | `script_run_env.all`, `close_current_tab` |
-| scheduled script expression label | `Geplante Aufgaben-Ausdruck` ist grammatisch unklar. | Nach Bestätigung der Funktion etwa `Ausdruck für geplante Aufgabe` verwenden. | `scheduled_script_description_description_expr` |
-| ScriptCat capitalization | Einige Einstiegstexte können eine abweichende Produkt-Schreibung enthalten. | Produktnamen stets als `ScriptCat` schreiben. | `start_guide_title`, `ext_update_notification` |
-| documentation link locale | Deutsche UI-Texte verweisen teilweise auf `/en/`-Dokumentation. | Nur ändern, wenn ein entsprechendes deutsches Ziel verfügbar ist. | `guide_script_list_content`, `develop_mode_guide` |
+| browser tabs | Die Ausführungsumgebung enthält `Alle Bezeichnungen`, während Schließen-Aktionen `Tab` verwenden. | Falls die Felder der Laufzeitumgebung Browser-Tabs bezeichnen, durchgängig `Alle Tabs`, `Normale Tabs`, `Inkognito-Tabs` verwenden. | `script_run_env.all`, `close_current_tab` |
+| documentation link locale | Deutsche UI-Texte verweisen teilweise auf `/en/`-Dokumentation. | Nur ändern, wenn ein entsprechendes deutsches Ziel verfügbar ist. | `script_list_content`, `develop_mode_guide` |
 
 ## Checkliste für AI und Mitwirkende
 

--- a/docs/translation/terminology-en-US.md
+++ b/docs/translation/terminology-en-US.md
@@ -2,7 +2,7 @@
 
 This document defines terminology for ScriptCat's US English (`en-US`) interface and documentation. It is intended to keep product concepts identifiable, make UI actions read naturally in English, and prevent later translations from copying unclear source wording.
 
-Usage sources reviewed: `src/locales/en-US/*.json`, `README.md`
+Usage sources reviewed: `src/locales/en-US/*.json`, `README.md`, `docs/ARCHITECTURE.md`
 
 ## Principles
 
@@ -28,15 +28,16 @@ Usage sources reviewed: `src/locales/en-US/*.json`, `README.md`
 
 | Concept | Preferred wording | Current example keys | Notes |
 | --- | --- | --- | --- |
-| ScriptCat browser extension | `ScriptCat extension` | `start_guide_title`, `ext_update_notification` | Preserve the `ScriptCat` product capitalization. |
-| generic userscript capability | `user script` / `userscript` | `create_user_script`, `guide_script_list_content`, README | Use `User Script` in UI type labels; prose may use `userscript` consistently within a document. |
-| Tampermonkey-compatible script type | `Tampermonkey script` | `script_status_tooltip` | Do not reduce a compatibility statement to a generic script label. |
-| page script | `Page Script` | `page_script`, `foreground_page_script_tooltip` | A script that runs on a specified page. |
+| ScriptCat browser extension | `ScriptCat extension` | `welcome_title`, `ext_update_notification` | Preserve the `ScriptCat` product capitalization. |
+| generic userscript capability | `user script` / `userscript` | `create_user_script`, `script_list_content`, README | Use `User Script` in UI type labels; prose may use `userscript` consistently within a document. |
+| normal userscript type | `User Script` / current category label `Normal Script` | `create_user_script`, `script_list.sidebar.normal_script` | Do not merge this category with background or scheduled scripts. |
+| Tampermonkey compatibility | `Tampermonkey-compatible userscript` / `Tampermonkey script` | `README.md`, `docs/ARCHITECTURE.md` | Use this wording when compatibility is the point; do not turn every generic userscript label into a Tampermonkey label. |
+| page script | `Page Script` | `script_list_enable_content` | Identifies the page-running concept in UI copy; do not silently replace the normal userscript category label without checking the surface. |
 | background script | `Background Script` | `create_background_script`, `background_script`, `enable_background.description` | A ScriptCat script type and background-running capability. |
 | scheduled script | `Scheduled Script` | `create_scheduled_script`, `scheduled_script`, `scheduled_script_description_title` | Use this product term instead of introducing `crontab script`. |
-| script sync | `Script Sync` | `script_sync`, `sync_status`, `guide_setting_sync_title` | When deletion is involved, explain whether deletion state or content is synchronized. |
-| script subscription | `Subscription` | `subscribe`, `subscribe_url`, `subscribe_import_progress` | Use `Subscribe` only as a verb or control action; use `Subscription` for the object. |
-| script gallery / market | `Script Gallery` / `Script Market` | `script_gallery`, `guide_script_list_title` | Match the destination's product label rather than merging names without confirmation. |
+| script sync | `Script Sync` | `script_sync`, `sync_status`, `setting_sync_title` | When deletion is involved, explain whether deletion state or content is synchronized. |
+| script subscription | `Subscription` | `subscribe`, `subscribe_url`, `importpage.count_subscribes` | Use `Subscribe` only as a verb or control action; use `Subscription` for the object. |
+| script gallery / market | `Script Gallery` / `Script Market` | `script_gallery`, `script_list_title` | Match the destination's product label rather than merging names without confirmation. |
 
 ## B. UI Actions and States
 
@@ -45,13 +46,13 @@ Usage sources reviewed: `src/locales/en-US/*.json`, `README.md`
 | create | `Create` | `create_script`, `create_background_script`, `create_success_note` | Use for creation actions and confirmations. |
 | save / save as | `Save` / `Save As` | `save`, `save_as`, `save_as_success` | Capitalize as a label; use sentence case within prose. |
 | import / export | `Import` / `Export` | `import`, `export`, `import_file`, `export_file` | Standard data/file actions. |
-| install / update | `Install` / `Update` | `install_script`, `update_script`, `install_success` | Use the object name when needed to disambiguate. |
+| install / update | `Install` / `Update` | `script`, `update_script`, `success` | Use the object name when needed to disambiguate. |
 | run / runtime | `Run` / `Runtime` | `run`, `running`, `runtime`, `log_title` | `Runtime Logs` is appropriate for execution logs. |
 | enable / disable | `Enable` / `Disable`; states `Enabled` / `Disabled` | `enable`, `disable`, `updatepage.enabled`, `updatepage.disabled` | Avoid `open` or `close` for feature enablement. |
-| settings / configuration | `Settings` / `Configuration` | `settings`, `script_setting.title`, `editor_config` | UI options are settings; configuration data or editor configuration uses configuration. |
+| settings / configuration | `Settings` / `Configuration` | `settings`, `script_setting`, `editor_config` | UI options are settings; configuration data or editor configuration uses configuration. |
 | connect / sync | `Connect` / `Sync` | `connect`, `connection_success`, `script_sync` | Keep connection state separate from data synchronization. |
 | restore / reset | `Restore` / `Reset` | `restore`, `restore_default_values`, `reset` | Use according to whether saved/default content is recovered or settings are reset. |
-| load / reload | `Loading` / `Reload` | `loading`, `install_page_loading`, `click_to_reload` | Use natural progressive/action forms. |
+| load / reload | `Loading` / `Reload` | `loading`, `loading_title`, `click_to_reload` | Use natural progressive/action forms. |
 | directory | `Directory` | `open_directory`, `open_backup_dir` | Suitable for this developer-facing file-system feature. |
 | browser tab | `Tab` | `close_current_tab`, `close_other_tabs` | Do not call browser tabs `tags`. |
 
@@ -59,11 +60,11 @@ Usage sources reviewed: `src/locales/en-US/*.json`, `README.md`
 
 | Concept | Candidate wording | Decision rule | Current example keys |
 | --- | --- | --- | --- |
-| local / cloud | `Local` / `Cloud` | Use for data origin, destination, and storage location; add `device` or `storage` where the object is otherwise unclear. | `local`, `cloud`, `source_local_script`, `guide_tools_backup_content` |
+| local / cloud | `Local` / `Cloud` | Use for data origin, destination, and storage location; add `device` or `storage` where the object is otherwise unclear. | `local`, `cloud`, `source_local_script`, `tools_backup_content` |
 | panel / console | `panel` / `console` | Use `panel` for ScriptCat UI controls and `console` for developer-tools output. | `background_script_description`, `build_success_message` |
-| source | `Source`, `Install Source`, `Subscription Source` | Name what the source provides; a subscription object is not a verb. | `source`, `install_source`, `subscribe_source_tooltip` |
-| permissions / authorization | `Permission`, `Allow`, `Grant access` | Use permission for capability records, allow/deny for decisions, and grant access in explanatory sentences. | `permission`, `allow_once`, `confirm_script_operation` |
-| run location / application | `Applies To`, `Run Status` | Verify the column behavior before rewriting `Apply To / Run Status`; it may combine two separate concepts. | `apply_to_run_status`, `guide_script_list_apply_to_run_status_title` |
+| source | `Source`, `Install Source`, `Subscription Source` | Name what the source provides; a subscription object is not a verb. | `source`, `importpage.col_source`, `source_subscribe_link` |
+| permissions / authorization | `Permission`, `Allow`, `Grant access` | Use permission for capability records, allow/deny for decisions, and grant access in explanatory sentences. | `permission`, `duration_once`, `confirm_script_operation` |
+| run location / application | `Applies To`, `Run Status` | Verify the column behavior before rewriting `Apply To / Run Status`; it may combine two separate concepts. | `apply_to_run_status`, `script_list_enable_title` |
 | sync deletion | `Sync Deletions` / `Sync Deletion Status` | Choose after confirming whether the setting propagates tombstones or performs deletion immediately. | `sync_delete`, `sync_delete_desc`, `notification.script_sync_delete` |
 | match / exclude | `Match` / `Exclude` | Keep metadata identifiers visible as `@match` and `@exclude` when the UI edits those rules. | `website_match`, `website_exclude`, `add_match`, `add_exclude` |
 
@@ -85,15 +86,12 @@ The entries below identify defects or inconsistencies already present in `*.json
 
 | Target | Current wording or issue | Preferred direction | Current example keys |
 | --- | --- | --- | --- |
-| spelling errors | `Suceeded`, `exeuction` | `Succeeded`, `execution` | `import_local_success`, `exclude_off` |
-| subscription as a noun | Object labels use `Subscribe`, such as `Subscribe URL` and `Install Subscribe`. | Use `Subscription URL`, `Install Subscription`, `Update Subscription`, and plural `Subscriptions` where the value is an object. | `subscribe_url`, `install_subscribe`, `update_subscribe`, `select_subscribes_to_import`, `notification.subscribe_update` |
-| browser tabs | Run-environment entries call tabs `tags`. | Use `All Tabs`, `Normal Tabs`, and `Incognito Tabs` if these values target browser tabs. | `script_run_env.all`, `script_run_env.normal-tabs`, `script_run_env.incognito-tabs` |
+| subscription as a noun | Object labels use `Subscribe`, such as `Subscribe URL` and `Install Subscribe`. | Use `Subscription URL`, `Install Subscription`, `Update Subscription`, and plural `Subscriptions` where the value is an object. | `subscribe_url`, `subscribe`, `update_subscribe`, `importpage.count_subscribes`, `notification.subscribe_update` |
+| browser tabs | The all-tabs entry is only `All`, while the sibling entries explicitly say `Normal tabs` and `Incognito tabs`. | Use `All Tabs`, `Normal Tabs`, and `Incognito Tabs` if these values target browser tabs. | `script_run_env.all`, `script_run_env.normal-tabs`, `script_run_env.incognito-tabs` |
 | scheduled script naming | One status string says `crontab scripts` while the feature name is `Scheduled Script`. | Use `scheduled scripts` consistently. | `only_background_scheduled_can_run`, `scheduled_script` |
 | product capitalization | `Scriptcat extension updated` does not match `ScriptCat`. | Preserve `ScriptCat` capitalization. | `ext_update_notification` |
-| metadata identifier | Tooltip refers to `@required`; userscript metadata uses `@require`. | Keep the identifier as `@require`. | `script_resource_tooltip` |
-| title-style fragments used as messages | Many success/error messages use noun-like forms such as `Delete Successful`, `Update Successful`, or `Dump success saved`. | For notifications, prefer natural result messages such as `Deleted successfully`, `Updated successfully`, and `Export successful`; keep label capitalization separate. | `delete_success`, `update_success`, `export_success`, `install_success` |
-| script type capitalization | Labels use title case while sentences capitalize `Background scripts` and `Scheduled scripts` mid-sentence. | Use title case only for displayed type labels; use lowercase common nouns in explanatory sentences. | `background_script`, `scheduled_script`, `script_status_tooltip` |
-| interaction instructions | Links use `tap` or `Click me`, and some instructional text is ungrammatical. | Use consistent desktop UI wording such as `Click to learn how to enable it` and sentence-form instructions. | `develop_mode_guide`, `allow_user_script_guide`, `lower_version_browser_guide`, `blacklist_placeholder`, `import_script_placeholder` |
+| title-style fragments used as messages | Many success/error messages use noun-like forms such as `Delete Successful`, `Update Successful`, or `Dump success saved`. | For notifications, prefer natural result messages such as `Deleted successfully`, `Updated successfully`, and `Export successful`; keep label capitalization separate. | `delete_success`, `update_success`, `export_success`, `success` |
+| interaction instructions | Links use `tap` or `Click me`, and some instructional text is ungrammatical. | Use consistent desktop UI wording such as `Click to learn how to enable it` and sentence-form instructions. | `develop_mode_guide`, `allow_user_script_guide`, `lower_version_browser_guide`, `blacklist_placeholder`, `link_import_placeholder` |
 | browser-specific background behavior | Background-running copy says the user must quit `Chrome`, although ScriptCat supports multiple browsers. | Confirm implementation behavior, then use `the browser` unless the setting is Chrome-specific. | `enable_background.description` |
 
 ## Preferred Vocabulary

--- a/docs/translation/terminology-ja-JP.md
+++ b/docs/translation/terminology-ja-JP.md
@@ -2,7 +2,7 @@
 
 本書は、ScriptCat の日本語（`ja-JP`）UI およびドキュメントで使用する用語と UI 文言の基準です。日本語の文言を翻訳または修正する際は、日本語として自然で、製品 UI として一貫した表現を使用します。
 
-用例の参照元：`src/locales/ja-JP/*.json`、`docs/README_ja.md`
+用例の参照元：`src/locales/ja-JP/*.json`、`docs/README_ja.md`、`docs/ARCHITECTURE.md`
 
 ## 外来語表記の基準
 
@@ -42,13 +42,14 @@
 
 | 概念 | 使用する表記 | 現行用例 key | 備考 |
 | --- | --- | --- | --- |
-| user script | `ユーザースクリプト` | `create_user_script`, `guide_script_list_content` | 一般名として使用します。 |
-| Tampermonkey compatible script | `Tampermonkey スクリプト` | `script_status_tooltip` | `ユーザースクリプト` に置き換えて種別情報を失わないでください。 |
-| page script | `ページスクリプト` | `page_script`, `guide_script_list_enable_content` | ページ上で動作するスクリプト種別です。 |
+| user script | `ユーザースクリプト` | `create_user_script`, `script_list_content` | 一般名として使用します。 |
+| normal userscript type | `ユーザースクリプト` / 現行カテゴリ名 `通常スクリプト` | `create_user_script`, `script_list.sidebar.normal_script` | バックグラウンドスクリプトやスケジュールスクリプトと統合しないでください。 |
+| Tampermonkey compatibility | `Tampermonkey 互換ユーザースクリプト` / `Tampermonkey のスクリプト` | `docs/README_ja.md`, `docs/ARCHITECTURE.md` | 互換性を説明する場合に使用し、一般名やカテゴリ名を一律に置き換えないでください。 |
+| page script | `ページスクリプト` | `script_list_enable_content` | ページ上で動作する概念を示す UI 表記です。現行の `通常スクリプト` カテゴリ名とは表示箇所を確認して使い分けます。 |
 | background script | `バックグラウンドスクリプト` | `create_background_script`, `background_script`, `enable_background.description` | 実行方式を示す製品用語です。 |
 | scheduled script | `スケジュールスクリプト` | `create_scheduled_script`, `scheduled_script`, `scheduled_script_description_title` | 定時実行のスクリプト種別です。 |
-| ScriptCat extension | `ScriptCat拡張機能` | `start_guide_title`, `ext_update_notification` | locale ファイルの現行表記を基準とします。 |
-| script center | `スクリプトセンター` | `guide_script_list_title`, `guide_script_list_content` | README にも使用例があります。 |
+| ScriptCat extension | `ScriptCat拡張機能` | `welcome_title`, `ext_update_notification` | locale ファイルの現行表記を基準とします。 |
+| script center | `スクリプトセンター` | `script_list_title`, `script_list_content` | README にも使用例があります。 |
 | sync deletion state | `削除状態を同期` / `スクリプトの削除状態を同期` | `sync_delete`, `notification.script_sync_delete` | 削除操作そのものではなく、削除済み状態を同期する機能です。 |
 
 ## B. UI 操作・状態の標準表現
@@ -58,18 +59,18 @@
 | create | `新しい...を作成` / `作成` | `create_script`, `create_background_script`, `create_success_note` | ボタンでは短く、説明文では目的語を補います。 |
 | save / save as | `保存` / `名前を付けて保存` | `save`, `save_as`, `save_success` | 現行 UI と揃えます。 |
 | import / export | `インポート` / `エクスポート` | `import`, `export`, `import_file`, `export_file` | 現行の外来語表記を維持します。 |
-| install | `インストール` | `install_script`, `install_success`, `install_failed` | 現行 UI と揃えます。 |
-| run / runtime | `実行` / `ランタイム` | `run`, `running`, `runtime`, `script_run_at.title` | `runtime` は `ランタイム` を維持します。 |
-| enable / disable | `有効` / `無効`、操作文では `有効にする` / `無効にする` | `enable`, `disable`, `enable_script`, `enable_background.title`, `in_use`, `sync_system_closed` | 状態表示には `有効` / `無効` を優先します。 |
-| settings | `設定` | `settings`, `script_setting.title`, `editor_config` | 現行 UI と揃えます。 |
-| permission | `権限` / `許可` | `permission`, `permission_management`, `allow_once` | 権限の種類は `権限`、許可する操作は `許可` を使用します。 |
+| install | `インストール` | `script`, `success`, `failed` | 現行 UI と揃えます。 |
+| run / runtime | `実行` / `ランタイム` | `run`, `running`, `runtime`, `run_at` | `runtime` は `ランタイム` を維持します。 |
+| enable / disable | `有効` / `無効`、操作文では `有効にする` / `無効にする` | `enable`, `disable`, `enabled_label`, `enable_background.title`, `in_use`, `sync_system_closed` | 状態表示には `有効` / `無効` を優先します。 |
+| settings | `設定` | `settings`, `script_setting`, `editor_config` | 現行 UI と揃えます。 |
+| permission | `権限` / `許可` | `permission`, `permission_management`, `duration_once` | 権限の種類は `権限`、許可する操作は `許可` を使用します。 |
 | connection | `接続` | `connect`, `connection_success`, `sync_system_connect_failed` | 状態を表す `closed` は機能の意味に応じて訳します。 |
-| synchronization | `同期` | `script_sync`, `sync_status`, `guide_setting_sync_title` | 対象がある場合は `削除状態を同期` のように対象を明示します。 |
+| synchronization | `同期` | `script_sync`, `sync_status`, `setting_sync_title` | 対象がある場合は `削除状態を同期` のように対象を明示します。 |
 | restore | `復元` | `restore`, `restore_default_values` | 現行 UI と揃えます。 |
-| load / reload | `読み込み` / `再読み込み` | `loading`, `install_page_loading`, `click_to_reload` | 現行 UI と揃えます。 |
+| load / reload | `読み込み` / `再読み込み` | `loading`, `loading_title`, `click_to_reload` | 現行 UI と揃えます。 |
 | tabs | `タブ` | `close_current_tab`, `script_run_env.all`, `script_run_env.normal-tabs` | 現行の外来語表記を維持します。 |
 | interface display | `表示` / `非表示` | `badge_type_none`, `editor.show_script_list`, `editor.hide_script_list` | 表示状態および表示操作に使用します。 |
-| action / operation | `操作` | `action`, `operation`, `guide_script_list_action_title` | UI の列名、操作欄、メニュー文脈では `操作` を使用します。 |
+| action / operation | `操作` | `action`, `script_list_action_title` | UI の列名、操作欄、メニュー文脈では `操作` を使用します。 |
 | work in progress | `開発中` | `under_construction` | ソフトウェアの機能状態を示します。 |
 | silent update | `サイレントで更新する` | `silent_update_non_critical_changes` | 通知を抑えた更新を示す現行表記です。 |
 | issue report | `バグ報告 / 問題のフィードバック` | `report_issue` | 読みやすい区切りを維持します。 |
@@ -78,11 +79,11 @@
 
 | 概念 | 現行表記 | 判断基準 | 現行用例 key |
 | --- | --- | --- | --- |
-| local / cloud | `ローカル` / `クラウド` | 端末上の保存先、作成元、インポート元は `ローカル`、同期先は `クラウド` を使用します。 | `local`, `cloud`, `source_local_script`, `local_creation`, `guide_tools_backup_content` |
+| local / cloud | `ローカル` / `クラウド` | 端末上の保存先、作成元、インポート元は `ローカル`、同期先は `クラウド` を使用します。 | `local`, `cloud`, `source_local_script`, `importpage.source_local`, `tools_backup_content` |
 | directory / path | `ディレクトリ` / `パス` | ファイルシステムを扱う開発機能では、現行の `ディレクトリ` を維持します。一般向け機能へ拡大する場合は別途確認します。 | `open_directory`, `open_backup_dir`, `script_operation_description`, `watch_file_description` |
 | panel / console | `パネル` / `コンソール` | `panel` は `パネル`、開発者ツールの console は `コンソール` とし、相互に置換しません。 | `background_script_description`, `build_success_message` |
-| check / confirm | `チェック` / `確認` | 更新確認の UI には両表現が現存します。新しい文言では周辺 UI に合わせ、統一はレビュー後に行います。 | `check_update`, `updatepage.main_header`, `status_checking_updates` |
-| source | `ソース` / `インストール元` | 外部リソースや出所一般は `ソース`、導入元を明示する欄では `インストール元` を使用しています。 | `source`, `install_source`, `install_from_legitimate_sources_warning` |
+| check / confirm | `チェック` / `確認` | 更新確認の UI には両表現が現存します。新しい文言では周辺 UI に合わせ、統一はレビュー後に行います。 | `check_update`, `updatepage.main_header`, `updatepage.status_checking_updates` |
+| source | `ソース` / `インストール元` | 外部リソースや出所一般は `ソース`、導入元を明示する欄では `インストール元` を使用しています。 | `source`, `importpage.col_source`, `from_legitimate_sources_warning` |
 | query / filter | `検索` / `絞り込み` / `クエリ` | ログ検索 UI の操作名は `検索`、結果を条件で狭める説明は `絞り込み` を優先します。API や問い合わせ言語など技術文脈では `クエリ` を使用できます。 | `query`, `enter_filter_conditions`, `filtered_logs` |
 | match / exclude | `対象` / `除外`、ラベルでは `対象サイト（@match）` / `除外サイト（@exclude）` | ユーザー向け操作では現行の `対象` / `除外` を優先します。`@match` / `@exclude` は識別子として保持します。現行の `マッチ` 文言は後日レビュー対象です。 | `add_match`, `add_exclude`, `website_match`, `website_exclude`, `match` |
 | storage access / operation | `ストレージにアクセス` / `ストレージ` | 許可ダイアログは一般のファイルストレージへのアクセス確認であり、同期機能に限定しません。タイトルでは対象への `アクセス` を明確にし、説明文で具体的操作を補います。 | `script_operation_title`, `script_storage`, `storage_api` |
@@ -93,7 +94,7 @@
 | --- | --- | --- | --- |
 | regular expression | `正規表現` | `search_regex` | 日本語の開発用語として定着しており、別表記へ変更しません。 |
 | cron expression | `cron 式` | `cron_invalid_expr`, `error_cron_invalid` | cron の入力エラーでは現行の短い表記を維持します。 |
-| expression（入力・エラー文言） | `式` | `value_export_expression`, `cookie_export_expression`, `expression_format_error` | 入力欄と形式エラーでは現行の `式` を維持します。スケジュール説明のラベルは後日レビュー対象です。 |
+| expression（入力・エラー文言） | `式` | `value_export_expression`, `cookie_export_expression`, `expression_format_error` | 入力欄と形式エラーでは現行の `式` を維持します。`schedule_cron_label` の `スケジュールタスク` は式そのものではなく、その表示欄のラベルです。 |
 | watch file changes | `監視` | `watch_file_description`, `watch_file`, `stop_watch_file` | ファイル変更の watch 機能は `監視` として統一されています。 |
 | metadata declaration | `宣言` | `error_metadata_line_duplicated` | metadata 行の declaration を示す技術用語です。 |
 | storage | `ストレージ` | `script_storage`, `storage_api`, `script_operation_title` | API・保存領域の機能名として使用します。 |
@@ -106,10 +107,8 @@
 
 | 対象 | 現行の状況 | 現行用例 key |
 | --- | --- | --- |
-| subscription | `サブスクライブ` と `サブスクリプション` が使用されています。機能名としてどちらを採用するか確認が必要です。 | `subscribe`, `subscribe_url`, `subscribe_source_tooltip`, `notification.subscribe_update` |
-| expression label | 多くの入力・エラーは `式` ですが、スケジュール説明には `表現` が使用されています。画面上の意味を確認してから統一を検討します。 | `scheduled_script_description_description_expr`, `cron_invalid_expr`, `expression_format_error` |
-| panel operation availability | `background_script_description` は `パネルで手動制御` と明記されていますが、`scheduled_script_description_title` は手動操作の場所を省略しています。機能仕様を確認してから調整します。 | `background_script_description`, `scheduled_script_description_title` |
-| documentation link locale | locale 文言内のドキュメントリンクに `/en/` または別 locale の URL が含まれています。利用可能な日本語ページを確認してから変更します。 | `develop_mode_guide`, `allow_user_script_guide`, `guide_script_list_action_content`, `import_script_placeholder` |
+| subscription | `サブスクライブ` と `サブスクリプション` が使用されています。機能名としてどちらを採用するか確認が必要です。 | `subscribe`, `subscribe_url`, `source_subscribe_link`, `notification.subscribe_update` |
+| documentation link locale | locale 文言内のドキュメントリンクに `/en/` または locale を含まない URL があります。利用可能な日本語ページを確認してから変更します。 | `develop_mode_guide`, `allow_user_script_guide`, `script_list_action_content` |
 | 外来語の語末長音 | 外来語表記の既定では長音符号を付けますが、現行文言に `エディタ`、`エディタ設定` など既存表記があります。製品内での統一範囲を確認してから変更します。 | `editor_config`, `editor_type_definition`, `editor_config_description`, `editor_type_definition_description`, `editor_config_reset`, `editor_config_saved`, `editor_config_format_error`, `editor_type_definition_reset`, `editor_type_definition_saved` |
 | match 表記 | 操作ラベルは `対象` / `除外` ですが、説明文や一部ラベルに `マッチ` が使用されています。UI 上の概念名としてどちらを採用するか確認してから統一します。 | `match`, `after_deleting_match_item`, `confirm_delete_match`, `add_match`, `website_match` |
 

--- a/docs/translation/terminology-ru-RU.md
+++ b/docs/translation/terminology-ru-RU.md
@@ -2,7 +2,7 @@
 
 Этот документ задает терминологию для русского (`ru-RU`) интерфейса и документации ScriptCat. Его цель - сохранять различия между возможностями продукта, использовать естественные для интерфейса формулировки и не повреждать технические идентификаторы при дальнейшей локализации.
 
-Проверенные источники употребления: `src/locales/ru-RU/*.json`, `docs/README_RU.md`
+Проверенные источники употребления: `src/locales/ru-RU/*.json`, `docs/README_RU.md`, `docs/ARCHITECTURE.md`
 
 ## Основные принципы
 
@@ -27,15 +27,16 @@
 
 | Понятие | Предпочтительная формулировка | Примеры ключей | Примечание |
 | --- | --- | --- | --- |
-| ScriptCat browser extension | `Расширение ScriptCat` | `start_guide_title`, `ext_update_notification` | Название продукта писать как `ScriptCat`. |
-| generic user script | `Пользовательский скрипт` | `create_user_script`, `guide_script_list_content` | Общее название пользовательского скрипта. |
-| Tampermonkey-compatible script type | `Скрипт Tampermonkey` | `script_status_tooltip` | Не заменять общим названием, если важна совместимость. |
-| page script | `Скрипт страницы` | `page_script`, `foreground_page_script_tooltip` | Выполняется на указанных страницах. |
+| ScriptCat browser extension | `Расширение ScriptCat` | `welcome_title`, `ext_update_notification` | Название продукта писать как `ScriptCat`. |
+| generic user script | `Пользовательский скрипт` | `create_user_script`, `script_list_content` | Общее название пользовательского скрипта. |
+| normal userscript type | `Пользовательский скрипт` / текущая категория `Обычный скрипт` | `create_user_script`, `script_list.sidebar.normal_script` | Не объединять с фоновыми или запланированными скриптами. |
+| Tampermonkey compatibility | `Пользовательский скрипт, совместимый с Tampermonkey` / `Скрипт Tampermonkey` | `docs/README_RU.md`, `docs/ARCHITECTURE.md` | Использовать, когда важна совместимость; не заменять этим общее название или категорию скрипта. |
+| page script | `Скрипт страницы` | `script_list_enable_content` | Обозначает выполняющийся на страницах скрипт в тексте интерфейса; не подменяет без проверки категорию `Обычный скрипт`. |
 | background script | `Фоновый скрипт` | `create_background_script`, `background_script` | Тип скрипта, выполняемого в фоне. |
 | scheduled script | `Скрипт по расписанию` | `create_scheduled_script`, `scheduled_script` | Предпочтительно для нового текста; сохраняет смысл планового запуска. |
 | script synchronization | `Синхронизация скриптов` | `script_sync`, `sync_status` | Для удаления следует уточнять синхронизацию состояния удаления. |
-| subscription | `Подписка` | `subscribe_url`, `install_subscribe`, `subscribe_import_progress` | `Подписаться` использовать только для действия. |
-| script browsing destination / gallery / market | `Хранилище скриптов` / `Галерея скриптов` / `Магазин скриптов` | `script_gallery`, `guide_script_list_title`, README | В документации `Хранилище скриптов` обозначает переход к `scriptcat.org/ru/search`; для UI выбирать название фактического раздела назначения. |
+| subscription | `Подписка` | `subscribe_url`, `subscribe`, `importpage.count_subscribes` | `Подписаться` использовать только для действия. |
+| script browsing destination / gallery / market | `Хранилище скриптов` / `Галерея скриптов` / `Магазин скриптов` | `script_gallery`, `script_list_title`, README | В документации `Хранилище скриптов` обозначает переход к `scriptcat.org/ru/search`; для UI выбирать название фактического раздела назначения. |
 
 ## B. Действия и состояния интерфейса
 
@@ -44,10 +45,10 @@
 | create | `Создать` | `create_script`, `create_background_script` | При необходимости указывать объект действия. |
 | save / save as | `Сохранить` / `Сохранить как` | `save`, `save_as` | Стандартные команды интерфейса. |
 | import / export | `Импорт` / `Экспорт`; в предложениях `импортировать` / `экспортировать` | `import`, `export`, `import_file`, `export_file` | Форму выбирать по роли строки. |
-| install / update | `Установить` / `Обновить` | `install_script`, `update_script` | При необходимости уточнять скрипт или подписку. |
+| install / update | `Установить` / `Обновить` | `script`, `update_script` | При необходимости уточнять скрипт или подписку. |
 | run / runtime | `Запустить` / `Время выполнения` | `run`, `runtime`, `log_title` | Для журнала подходит `Журнал выполнения`. |
 | enable / disable | `Включить` / `Выключить`; состояния `Включено` / `Выключено` | `enable`, `disable`, `updatepage.enabled` | Не смешивать с открытием и закрытием UI. |
-| settings | `Настройки` | `settings`, `script_setting.title` | Для параметров продукта. |
+| settings | `Настройки` | `settings`, `script_setting` | Для параметров продукта. |
 | permission | `Разрешение` / `Разрешения` | `permission`, `request_permission` | Для прав доступа скрипта. |
 | connect / sync | `Подключить` / `Синхронизировать` | `connect`, `script_sync` | Подключение сервиса и синхронизация данных различаются. |
 | directory | `Папка` / `Каталог` | `open_backup_dir`, `open_directory` | В пользовательском интерфейсе естественнее `папка`; технический контекст может требовать `каталог`. |
@@ -59,7 +60,7 @@
 | --- | --- | --- | --- |
 | local / cloud | `Локальный` / `Облачный`, `Облако` | Выбирать по тому, описывается ли источник, место хранения или назначение синхронизации. | `local`, `cloud`, `source_local_script` |
 | panel / console | `панель` / `консоль` | Панель управления продуктом не называть консолью разработчика. | `background_script_description`, `build_success_message` |
-| source | `Источник`, `Источник установки`, `Источник подписки` | Называть объект, который предоставляет источник. | `source`, `install_source`, `subscribe_source_tooltip` |
+| source | `Источник`, `Источник установки`, `Источник подписки` | Называть объект, который предоставляет источник. | `source`, `importpage.col_source`, `source_subscribe_link` |
 | storage | `Хранилище`, `пространство хранения`, `API хранилища` | Различать данные скрипта, настроенное место хранения и API. | `script_storage`, `script_operation_description`, `storage_api` |
 | sync deletion | `Синхронизировать состояние удаления` / `Синхронизировать удаления` | Выбрать после подтверждения поведения функции. | `sync_delete`, `sync_delete_desc`, `notification.script_sync_delete` |
 
@@ -81,9 +82,8 @@
 | Тема | Текущее состояние | Предпочтительное направление | Примеры ключей |
 | --- | --- | --- | --- |
 | scheduled script naming | Используются как `Скрипт по расписанию`, так и `Запланированный скрипт`. | После проверки экранов унифицировать термин продукта как `Скрипт по расписанию`, если это соответствует назначению типа. | `create_scheduled_script`, `scheduled_script` |
-| subscription as object/action | Действие и объект могут встречаться в близких строках. | Для объекта использовать `Подписка`, для кнопки действия - `Подписаться`. | `subscribe`, `subscribe_url`, `install_subscribe` |
-| documentation link locale | Русские строки могут вести на англоязычные страницы документации. | Менять ссылки только после подтверждения доступной русской страницы. | `guide_script_list_content`, `develop_mode_guide` |
-| metadata identifier | В подсказках ресурсов следует подтвердить использование `@require`, а не ошибочного варианта. | Всегда сохранять действительный metadata-идентификатор `@require`. | `script_resource_tooltip` |
+| subscription as object/action | Действие и объект могут встречаться в близких строках. | Для объекта использовать `Подписка`, для кнопки действия - `Подписаться`. | `subscribe`, `subscribe_url`, `update_subscribe` |
+| documentation link locale | Русские строки могут вести на англоязычные страницы документации. | Менять ссылки только после подтверждения доступной русской страницы. | `script_list_content`, `develop_mode_guide` |
 
 ## Контрольный список для AI и участников
 

--- a/docs/translation/terminology-tr-TR.md
+++ b/docs/translation/terminology-tr-TR.md
@@ -1,0 +1,97 @@
+# tr-TR Terminoloji ve Arayüz Metni Kılavuzu
+
+Bu belge, ScriptCat'in Türkçe (`tr-TR`) arayüzü ve belgeleri için terminoloji kurallarını tanımlar. Amaç, ürün kavramlarını tutarlı biçimde adlandırmak, doğal Türkçe arayüz metinleri yazmak ve teknik tanımlayıcıları korumaktır.
+
+İncelenen kullanım kaynakları: `src/locales/tr-TR/*.json`, `docs/ARCHITECTURE.md`
+
+## İlkeler
+
+1. Eylemi veya durumu doğrudan anlatan, kısa ve doğal Türkçe arayüz metinleri kullanın.
+2. `Kullanıcı Betiği`, `Normal Betik`, `Sayfa Betiği`, `Arka Plan Betiği` ve `Zamanlanmış Betik` kavramlarını birbirinden ayırın.
+3. Sözcükleri yalnızca yazılışlarına bakarak topluca değiştirmeyin; özelliği, arayüz konumunu ve cümle bağlamını kontrol edin.
+4. `Regex`, `cron ifadesi`, `ESLint`, `VSCode`, `GM API`, `@match`, `@exclude`, `@grant`, `@connect`, `@resource` ve `@require` gibi teknik terimleri ve tanımlayıcıları koruyun.
+5. Dil düzenlemesi sırasında placeholder'ları, HTML/React etiketlerini, i18next interpolasyonunu, URL'leri veya metadata tanımlayıcılarını değiştirmeyin.
+6. Aşağıdaki key'ler güncel kullanımı veya doğrulanmış inceleme noktalarını gösterir; aynı anlamdaki yeni metinlerde de aynı kurallar geçerlidir.
+
+## Kategoriler
+
+| Kategori | Kullanım |
+| --- | --- |
+| **A. Ürün ve özellik terimleri** | ScriptCat özelliklerinin ve betik türlerinin adları. |
+| **B. Arayüz eylemleri ve durumları** | Kontroller, etiketler ve durum mesajları için tercih edilen ifadeler. |
+| **C. Bağlama bağlı terimler** | Doğru karşılığı özelliğe veya arayüz yüzeyine göre değişen terimler. |
+| **D. Korunacak teknik terimler** | Teknik anlamı ve yazımı korunması gereken terimler ve tanımlayıcılar. |
+| **E. Sonraki inceleme noktaları** | Mevcut metinlerde ayrı ve doğrulanmış bir düzenleme gerektiren tutarsızlıklar. |
+
+## A. Ürün ve Özellik Terimleri
+
+| Kavram | Tercih edilen ifade | Güncel örnek key'ler | Notlar |
+| --- | --- | --- | --- |
+| ScriptCat browser extension | `ScriptCat uzantısı` | `welcome_title`, `ext_update_notification` | Ürün adını her zaman `ScriptCat` olarak yazın. |
+| generic userscript | `kullanıcı betiği` | `create_user_script`, `script_list_content` | Userscript kavramının genel adıdır. |
+| normal userscript type | `Normal Betik` | `create_user_script`, `script_list.sidebar.normal_script` | Arka plan ve zamanlanmış betik türleriyle birleştirmeyin. |
+| Tampermonkey compatibility | `Tampermonkey uyumlu kullanıcı betiği` / `Tampermonkey betiği` | `docs/ARCHITECTURE.md` | Yalnızca uyumluluk vurgulanırken kullanın; genel userscript veya kategori adının yerine geçirmeyin. |
+| page script | `Sayfa Betiği` | `script_list_enable_content` | Arayüz metnindeki sayfada çalışan betik kavramıdır; `Normal Betik` kategori etiketinin yerine denetimsiz kullanmayın. |
+| background script | `Arka Plan Betiği` | `create_background_script`, `background_script` | Arka planda çalışan ScriptCat betik türüdür. |
+| scheduled script | `Zamanlanmış Betik` | `create_scheduled_script`, `scheduled_script` | Tür adı olarak `crontab betiği` kullanmayın; `cron` yalnızca zamanlama ifadesini anlatır. |
+| script synchronization | `Betik Senkronizasyonu` | `script_sync`, `sync_status`, `setting_sync_title` | Silme davranışında neyin senkronize edildiğini açıklama metninde belirtin. |
+| subscription | `Abonelik` | `subscribe`, `subscribe_url`, `importpage.count_subscribes` | Nesne adı olarak `Abonelik`, eylem olarak `Abone ol` kullanın. |
+| script gallery / market | `Betik Galerisi` / `Betik Pazarı` | `script_gallery`, `script_list_title` | Bağlantının götürdüğü ürün alanının mevcut adını kullanın. |
+
+## B. Arayüz Eylemleri ve Durumları
+
+| Kavram | Tercih edilen ifade | Güncel örnek key'ler | Notlar |
+| --- | --- | --- | --- |
+| create | `Oluştur` | `create_script`, `create_background_script` | Gerekirse nesne adını ekleyin. |
+| save / save as | `Kaydet` / `Farklı Kaydet` | `save`, `save_as` | Dosya ve ayar eylemleri için kullanın. |
+| import / export | `İçe Aktar` / `Dışa Aktar` | `import`, `export`, `import_file`, `export_file` | Eylem etiketlerinde fiil biçimini kullanın. |
+| install / update | `Yükle` / `Güncelle` | `script`, `update_script`, `update_subscribe` | Betik veya abonelik nesnesini gerektiğinde belirtin. |
+| run / runtime | `Çalıştır` / `Çalışma Zamanı` | `run`, `running`, `runtime` | Betik çalıştırma ile çalışma zamanı bilgisini ayırın. |
+| enable / disable | `Etkinleştir` / `Devre Dışı Bırak`; durumlarda `Etkin` / `Devre Dışı` | `enable`, `disable`, `enabled_label`, `updatepage.disabled` | Özelliği açma-kapama ile pencere açma-kapamayı karıştırmayın. |
+| settings | `Ayarlar` | `settings`, `script_setting`, `editor_config` | Kullanıcı tarafından değiştirilebilen ürün seçenekleri için kullanın. |
+| permission | `İzin` | `permission`, `request_permission`, `permission_management` | Erişim yetkileri ve izin istekleri için kullanın. |
+| connect / sync | `Bağlan` / `Senkronize Et` | `connect`, `connection_success`, `script_sync` | Bağlantı durumu ile veri senkronizasyonunu ayırın. |
+| directory | `Dizin` | `open_directory`, `open_backup_dir` | Dosya sistemi araçlarında mevcut teknik terimi koruyun. |
+| browser tab | `Sekme` | `close_current_tab`, `script_run_env.normal-tabs` | Tarayıcı sekmelerini `etiket` olarak adlandırmayın. |
+
+## C. Bağlama Bağlı Terimler
+
+| Kavram | Kullanılabilecek ifade | Karar kuralı | Güncel örnek key'ler |
+| --- | --- | --- | --- |
+| local / cloud | `Yerel` / `Bulut` | Veri kaynağı, depolama konumu veya senkronizasyon hedefi için kullanın; belirsizse nesneyi ekleyin. | `local`, `cloud`, `source_local_script`, `tools_backup_content` |
+| panel / console | `panel` / `konsol` | ScriptCat kontrol yüzeyi için `panel`, geliştirici çıktısı için `konsol` kullanın. | `scheduled_script_description_title`, `build_success_message` |
+| source | `Kaynak`, `Yükleme Kaynağı`, `Abonelik Kaynağı` | Kaynağın ne sağladığını açıkça adlandırın. | `source`, `importpage.col_source`, `source_subscribe_link` |
+| storage | `depolama`, `depolama alanı`, `Depolama API'si` | Veri saklama, ayrılmış alan ve API kavramlarını bağlama göre ayırın. | `script_storage`, `script_operation_title`, `storage_api` |
+| sync deletion | `Silme Senkronizasyonu` / `Betik Silme Senkronizasyonu` | Ayar etiketi ile açıklama metninin ayrıntı düzeyini ayrı değerlendirin. | `sync_delete`, `notification.script_sync_delete`, `sync_delete_desc` |
+
+## D. Korunacak Teknik Terimler
+
+| Kavram | Kullanım | Güncel örnek key'ler | Gerekçe |
+| --- | --- | --- | --- |
+| regular expression | `Regex` / `düzenli ifade` | `search_regex` | Yerleşik geliştirici terminolojisidir. |
+| cron expression | `cron ifadesi` | `cron_invalid_expr`, `error_cron_invalid` | Kabul edilen zamanlama sözdizimini açıkça belirtir. |
+| expression | `ifade` | `value_export_expression`, `expression_format_error` | Girilen veya değerlendirilen teknik ifadeyi belirtir. |
+| watch file changes | `Dosyayı İzle` / `İzlemeyi Durdur` | `watch_file`, `stop_watch_file` | Sürekli dosya değişikliği takibini anlatır. |
+| metadata declaration | `bildirim` | `error_metadata_line_duplicated` | Userscript metadata sözdizimindeki declaration kavramıdır. |
+| product/API identifiers | `ESLint`, `VSCode`, `Cookie`, `GM API`, `@match`, `@exclude`, `@grant`, `@connect`, `@resource`, `@require` ifadelerini koruyun | `enable_eslint`, `vscode_url`, `confirm_operation_description`, `script_resource_tooltip` | Ürün adları ve kod tanımlayıcıları tanınabilir kalmalıdır. |
+
+## E. Sonraki İnceleme Noktaları
+
+Aşağıdaki maddeler mevcut çevirilerde doğrulanmış tutarsızlıkları kaydeder. Bu kılavuz çalışma zamanı metinlerini değiştirmez; düzeltmeler ayrı bir Türkçe arayüz incelemesi ve UI kontrolüyle yapılmalıdır.
+
+| Konu | Güncel durum | Tercih edilen yön | Güncel örnek key'ler |
+| --- | --- | --- | --- |
+| scheduled script naming | Ürün adı `Zamanlanmış Betik` iken bir hata metninde `crontab betikleri` kullanılıyor. | Aynı betik türü için `zamanlanmış betik`; yalnızca zamanlama sözdizimi için `cron` kullanın. | `scheduled_script`, `only_background_scheduled_can_run`, `cron_invalid_expr` |
+| documentation link locale | Bazı Türkçe metinler `/en/` dokümantasyonuna veya İngilizce pazar sayfasına bağlanıyor. | Yalnızca karşılık gelen Türkçe hedef doğrulandıktan sonra bağlantıyı değiştirin. | `script_list_content`, `develop_mode_guide` |
+| desktop interaction wording | Geliştirici modu bağlantısı masaüstü arayüzünde `dokunun` diyor. | Kontrol masaüstünde tıklanıyorsa `tıklayın` kullanın. | `develop_mode_guide`, `allow_user_script_guide` |
+
+## AI ve Katkıda Bulunanlar İçin Kontrol Listesi
+
+Türkçe içerik eklerken veya düzenlerken:
+
+1. Hedef locale'in `tr-TR` olduğunu doğrulayın ve bu kılavuzla birlikte komşu mevcut metinleri okuyun.
+2. Aynı ScriptCat kavramı için aynı ürün terimini kullanın; betik türlerini benzer ifadeler nedeniyle birleştirmeyin.
+3. Bağlama bağlı terimlerde değişiklik yapmadan önce gerçek davranışı ve arayüz konumunu kontrol edin.
+4. Teknik terimleri, placeholder'ları, etiketleri, interpolasyonu, URL'leri ve metadata tanımlayıcılarını koruyun.
+5. İnceleme noktalarını doğrulanmamış toplu değiştirme talimatları olarak yorumlamayın.
+6. Teslimden önce yeni veya değiştirilen metinlerde betik türlerini, `Abonelik` nesne adını, sekme terimini ve teknik tanımlayıcıları yeniden kontrol edin.

--- a/docs/translation/terminology-vi-VN.md
+++ b/docs/translation/terminology-vi-VN.md
@@ -2,7 +2,7 @@
 
 Tài liệu này quy định thuật ngữ dùng cho giao diện và tài liệu tiếng Việt (`vi-VN`) của ScriptCat. Mục đích là giữ rõ các khái niệm sản phẩm, dùng câu chữ tự nhiên trong giao diện và bảo toàn các định danh kỹ thuật khi tiếp tục bản địa hóa.
 
-Nguồn sử dụng đã kiểm tra: `src/locales/vi-VN/*.json`
+Nguồn sử dụng đã kiểm tra: `src/locales/vi-VN/*.json`, `docs/ARCHITECTURE.md`
 
 ## Nguyên tắc
 
@@ -27,15 +27,16 @@ Nguồn sử dụng đã kiểm tra: `src/locales/vi-VN/*.json`
 
 | Khái niệm | Cách viết ưu tiên | Key ví dụ hiện tại | Ghi chú |
 | --- | --- | --- | --- |
-| ScriptCat browser extension | `tiện ích ScriptCat` | `start_guide_title`, `ext_update_notification` | Giữ tên sản phẩm là `ScriptCat`. |
-| generic user script | `script người dùng` | `create_user_script`, `guide_script_list_content` | Dùng cho khái niệm userscript chung. |
-| Tampermonkey-compatible script type | `script Tampermonkey` | `script_status_tooltip` | Không rút gọn thành loại script chung nếu cần giữ ý tương thích. |
-| page script | `script trang` | `page_script`, `foreground_page_script_tooltip` | Script chạy trên các trang được chỉ định. |
+| ScriptCat browser extension | `tiện ích ScriptCat` | `welcome_title`, `ext_update_notification` | Giữ tên sản phẩm là `ScriptCat`. |
+| generic user script | `script người dùng` | `create_user_script`, `script_list_content` | Dùng cho khái niệm userscript chung. |
+| normal userscript type | `script người dùng` / nhãn danh mục hiện tại `script bình thường` | `create_user_script`, `script_list.sidebar.normal_script` | Không gộp với script nền hoặc script hẹn giờ. |
+| Tampermonkey compatibility | `script người dùng tương thích Tampermonkey` / `script Tampermonkey` | `docs/ARCHITECTURE.md` | Chỉ dùng khi cần nói rõ tính tương thích; không thay thế mọi tên gọi userscript hoặc danh mục script. |
+| page script | `script trang` | `script_list_enable_content` | Chỉ khái niệm script chạy trên trang trong nội dung UI; không tự động thay thế nhãn danh mục `script bình thường`. |
 | background script | `script nền` | `create_background_script`, `background_script` | Loại script chạy nền của sản phẩm. |
 | scheduled script | `script hẹn giờ` | `create_scheduled_script`, `scheduled_script` | Dùng thay cho việc giới thiệu thêm tên `script crontab`. |
 | script synchronization | `đồng bộ script` | `script_sync`, `sync_status` | Khi liên quan đến xóa, cần nói rõ trạng thái hoặc thao tác xóa được đồng bộ. |
-| subscription | `đăng ký` | `subscribe_url`, `install_subscribe`, `subscribe_import_progress` | Cần phân biệt với thao tác đăng ký bằng ngữ cảnh câu. |
-| script gallery / market | `thư viện script` / `chợ script` | `script_gallery`, `guide_script_list_title` | Dùng tên phù hợp với trang đích thực tế. |
+| subscription | `đăng ký` | `subscribe_url`, `subscribe`, `importpage.count_subscribes` | Cần phân biệt với thao tác đăng ký bằng ngữ cảnh câu. |
+| script gallery / market | `thư viện script` / `chợ script` | `script_gallery`, `script_list_title` | Dùng tên phù hợp với trang đích thực tế. |
 
 ## B. Thao tác và trạng thái giao diện
 
@@ -44,10 +45,10 @@ Nguồn sử dụng đã kiểm tra: `src/locales/vi-VN/*.json`
 | create | `Tạo` | `create_script`, `create_background_script` | Thêm đối tượng khi nhãn cần rõ nghĩa. |
 | save / save as | `Lưu` / `Lưu thành` | `save`, `save_as` | Giữ nhất quán với giao diện hiện tại. |
 | import / export | `Nhập` / `Xuất` | `import`, `export`, `import_file`, `export_file` | Dùng cho dữ liệu hoặc tệp theo ngữ cảnh. |
-| install / update | `Cài đặt` / `Cập nhật` | `install_script`, `update_script` | Có thể thêm `script` hoặc `đăng ký` để phân biệt. |
+| install / update | `Cài đặt` / `Cập nhật` | `script`, `update_script` | Có thể thêm `script` hoặc `đăng ký` để phân biệt. |
 | run / runtime | `Chạy` / `Thời gian chạy` | `run`, `runtime`, `log_title` | Dùng cho việc thực thi script. |
 | enable / disable | `Bật` / `Tắt`; trạng thái `Đã bật` / `Đã tắt` | `enable`, `disable`, `script_disabled` | Không dùng như thao tác mở hoặc đóng thành phần giao diện. |
-| settings | `Cài đặt` | `settings`, `script_setting.title` | Dành cho các tùy chọn sản phẩm. |
+| settings | `Cài đặt` | `settings`, `script_setting` | Dành cho các tùy chọn sản phẩm. |
 | permission | `Quyền` / `Cấp quyền` | `permission`, `confirm_script_operation` | Phân biệt loại quyền và thao tác cho phép. |
 | connect / sync | `Kết nối` / `Đồng bộ` | `connect`, `script_sync` | Không gộp trạng thái kết nối với đồng bộ dữ liệu. |
 | directory | `Thư mục` | `open_directory`, `open_backup_dir` | Dùng cho thao tác hệ thống tệp. |
@@ -59,7 +60,7 @@ Nguồn sử dụng đã kiểm tra: `src/locales/vi-VN/*.json`
 | --- | --- | --- | --- |
 | local / cloud | `Cục bộ` / `Đám mây` | Dùng cho nguồn, nơi lưu hoặc đích đồng bộ; thêm đối tượng nếu câu chưa rõ. | `local`, `cloud`, `source_local_script` |
 | panel / console | `bảng điều khiển` / `console` | Thành phần điều khiển của sản phẩm dùng `bảng điều khiển`; đầu ra công cụ phát triển cần giữ nghĩa console. | `background_script_description`, `build_success_message` |
-| source | `Nguồn`, `Nguồn cài đặt`, `Nguồn đăng ký` | Nêu rõ nguồn cung cấp nội dung gì. | `source`, `install_source`, `subscribe_source_tooltip` |
+| source | `Nguồn`, `Nguồn cài đặt`, `Nguồn đăng ký` | Nêu rõ nguồn cung cấp nội dung gì. | `source`, `importpage.col_source`, `source_subscribe_link` |
 | storage | `Lưu trữ`, `không gian lưu trữ`, `API lưu trữ` | Phân biệt dữ liệu script, vị trí được cấu hình và tên API. | `script_storage`, `script_operation_description`, `storage_api` |
 | sync deletion | `Đồng bộ trạng thái xóa` / `Đồng bộ xóa` | Chỉ thống nhất sau khi xác nhận hành vi thực tế của tùy chọn. | `sync_delete`, `sync_delete_desc`, `notification.script_sync_delete` |
 
@@ -80,11 +81,10 @@ Các mục dưới đây ghi nhận vấn đề đã tồn tại. Việc tạo h
 
 | Chủ đề | Hiện trạng | Hướng ưu tiên | Key ví dụ hiện tại |
 | --- | --- | --- | --- |
-| `script` / `tập lệnh` | Hai cách gọi xuất hiện trong cùng luồng giao diện. | Xác nhận giọng điệu sản phẩm rồi thống nhất; với chuỗi mới trong ngữ cảnh hiện đang dùng rộng rãi, ưu tiên `script`. | `installed_scripts`, `create_user_script`, `script_status_tooltip` |
+| `script` / `tập lệnh` | Hai cách gọi xuất hiện trong cùng luồng giao diện. | Xác nhận giọng điệu sản phẩm rồi thống nhất; với chuỗi mới trong ngữ cảnh hiện đang dùng rộng rãi, ưu tiên `script`. | `installed_scripts`, `create_user_script`, `script_list_action_content` |
 | scheduled script naming | Loại sản phẩm là `script hẹn giờ` nhưng một thông báo dùng `script crontab`. | Dùng `script hẹn giờ` cho cùng loại sản phẩm; chỉ nhắc `cron` khi nói đến biểu thức lịch chạy. | `scheduled_script`, `only_background_scheduled_can_run`, `cron_invalid_expr` |
-| identifier and brand capitalization | Có các dạng `scriptcat`, `eslint`, `vscode`, `api`, `Url` trong văn bản hiện tại. | Trong chỉnh sửa có phạm vi rõ ràng, giữ `ScriptCat`, `ESLint`, `VSCode`, `API`, `URL`. | `start_guide_title`, `api_docs`, `enable_eslint`, `vscode_url` |
-| metadata identifier | Tooltip tài nguyên ghi `@required`, trong khi metadata dùng `@require`. | Giữ đúng định danh `@require`. | `script_resource_tooltip` |
-| documentation link locale | Một số chuỗi tiếng Việt liên kết đến tài liệu `/en/`. | Chỉ đổi khi đã xác nhận có trang tiếng Việt tương ứng. | `guide_script_list_content`, `develop_mode_guide` |
+| identifier and brand capitalization | Có các dạng `scriptcat`, `eslint`, `vscode`, `api`, `Url` trong văn bản hiện tại. | Trong chỉnh sửa có phạm vi rõ ràng, giữ `ScriptCat`, `ESLint`, `VSCode`, `API`, `URL`. | `script_list_content`, `api_docs`, `enable_eslint`, `vscode_url` |
+| documentation link locale | Một số chuỗi tiếng Việt liên kết đến tài liệu `/en/`. | Chỉ đổi khi đã xác nhận có trang tiếng Việt tương ứng. | `script_list_content`, `develop_mode_guide` |
 
 ## Danh sách kiểm tra cho AI và người đóng góp
 

--- a/docs/translation/terminology-zh-CN.md
+++ b/docs/translation/terminology-zh-CN.md
@@ -2,7 +2,7 @@
 
 本文档是 ScriptCat 简体中文（`zh-CN`）界面与文档的用语依据。翻译或修改简体中文时，目标是让中国大陆用户自然理解，同时保留 ScriptCat 已建立的脚本类型、功能名称和开发者术语。
 
-用例参考来源：`src/locales/zh-CN/*.json`、`docs/README_zh-CN.md`
+用例参考来源：`src/locales/zh-CN/*.json`、`docs/README_zh-CN.md`、`docs/ARCHITECTURE.md`
 
 作者确认参考：[PR #1421 讨论](https://github.com/scriptscat/scriptcat/pull/1421)。其中 CodFrm 明确确认了 `同步删除`、`同步脚本删除`、`查询`，并建议将存储权限标题写为 `脚本正在尝试访问存储空间`。
 
@@ -30,31 +30,32 @@
 
 | 概念 | 优先使用 | 当前用例 key | 说明 |
 | --- | --- | --- | --- |
-| ScriptCat browser extension | `脚本猫扩展` | `start_guide_title`, `ext_update_notification` | `扩展` 是浏览器 extension 的标准表达。 |
-| generic user script | `用户脚本` | `guide_script_list_content`, `allow_user_script_guide` | 泛指用户脚本能力或浏览器权限。 |
-| ordinary / Tampermonkey-compatible script type | `普通脚本` / `普通油猴脚本` | `create_user_script`, `script_status_tooltip`, `script_list.sidebar.normal_script` | 表示产品中的脚本分类；不可仅因泛称为用户脚本而抹去分类信息。 |
-| page script | `页面脚本` | `page_script`, `foreground_page_script_tooltip`, `guide_script_list_enable_content` | 表示在指定页面运行的脚本。 |
+| ScriptCat browser extension | `脚本猫扩展` | `welcome_title`, `ext_update_notification` | `扩展` 是浏览器 extension 的标准表达。 |
+| generic user script | `用户脚本` | `script_list_content`, `allow_user_script_guide` | 泛指用户脚本能力或浏览器权限。 |
+| ordinary userscript type | `普通脚本` | `create_user_script`, `script_list.sidebar.normal_script` | 表示当前产品中的普通脚本分类；不可与后台脚本或定时脚本合并。 |
+| Tampermonkey compatibility | `油猴脚本` / `兼容 Tampermonkey 的用户脚本` | `docs/README_zh-CN.md`, `docs/ARCHITECTURE.md` | 仅在说明兼容性时使用，不把所有“用户脚本”泛称或“普通脚本”分类改写为油猴脚本。 |
+| page script | `页面脚本` | `script_list_enable_content` | 表示页面运行概念；不能仅因分类标签使用“普通脚本”而删去，也不应未经界面确认便互相替换。 |
 | background script | `后台脚本` | `create_background_script`, `background_script`, `enable_background.description` | 表示后台运行能力及脚本类型。 |
 | scheduled script | `定时脚本` | `create_scheduled_script`, `scheduled_script`, `scheduled_script_description_title` | 表示按计划执行的脚本类型。 |
-| ScriptCat script-browsing destination | `脚本站` / `脚本市场` | `script_gallery`, `guide_script_list_title`, `guide_script_list_content`, README | README 将指向 `https://scriptcat.org/search` 的入口称为 `脚本站`；引导界面的脚本发现与安装区域使用 `脚本市场`。按显示位置沿用名称，不自动互换。 |
-| script synchronization | `脚本同步` | `script_sync`, `guide_setting_sync_title`, `sync_status` | 与同步相关的功能名称沿用现行产品用语。 |
-| deletion synchronization | `同步删除` / `同步脚本删除` | `sync_delete`, `notification.script_sync_delete`, `guide_setting_sync_content` | CodFrm 在 PR #1421 中明确选择此写法；具体行为由右侧帮助说明解释，不在标签中扩写为 `删除状态`。 |
-| script subscription | `订阅` / `脚本订阅` | `subscribe`, `subscribe_url`, `subscribe_import_progress` | 对象为订阅，不使用英文式动词名词混写。 |
+| ScriptCat script-browsing destination | `脚本站` / `脚本市场` | `script_gallery`, `script_list_title`, `script_list_content`, README | README 将指向 `https://scriptcat.org/search` 的入口称为 `脚本站`；引导界面的脚本发现与安装区域使用 `脚本市场`。按显示位置沿用名称，不自动互换。 |
+| script synchronization | `脚本同步` | `script_sync`, `setting_sync_title`, `sync_status` | 与同步相关的功能名称沿用现行产品用语。 |
+| deletion synchronization | `同步删除` / `同步脚本删除` | `sync_delete`, `notification.script_sync_delete`, `setting_sync_content` | CodFrm 在 PR #1421 中明确选择此写法；具体行为由右侧帮助说明解释，不在标签中扩写为 `删除状态`。 |
+| script subscription | `订阅` / `脚本订阅` | `subscribe`, `subscribe_url`, `importpage.count_subscribes` | 对象为订阅，不使用英文式动词名词混写。 |
 
 ## B. 界面操作与状态标准表达
 
 | 概念 | 优先使用 | 当前用例 key | 说明 |
 | --- | --- | --- | --- |
-| create | `新建` / `创建` | `create_script`, `create_background_script`, `local_creation` | 新建按钮使用 `新建`；描述创建来源或过程时可用 `创建`。 |
+| create | `新建` / `创建` | `create_script`, `create_background_script`, `source_local_script` | 新建按钮使用 `新建`；描述创建来源或过程时可用 `创建`。 |
 | save / save as | `保存` / `另存为` | `save`, `save_as`, `save_success` | 与现行 UI 一致。 |
 | import / export | `导入` / `导出` | `import`, `export`, `import_file`, `export_file` | 与现行 UI 和大陆技术产品习惯一致。 |
-| install / update | `安装` / `更新` | `install_script`, `update_script`, `install_success` | 脚本与订阅均沿用同一动词。 |
-| run / runtime | `运行` / `运行时` | `run`, `running`, `runtime`, `script_run_at.title` | 脚本执行及 runtime 语境使用现行表达。 |
-| enable / disable | `开启` / `关闭`；状态或系统能力可用 `启用` / `禁用` | `enable`, `disable`, `enable_script`, `sync_system_closed`, `enable_background.title` | 操作按钮与配置状态需按句子自然度决定，不机械互换。 |
-| settings / configuration | `设置` / `配置` | `settings`, `script_setting.title`, `editor_config`, `user_config` | 产品设置页用 `设置`；配置对象或开发者配置使用 `配置`。 |
+| install / update | `安装` / `更新` | `script`, `update_script`, `success` | 脚本与订阅均沿用同一动词。 |
+| run / runtime | `运行` / `运行时` | `run`, `running`, `runtime`, `run_at` | 脚本执行及 runtime 语境使用现行表达。 |
+| enable / disable | `开启` / `关闭`；状态或系统能力可用 `启用` / `禁用` | `enable`, `disable`, `enabled_label`, `sync_system_closed`, `enable_background.title` | 操作按钮与配置状态需按句子自然度决定，不机械互换。 |
+| settings / configuration | `设置` / `配置` | `settings`, `script_setting`, `editor_config`, `user_config` | 产品设置页用 `设置`；配置对象或开发者配置使用 `配置`。 |
 | connect / synchronization | `连接` / `同步` | `connect`, `connection_success`, `script_sync`, `sync_system_connect_failed` | 分别表示网络或服务连接、数据同步。 |
-| restore / reset | `恢复` / `重置` | `restore`, `restore_default_values`, `reset`, `reset_success` | 恢复备份/默认值与重置操作应按实际行为区分。 |
-| load / reload | `加载` / `重新加载` | `loading`, `install_page_loading`, `click_to_reload` | 与现行 UI 一致。 |
+| restore / reset | `恢复` / `重置` | `restore`, `restore_default_values`, `reset`, `editor_config_reset` | 恢复备份/默认值与重置操作应按实际行为区分。 |
+| load / reload | `加载` / `重新加载` | `loading`, `loading_title`, `click_to_reload` | 与现行 UI 一致。 |
 | directory | `目录` | `open_directory`, `open_backup_dir` | 文件系统操作的常用表达。 |
 | tabs | `标签页` | `close_current_tab`, `close_other_tabs` | 指浏览器 tab 时使用完整的 `标签页`。 |
 | log query | `查询` | `query`, `total_logs`, `filtered_logs`, `enter_filter_conditions` | CodFrm 在 PR #1421 中明确偏好 `查询`；日志筛选说明可继续使用 `筛选`。 |
@@ -63,12 +64,12 @@
 
 | 概念 | 可用表达 | 判断标准 | 当前用例 key |
 | --- | --- | --- | --- |
-| local / cloud | `本地` / `云端` | 保存位置、导入来源与同步目的地使用现行成对表达。 | `local`, `cloud`, `source_local_script`, `guide_tools_backup_content` |
-| storage | `存储` / `储存` / `存储空间` | 权限对话框标题使用 CodFrm 建议的 `脚本正在尝试访问存储空间`；API 名使用 `存储 API`。其他既有混用列入审查，不直接全局替换。 | `storage_api`, `script_operation_title`, `script_storage`, `storage_error` |
+| local / cloud | `本地` / `云端` | 保存位置、导入来源与同步目的地使用现行成对表达。 | `local`, `cloud`, `source_local_script`, `tools_backup_content` |
+| storage | `存储` / `储存` / `存储空间` | 当前权限标题和脚本数据文案使用 `储存` / `储存空间`，API 标签保留英文 `Storage API`；统一用词前需按 UI 语境单独审查。 | `storage_api`, `script_operation_title`, `script_storage`, `storage_error` |
 | panel / console | `面板` / `控制台` | 操作面板使用 `面板`；开发者工具输出位置使用 `控制台`。 | `background_script_description`, `build_success_message` |
-| source | `来源` / `安装来源` / `订阅源` | 依据是一般来源、安装出处还是提供订阅内容的源来选择。 | `source`, `install_source`, `subscribe_source_tooltip` |
+| source | `来源` / `安装来源` / `订阅源` | 依据是一般来源、安装出处还是提供订阅内容的源来选择。 | `source`, `importpage.col_source`, `source_subscribe_link` |
 | permission / authorization | `权限` / `授权` | 能力类别与请求使用 `权限`；给予脚本访问权或已授权项使用 `授权`。 | `permission`, `request_permission`, `permission_management`, `confirm_delete_permission` |
-| ordinary / normal / page | `普通脚本` / `页面脚本` | 两者是否同一运行类型需依据产品模型确认，不从字面推定。 | `create_user_script`, `page_script`, `guide_script_list_enable_content` |
+| ordinary / normal script | `普通脚本` | 与后台脚本、定时脚本分开处理，不从一般“用户脚本”称呼推定分类。 | `create_user_script`, `script_list.sidebar.normal_script`, `script_list_enable_content` |
 | match / exclude | `匹配` / `排除` | 用户可见文案保留 `@match` / `@exclude` 标识符并配以中文说明。 | `website_match`, `website_exclude`, `add_match`, `add_exclude` |
 
 ## D. 固定保留的技术词
@@ -76,7 +77,7 @@
 | 英文概念 | 固定使用 | 当前用例 key | 理由 |
 | --- | --- | --- | --- |
 | expression | `表达式` | `value_export_expression`, `cookie_export_expression`, `expression_format_error` | 是脚本、条件与导出字段中一致且明确的开发术语。 |
-| cron expression | `定时表达式` | `cron_invalid_expr`, `error_cron_invalid`, `scheduled_script_description_description_expr` | 当前界面对 cron 采用用户可理解的产品表述。 |
+| cron expression | `定时表达式` | `cron_invalid_expr`, `error_cron_invalid` | 当前界面对 cron 采用用户可理解的产品表述。 |
 | regular expression | `正则表达式`；紧凑提示可写 `正则` | `search_regex` | 简体中文开发语境中的通用写法。 |
 | watch file changes | `监听文件` / `停止监听` | `watch_file_description`, `watch_file`, `stop_watch_file` | 表达持续监听变化并触发更新的功能含义。 |
 | metadata declaration | `声明` | `error_metadata_line_duplicated` | 对应 metadata declaration 的技术含义。 |
@@ -89,9 +90,9 @@
 
 | 对象 | 当前情况 | 建议方向 | 当前用例 key |
 | --- | --- | --- | --- |
-| `存储` / `储存` | API 与权限标题使用 `存储` / `存储空间`，脚本数据和迁移文案仍有 `储存`。 | `script_operation_title` 已按作者建议使用 `存储空间`；其余是否统一需单独确认。 | `storage_api`, `script_operation_title`, `script_storage`, `storage_error`, `migration_confirm_message` |
-| browser tabs | 关闭操作使用 `标签页`，运行环境使用 `标签`。 | 若 `script_run_env` 表示浏览器 tab，应改用 `所有标签页`、`普通标签页`、`隐身标签页`。 | `close_current_tab`, `script_run_env.all`, `script_run_env.normal-tabs`, `script_run_env.incognito-tabs` |
-| script type boundaries | 界面同时存在 `普通脚本`、`普通油猴脚本`、`用户脚本` 和 `页面脚本`。 | 在确认类型模型前保留各自现行含义；新文案不要擅自合并类别。 | `create_user_script`, `script_status_tooltip`, `guide_script_list_content`, `page_script` |
+| `存储` / `储存` | 脚本数据、权限标题和迁移文案均使用 `储存` / `储存空间`，API 标签为英文 `Storage API`。 | 面向简体中文用户的新普通 storage 文案优先使用 `存储`；既有内容是否统一需单独确认。 | `storage_api`, `script_operation_title`, `script_storage`, `storage_error`, `migration_confirm_message` |
+| browser tabs | 关闭操作使用 `标签页`，运行环境使用 `标签`。 | 若运行环境字段表示浏览器 tab，应改用 `所有标签页`、`普通标签页`、`隐身标签页`。 | `close_current_tab`, `script_run_env.all`, `script_run_env.normal-tabs`, `script_run_env.incognito-tabs` |
+| script type boundaries | 界面同时存在 `普通脚本` 与一般称呼 `用户脚本`。 | 新文案不要把普通脚本、后台脚本和定时脚本合并为同一分类。 | `create_user_script`, `script_list.sidebar.normal_script`, `script_list_content` |
 | UI spacing around Latin identifiers | 部分字符串写成 `API文档`、`ESLint规则`、`Cookie域`、`@connect标签`。 | 新增文案优先在中文与英文/标识符之间保留空格，既有内容应在单独审查中统一。 | `api_docs`, `eslint_rules`, `cookie_domain`, `confirm_operation_description` |
 
 ## 常用标准词

--- a/docs/translation/terminology-zh-TW.md
+++ b/docs/translation/terminology-zh-TW.md
@@ -2,7 +2,7 @@
 
 本文件是 ScriptCat 繁體中文（`zh-TW`）介面與文件的用語依據。翻譯或修改繁體中文時，目標是讓台灣使用者自然理解，並維持台灣軟體產品介面常見的語氣。
 
-盤點來源：`src/locales/zh-TW/*.json`、`docs/README_zh-TW.md`
+盤點來源：`src/locales/zh-TW/*.json`、`docs/README_zh-TW.md`、`docs/ARCHITECTURE.md`
 
 產品互動參考：[PR #1421 討論](https://github.com/scriptscat/scriptcat/pull/1421)。CodFrm 對相同同步刪除設定確認應以簡短標籤呈現，詳細行為由旁側說明交代；此項產品決策在 `zh-TW` 對應為 `同步刪除` / `同步腳本刪除`，不代表其他 `zh-CN` 詞彙偏好應套用至繁中。
 
@@ -32,15 +32,15 @@
 | `通用` | `一般` | `general` |
 | `列表` | `清單` | `backup_list`, `editor.show_script_list`, `editor.hide_script_list` |
 | `連接` | `連線` | `auto_connect_vscode_service`, `connect`, `connection_success`, `connection_failed`, `sync_system_connect_failed` |
-| `應用至` | `套用至` | `apply_to_run_status`, `guide_script_list_apply_to_run_status_title` |
+| `應用至` | `套用至` | `apply_to_run_status`, `script_list_enable_title` |
 | `每星期` | `每週` | `cron_oncetype.week` |
-| `返傭連結` | `分潤連結` | `antifeature_referral_link_description` |
-| `訂閱源` | `訂閱來源` | `subscribe_source_tooltip` |
-| `展示` | `顯示` | `guide_script_list_apply_to_run_status_content` |
-| `懸停` | `滑鼠停留` / `將滑鼠移到...上方` | `guide_script_list_apply_to_run_status_content` |
-| `運行` | 腳本用 `執行`；功能或環境用 `運作` | `guide_script_list_action_content`, `script_run_at.title`, `runtime`, `enable_background.title`, `enable_background.prompt_title`, `enable_background.prompt_description` |
-| `視圖模式` | `檢視模式` | `guide_script_list_action_content` |
-| `其它` | `其他` | `guide_setting_sync_content` |
+| `返傭連結` | `分潤連結` | `referral_link_description` |
+| `訂閱源` | `訂閱來源` | `source_subscribe_link` |
+| `展示` | `顯示` | `script_list_enable_content` |
+| `懸停` | `滑鼠停留` / `將滑鼠移到...上方` | `script_list_enable_content` |
+| `運行` | 腳本用 `執行`；功能或環境用 `運作` | `script_list_action_content`, `run_at`, `runtime`, `enable_background.title`, `enable_background.prompt_title`, `enable_background.prompt_description` |
+| `視圖模式` | `檢視模式` | `script_list_action_content` |
+| `其它` | `其他` | `setting_sync_content` |
 | `批量` | `批次` | `batch_edit` |
 | `代碼` | `程式碼` | `script_code` |
 | `回車` | `Enter 鍵` | `input_tags_placeholder` |
@@ -54,18 +54,20 @@
 | `目錄` | 指 filesystem directory 的介面動作用 `資料夾`；文章或文件的內容目錄仍用 `目錄`。 | `open_backup_dir`, `open_directory`, `script_operation_description`, `get_backup_dir_url_failed` |
 | `恢復` | restore settings/default values 用 `還原`；resume operation 或 recover 依語意使用 `恢復` / `復原`。 | `exclude_on`, `restore_default_values` |
 | `拉取` | Git pull 可用 `拉取`；從雲端取得備份或資料的 UI 動作用 `下載` / `擷取` / `同步取得`。 | `pulling_data_from_cloud`, `pull_failed` |
-| `保存` / `儲存` | UI 的 save 動作用 `儲存`；保存期限、保存證據或一般敘述仍可使用 `保存`。 | `guide_tools_backup_content` |
-| `設備` / `裝置` | 使用者持有、同步或連線的 device 介面用 `裝置`；equipment 或設備管理等語境仍可使用 `設備`。 | `guide_setting_sync_content` |
-| `打開` / `開啟` | 按鈕、選單或操作指示優先用 `開啟`；一般敘述中的 `打開` 並非錯誤。 | `open_sidebar` |
+| `保存` / `儲存` | UI 的 save 動作用 `儲存`；保存期限、保存證據或一般敘述仍可使用 `保存`。 | `tools_backup_content` |
+| `設備` / `裝置` | 使用者持有、同步或連線的 device 介面用 `裝置`；equipment 或設備管理等語境仍可使用 `設備`。 | `setting_sync_content` |
+| `打開` / `開啟` | 按鈕、選單或操作指示優先用 `開啟`；一般敘述中的 `打開` 並非錯誤。 | `show_main_sidebar` |
 | `聲明` / `宣告` | 程式 metadata declaration 使用 `宣告`；政策、立場或正式 statement 仍使用 `聲明`。 | `error_metadata_line_duplicated` |
 | `控制面板` / `面板` / `控制台` | 依實際產品元件與英文原文決定。英文為 `panel` 時優先保留 `面板`；只有 console/dashboard 或既定元件名稱才用 `控制台` / `儀表板`。 | `scheduled_script_description_title`, `background_script_description` |
-| `查看` | 台灣可用；選單、模式或系統動作可用 `檢視`，開啟工具則可直接寫 `開啟`。 | `guide_script_list_apply_to_run_status_content`, `develop_mode_guide`, `allow_user_script_guide`, `build_success_message`, `ext_update_notification_desc` |
+| `查看` | 台灣可用；選單、模式或系統動作可用 `檢視`，開啟工具則可直接寫 `開啟`。 | `script_list_enable_content`, `develop_mode_guide`, `allow_user_script_guide`, `build_success_message`, `ext_update_notification_desc` |
 | `退出瀏覽器` | quit/close browser 通常用 `關閉瀏覽器`，必要時可用 `結束瀏覽器`。 | `enable_background.description` |
 | `前臺` / `後臺` | foreground/background 用 `前景` / `背景`；frontend/backend 用 `前端` / `後端`；管理系統語境才可能用 `前台` / `後台`。 | `error_script_type_mismatch` |
-| `本地` / `本機` | 兩者皆為台灣可用寫法，不應只因 `zh-TW` 在地化而互相取代。`本地` 適合表達 local source / local creation 等與遠端來源相對的概念；`本機` 適合強調目前裝置或與雲端相對的儲存、匯入位置。同一功能流程內應維持一致。 | `source_local_script`, `by_manual_creation`, `local`, `import_by_local`, `import_local_failure`, `import_local_success`, `local_creation`, `sync_delete_desc`, `guide_tools_backup_content` |
-| `腳本站` / `腳本網站` / `腳本中心` | README 將指向 `https://scriptcat.org/zh-TW/search` 的入口稱為 `腳本站`；介面另有 `腳本網站` 與用於尋找、安裝腳本的 `腳本中心`。依顯示位置沿用名稱，不自動互換。 | `script_gallery`, `guide_script_list_title`, `guide_script_list_content`, README |
-| `查詢` / `搜尋` | 兩者皆可用；紀錄或資料條件查詢的欄位可保留 `查詢`，搜尋動作與正規表達式搜尋使用 `搜尋`。不因 `zh-CN` 對 `查詢` 的偏好而全域統一。 | `query`, `search_regex`, `search_scripts`, `enter_search_value` |
-| `同步刪除` / `同步腳本刪除` | 依 CodFrm 對同一設定的產品文案決策，設定標籤與通知標題保留短稱；刪除狀態的傳播行為由說明文字呈現，不在標籤中擴寫。 | `sync_delete`, `notification.script_sync_delete`, `guide_setting_sync_content`, `sync_delete_desc` |
+| `使用者腳本` / `普通腳本` / `頁面腳本` | `使用者腳本` 是一般概念，`普通腳本` 是現行分類標籤，`頁面腳本` 是介面中的頁面執行概念。三者應依顯示位置保留，不因用詞相近而自動合併或互換。 | `script_list_content`, `create_user_script`, `script_list.sidebar.normal_script`, `script_list_enable_content` |
+| `Tampermonkey 腳本` | 僅在說明相容性時使用；不要把所有 `使用者腳本` 泛稱或 `普通腳本` 分類改成 Tampermonkey 標籤。 | `docs/README_zh-TW.md`, `docs/ARCHITECTURE.md` |
+| `本地` / `本機` | 兩者皆為台灣可用寫法，不應只因 `zh-TW` 在地化而互相取代。`本地` 適合表達 local source / local creation 等與遠端來源相對的概念；`本機` 適合強調目前裝置或與雲端相對的儲存、匯入位置。同一功能流程內應維持一致。 | `source_local_script`, `local`, `importpage.source_local`, `sync_delete_desc`, `tools_backup_content` |
+| `腳本站` / `腳本網站` / `腳本中心` | README 將指向 `https://scriptcat.org/zh-TW/search` 的入口稱為 `腳本站`；介面另有 `腳本網站` 與用於尋找、安裝腳本的 `腳本中心`。依顯示位置沿用名稱，不自動互換。 | `script_gallery`, `script_list_title`, `script_list_content`, README |
+| `查詢` / `搜尋` | 兩者皆可用；紀錄或資料條件查詢的欄位可保留 `查詢`，搜尋動作與正規表達式搜尋使用 `搜尋`。不因 `zh-CN` 對 `查詢` 的偏好而全域統一。 | `query`, `search_regex`, `search_scripts` |
+| `同步刪除` / `同步腳本刪除` | 依 CodFrm 對同一設定的產品文案決策，設定標籤與通知標題保留短稱；刪除狀態的傳播行為由說明文字呈現，不在標籤中擴寫。 | `sync_delete`, `notification.script_sync_delete`, `setting_sync_content`, `sync_delete_desc` |
 | `腳本同步儲存空間` | 權限對話框標題使用 `儲存空間` 即可；同步用途由周邊功能語境與說明文字交代。 | `script_operation_title`, `script_operation_description` |
 
 ## C. 風格一致性
@@ -75,14 +77,14 @@
 | `幫助` | `說明` / `協助` | `helpcenter`, `help_translate` | 台灣日常用語可使用 `幫助`；Help Center 建議為 `說明中心`，help translate 建議為 `協助翻譯`。 |
 | `更新日誌` | `更新紀錄` / `版本紀錄` | `ext_update_notification_desc` | 技術內容可理解，產品介面以 `紀錄` 較自然。 |
 | `腳本個數` | `腳本數量` | `badge_type_script_count` | `個數` 可理解，但介面欄位以 `數量` 較自然。 |
-| `普通腳本` / `普通油猴腳本` / `普通標籤` | `一般腳本` / `一般油猴腳本` / `一般分頁` | `create_user_script`, `script_status_tooltip`, `script_run_env.normal-tabs`, `script_list.sidebar.normal_script` | `普通` 可改為較適合分類名稱的 `一般`；但 `油猴` 表示 Tampermonkey 相容腳本類型，不可逕改為語意較廣的 `使用者腳本`。若 `tabs` 指瀏覽器分頁，應使用 `分頁`。 |
+| `普通腳本` / `普通標籤` | `一般腳本` / `一般分頁` | `create_user_script`, `script_run_env.normal-tabs`, `script_list.sidebar.normal_script` | `普通` 可改為較適合分類名稱的 `一般`；若 `tabs` 指瀏覽器分頁，應使用 `分頁`。 |
 | `API文件` / `專案文件` | `API 文件` / `API 說明文件` / `專案文件` | `api_docs`, `project_docs` | `文件` 在台灣技術語境可接受；不要改為偏中國大陸用語的 `文檔`。 |
 
 ## D. 固定保留的技術詞
 
 | 英文概念 | 固定使用 | 不使用 | 目前使用 key | 理由 |
 | --- | --- | --- | --- | --- |
-| `expression` | `表達式` | `運算式` | `value_export_expression`, `cookie_export_expression`, `cron_invalid_expr`, `scheduled_script_description_description_expr`, `expression_format_error`, `search_regex` | `表達式` 是台灣程式開發語境常見用法，也與既有 `正規表達式` 術語一致。將不同 expression 文案改成 `運算式` 會造成同一概念在介面中不一致，且容易讓人誤解為只限數學或計算公式。 |
+| `expression` | `表達式` | `運算式` | `value_export_expression`, `cookie_export_expression`, `cron_invalid_expr`, `expression_format_error`, `search_regex` | `表達式` 是台灣程式開發語境常見用法，也與既有 `正規表達式` 術語一致。將不同 expression 文案改成 `運算式` 會造成同一概念在介面中不一致，且容易讓人誤解為只限數學或計算公式。 |
 | `watch`（檔案變動功能） | `監聽` | `監看` | `watch_file_description`, `watch_file`, `stop_watch_file` | 在開發工具中，watch 表示持續監聽檔案變動並觸發更新，與 watcher、事件監聽等技術概念相連。`監聽` 能保持技術意義與現有文案一致；`監看` 雖可理解，但不作為本專案術語。 |
 
 ## 常用標準詞


### PR DESCRIPTION
## Checklist / 检查清单

* [ ] Fixes mentioned issues / 修复已提及的问题
* [ ] Code reviewed by human / 代码通过人工检查
* [ ] Changes tested / 已完成测试

## Description / 描述

本 PR 更新翻译与本地化相关文档，补充 `tr-TR` 土耳其语术语规范，并同步修正现有多语言术语文档中的参考来源、示例 key 与术语说明，使其与当前项目结构和实际 locale 内容保持一致。

主要变更：

* 将 i18n 文档中的 locale 数量从 7 个更新为 8 个，并补充 `tr-TR` 到 locale 列表。
* 在 `docs/translation/README.md` 中新增土耳其语 `tr-TR` 术语规范入口。
* 新增 `docs/translation/terminology-tr-TR.md`，定义土耳其语界面与文档的术语规则，包括：

  * ScriptCat 产品与脚本类型命名；
  * 用户脚本、普通脚本、页面脚本、后台脚本、定时脚本的边界；
  * Tampermonkey 兼容性描述的使用场景；
  * 订阅、同步、来源、存储、权限等常见 UI 术语；
  * `Regex`、`cron`、`@match`、`@require` 等技术术语和 metadata 标识符的保留规则；
  * 后续需要单独审查的土耳其语文案问题。
* 更新 `en-US`、`zh-CN`、`zh-TW`、`ja-JP`、`de-DE`、`ru-RU`、`vi-VN` 等现有术语文档：

  * 增加 `docs/ARCHITECTURE.md` 作为术语参考来源；
  * 修正过期或已迁移的示例 key；
  * 明确普通脚本、用户脚本、页面脚本与 Tampermonkey 兼容描述之间的区别；
  * 调整订阅、来源、同步删除、浏览器标签页等术语说明；
  * 移除或收敛部分已不适合当前文档状态的审查项。
* 更新 `docs/DESIGN.md` 与 `docs/DEVELOP.md` 中的 i18n 说明，使设计与开发文档反映当前 8 个 locale 的状态。

本 PR 仅涉及文档与术语规范更新，不包含运行时代码变更。

## Screenshots / 截图

不适用。本 PR 仅更新文档内容。
