### PR TITLE
🐛 修复 crontab 示例中不可用的演示 API

### DIFF
--- a/example/crontab/crontab.js
+++ b/example/crontab/crontab.js
@@ -1,37 +1,36 @@
 // ==UserScript==
 // @name         crontab example
 // @namespace    https://bbs.tampermonkey.net.cn/
-// @version      0.1.0
+// @version      0.2.0
 // @description  定时脚本示例
 // @author       You
 // @crontab      */15 14-16 * * *
 // @grant        GM_log
 // @grant        GM_xmlhttpRequest
-// @connect      dog.ceo
+// @connect      httpbun.com
 // ==/UserScript==
 
 return new Promise((resolve, reject) => {
-    // Your code here...
-    GM_log("下午两点至四点每十五分钟运行一次");
-    
+  GM_log("下午两点至四点每十五分钟运行一次");
 
-    GM_xmlhttpRequest({
-        url: "https://dog.ceo/api/breeds/image/random",
-        method: "GET",
-        responseType: "json",
-        anonymous: true,
+  GM_xmlhttpRequest({
+    url: "https://httpbun.com/get",
+    method: "GET",
+    responseType: "json",
+    anonymous: true,
 
-        onload(resp) {
-            if (typeof resp.response.message !== "string") {
-                reject("服务器回应错误。");
-            }
-            else {
-                GM_log(`你可能会遇到的狗狗是\n${resp.response.message}`);
-                resolve();
-            }
-        },
-        onerror(){
-            reject("服务器回应错误。");
-        }
-    });
+    onload(resp) {
+      const data = resp.response;
+      if (resp.status !== 200 || data?.url !== "https://httpbun.com/get") {
+        reject("服务器回应错误。");
+        return;
+      }
+
+      GM_log(`定时请求成功：\n${data.url}`);
+      resolve();
+    },
+    onerror() {
+      reject("服务器回应错误。");
+    },
+  });
 });

--- a/tests/example/crontab.test.ts
+++ b/tests/example/crontab.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it, vi } from "vitest";
+
+type RequestDetails = {
+  url: string;
+  onload: (response: { status: number; response: unknown }) => void;
+};
+
+const source = readFileSync(resolve(process.cwd(), "example/crontab/crontab.js"), "utf8");
+const runExample = new Function("GM_log", "GM_xmlhttpRequest", source) as (
+  log: (message: string) => void,
+  request: (details: RequestDetails) => void
+) => Promise<void>;
+
+describe("定时脚本示例", () => {
+  it("定时请求 httpbun 并记录响应 URL", async () => {
+    const log = vi.fn();
+    let requestDetails: RequestDetails | undefined;
+    const result = runExample(log, (details) => {
+      requestDetails = details;
+    });
+
+    expect(requestDetails?.url).toBe("https://httpbun.com/get");
+
+    requestDetails?.onload({
+      status: 200,
+      response: {
+        url: "https://httpbun.com/get",
+      },
+    });
+
+    await expect(result).resolves.toBeUndefined();
+    expect(log).toHaveBeenCalledWith("定时请求成功：\nhttps://httpbun.com/get");
+  });
+});


### PR DESCRIPTION
## Checklist / 检查清单

* [ ] Fixes mentioned issues / 修复已提及的问题
* [ ] Code reviewed by human / 代码通过人工检查
* [ ] Changes tested / 已完成测试

## Description / 描述

修复 crontab 示例中使用的不可用演示 API，将原来的 `dog.ceo` 请求替换为 `httpbun.com/get`，并同步更新 `@connect` 配置。

同时调整了响应校验逻辑，改为检查请求状态码和返回的 URL，避免示例依赖不稳定或不可用的第三方接口。

本次变更还新增了对应的 Vitest 测试，用于验证 crontab 示例会请求正确的 API，并在请求成功后输出预期日志。

## Screenshots / 截图

无界面变更。
