### PR TITLE
✨ 编辑器标签栏「＋」支持选择新建脚本类型

### DIFF
--- a/src/pages/options/routes/ScriptEditor/EditorTabs.test.tsx
+++ b/src/pages/options/routes/ScriptEditor/EditorTabs.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeAll, afterEach, beforeEach } from "vitest";
+import { render, cleanup, screen, fireEvent, act } from "@testing-library/react";
+import { initTestLanguage } from "@Tests/initTestLanguage";
+import type { Script } from "@App/app/repo/scripts";
+import EditorTabs from "./EditorTabs";
+import type { EditorTab } from "./useEditorTabs";
+
+afterEach(cleanup);
+beforeAll(() => initTestLanguage("zh-CN"));
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const makeTab = (uuid: string, name: string): EditorTab => ({
+  uuid,
+  script: { uuid, name, metadata: {} } as Script,
+  code: "",
+  subView: "code",
+  isChanged: false,
+});
+
+const onNew = vi.fn();
+
+function renderTabs() {
+  return render(
+    <EditorTabs
+      tabs={[makeTab("u1", "脚本一")]}
+      activeUuid="u1"
+      onActivate={vi.fn()}
+      onClose={vi.fn()}
+      onCloseOthers={vi.fn()}
+      onCloseLeft={vi.fn()}
+      onCloseRight={vi.fn()}
+      onNew={onNew}
+    />
+  );
+}
+
+describe("EditorTabs「＋」新建菜单", () => {
+  it("hover「＋」展开脚本类型选择菜单", async () => {
+    renderTabs();
+    const plusBtn = screen.getByLabelText("新建脚本");
+
+    await act(async () => {
+      fireEvent.mouseEnter(plusBtn);
+    });
+
+    expect(screen.getByText("新建普通脚本")).toBeInTheDocument();
+    expect(screen.getByText("新建后台脚本")).toBeInTheDocument();
+    expect(screen.getByText("新建定时脚本")).toBeInTheDocument();
+  });
+
+  it("点击「新建后台脚本」以 background 模板回调 onNew", async () => {
+    renderTabs();
+    const plusBtn = screen.getByLabelText("新建脚本");
+
+    await act(async () => {
+      fireEvent.mouseEnter(plusBtn);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("新建后台脚本"));
+    });
+
+    expect(onNew).toHaveBeenCalledTimes(1);
+    expect(onNew).toHaveBeenCalledWith("background");
+  });
+
+  it("点击「新建定时脚本」以 crontab 模板回调 onNew", async () => {
+    renderTabs();
+    const plusBtn = screen.getByLabelText("新建脚本");
+
+    await act(async () => {
+      fireEvent.mouseEnter(plusBtn);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("新建定时脚本"));
+    });
+
+    expect(onNew).toHaveBeenCalledTimes(1);
+    expect(onNew).toHaveBeenCalledWith("crontab");
+  });
+
+  it("点击「新建普通脚本」以空模板回调 onNew", async () => {
+    renderTabs();
+    const plusBtn = screen.getByLabelText("新建脚本");
+
+    await act(async () => {
+      fireEvent.mouseEnter(plusBtn);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText("新建普通脚本"));
+    });
+
+    expect(onNew).toHaveBeenCalledTimes(1);
+    expect(onNew).toHaveBeenCalledWith("");
+  });
+
+  it("直接点击「＋」沿用默认模板新建(不传模板参数)", async () => {
+    renderTabs();
+    const plusBtn = screen.getByLabelText("新建脚本");
+
+    await act(async () => {
+      fireEvent.pointerDown(plusBtn, { button: 0 });
+      fireEvent.click(plusBtn);
+    });
+
+    expect(onNew).toHaveBeenCalledTimes(1);
+    expect(onNew).toHaveBeenCalledWith();
+  });
+});

--- a/src/pages/options/routes/ScriptEditor/EditorTabs.tsx
+++ b/src/pages/options/routes/ScriptEditor/EditorTabs.tsx
@@ -3,6 +3,13 @@ import { useTranslation } from "react-i18next";
 import { Plus, X } from "lucide-react";
 import { i18nName } from "@App/locales/locales";
 import { cn } from "@App/pkg/utils/cn";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@App/pages/components/ui/dropdown-menu";
+import { useHoverMenu } from "@App/pages/components/ui/use-hover-menu";
 import type { EditorTab } from "./useEditorTabs";
 
 export interface EditorTabsProps {
@@ -13,7 +20,8 @@ export interface EditorTabsProps {
   onCloseOthers: (uuid: string) => void;
   onCloseLeft: (uuid: string) => void;
   onCloseRight: (uuid: string) => void;
-  onNew: () => void;
+  /** 不传模板即沿用页面默认模板（URL template 参数） */
+  onNew: (template?: string) => void;
 }
 
 interface MenuState {
@@ -26,6 +34,12 @@ function EditorTabs(props: EditorTabsProps) {
   const { t } = useTranslation();
   const { tabs, activeUuid, onActivate, onClose, onCloseOthers, onCloseLeft, onCloseRight, onNew } = props;
   const [menu, setMenu] = useState<MenuState | null>(null);
+  const { close, rootProps, hoverProps, contentProps } = useHoverMenu();
+
+  const handleNew = (template: string) => {
+    close();
+    onNew(template);
+  };
 
   const menuItems = menu
     ? [
@@ -74,14 +88,32 @@ function EditorTabs(props: EditorTabsProps) {
           </div>
         );
       })}
-      <button
-        type="button"
-        aria-label={t("editor:new_script")}
-        onClick={onNew}
-        className="flex w-9 shrink-0 items-center justify-center text-muted-foreground hover:bg-accent hover:text-foreground"
-      >
-        <Plus className="size-4" />
-      </button>
+      {/* hover 弹出脚本类型选择（同「新建脚本」下拉）；直接点击仍按默认模板快速新建 */}
+      <DropdownMenu {...rootProps}>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label={t("editor:new_script")}
+            onClick={() => {
+              close();
+              onNew();
+            }}
+            className="flex w-9 shrink-0 items-center justify-center text-muted-foreground hover:bg-accent hover:text-foreground"
+            {...hoverProps}
+          >
+            <Plus className="size-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" {...contentProps}>
+          <DropdownMenuItem onClick={() => handleNew("")}>{t("script:create_user_script")}</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => handleNew("background")}>
+            {t("script:create_background_script")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => handleNew("crontab")}>
+            {t("script:create_scheduled_script")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       {menu && (
         <>

--- a/src/pages/options/routes/ScriptEditor/index.tsx
+++ b/src/pages/options/routes/ScriptEditor/index.tsx
@@ -362,7 +362,11 @@ export default function ScriptEditor() {
   const onCloseOthersTab = useCallback((uuid: string) => dispatch({ type: "closeOthers", uuid }), []);
   const onCloseLeftTab = useCallback((uuid: string) => dispatch({ type: "closeLeft", uuid }), []);
   const onCloseRightTab = useCallback((uuid: string) => dispatch({ type: "closeRight", uuid }), []);
-  const onNewTab = useCallback(() => void openScript(undefined, templateRef.current, targetRef.current), [openScript]);
+  // template 未传时沿用 URL 默认模板；「＋」菜单显式选择类型时以所选为准
+  const onNewTab = useCallback(
+    (template?: string) => void openScript(undefined, template ?? templateRef.current, targetRef.current),
+    [openScript]
+  );
   const onOpenScript = useCallback((uuid: string) => void openScript(uuid), [openScript]);
   const onBack = useCallback(() => navigate("/"), [navigate]);
 


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

close #1540

**问题**：新 UI 中脚本编辑器标签栏的「＋」只能按页面默认模板新建脚本，无法像旧 UI 那样选择脚本类型（普通 / 后台 / 定时）。

**方案**：按 issue 的提案，指向「＋」时弹出与脚本列表「新建脚本」一致的类型选择菜单（复用 `useHoverMenu` + shadcn `DropdownMenu` 的既有模式），点击菜单项以对应模板（`` / `background` / `crontab`）新建标签；直接点击「＋」保持原行为，沿用 URL 默认模板快速新建，不影响现有工作流。

**改动**：
- `EditorTabs.tsx`：「＋」按钮外包一层 hover 触发的 DropdownMenu，`onNew` 增加可选 `template` 参数；菜单文案复用现有 `script:` 命名空间 i18n key，无新增翻译。
- `ScriptEditor/index.tsx`：`onNewTab` 接受可选 `template`，未传时沿用 URL 的 `template` 参数（原行为）。
- `EditorTabs.test.tsx`：新增 5 个单元测试（TDD，先写失败测试再实现）。

**测试**：
- `vitest` 全量 287 文件 / 3010 用例通过；`pnpm run lint`（prettier + tsc + eslint）通过。
- 已按 `docs/VERIFICATION.md` 用 Playwright 驱动真实构建的扩展验证：hover「＋」弹出三个类型项（Create User Script / Create Background Script / Create Scheduled Script），点击「Create Background Script」后新标签载入含 `// @background` 的后台脚本模板。

## Screenshots / 截图

（CLI 无法上传附件，验证截图见上述 Playwright 验证描述；如需可补充。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)