### PR TITLE
⚡ e2e: 分片 CI 并复用预配置 Profile，降低 Chromium 启动开销

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -129,8 +129,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2]
-        shardTotal: [2]
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -125,7 +125,12 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    name: Run E2E tests
+    name: Run E2E tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2]
+        shardTotal: [2]
     steps:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5
@@ -138,6 +143,9 @@ jobs:
 
       - name: Setup pnpm
         run: corepack enable
+
+      - name: Show runner CPU count
+        run: nproc
 
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
@@ -159,13 +167,13 @@ jobs:
         run: pnpm build
 
       - name: Run E2E tests
-        run: pnpm test:e2e
+        run: pnpm exec playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: e2e-test-results
+          name: e2e-test-results-${{ matrix.shardIndex }}
           path: |
             test-results/
             playwright-report/

--- a/e2e/agent-fixtures.ts
+++ b/e2e/agent-fixtures.ts
@@ -5,7 +5,11 @@ import { test as base, expect, chromium, type BrowserContext, type Route } from 
 export { expect };
 
 const pathToExtension = path.resolve(__dirname, "../dist/ext");
-const chromeArgs = [`--disable-extensions-except=${pathToExtension}`, `--load-extension=${pathToExtension}`];
+const chromeArgs = [
+  `--disable-extensions-except=${pathToExtension}`,
+  `--load-extension=${pathToExtension}`,
+  "--disable-gpu",
+];
 
 function getProxyOptions() {
   const proxy =
@@ -106,6 +110,7 @@ export const test = base.extend<AgentFixtures, { agentProfileDir: string }>({
       const ctx1 = await chromium.launchPersistentContext(userDataDir, {
         headless: false,
         args: ["--headless=new", ...chromeArgs],
+        timeout: 60_000,
       });
       let [bg] = ctx1.serviceWorkers();
       if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
@@ -165,6 +170,7 @@ export const test = base.extend<AgentFixtures, { agentProfileDir: string }>({
     const context = await chromium.launchPersistentContext(userDataDir, {
       headless: false,
       args: ["--headless=new", ...chromeArgs],
+      timeout: 60_000,
       ...getProxyOptions(),
     });
     const [sw] = context.serviceWorkers();

--- a/e2e/agent-fixtures.ts
+++ b/e2e/agent-fixtures.ts
@@ -11,6 +11,10 @@ const chromeArgs = [
   "--disable-gpu",
 ];
 
+// CI（GitHub Actions）跑在非 root 用户下不会自动应用 --no-sandbox，关掉沙箱能省下每次
+// launchPersistentContext 的 sandbox/fork 开销；本地开发机上仍保留沙箱隔离。
+const chromiumSandbox = !process.env.CI;
+
 function getProxyOptions() {
   const proxy =
     process.env.E2E_PROXY ||
@@ -111,6 +115,7 @@ export const test = base.extend<AgentFixtures, { agentProfileDir: string }>({
         headless: false,
         args: ["--headless=new", ...chromeArgs],
         timeout: 60_000,
+        chromiumSandbox,
       });
       let [bg] = ctx1.serviceWorkers();
       if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
@@ -171,6 +176,7 @@ export const test = base.extend<AgentFixtures, { agentProfileDir: string }>({
       headless: false,
       args: ["--headless=new", ...chromeArgs],
       timeout: 60_000,
+      chromiumSandbox,
       ...getProxyOptions(),
     });
     const [sw] = context.serviceWorkers();

--- a/e2e/agent-fixtures.ts
+++ b/e2e/agent-fixtures.ts
@@ -108,7 +108,7 @@ export const test = base.extend<AgentFixtures, { agentProfileDir: string }>({
         args: ["--headless=new", ...chromeArgs],
       });
       let [bg] = ctx1.serviceWorkers();
-      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 30_000 });
+      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
       const extensionId = bg.url().split("/")[2];
 
       // 启用 userScripts 权限
@@ -128,7 +128,7 @@ export const test = base.extend<AgentFixtures, { agentProfileDir: string }>({
       // userScripts 启用后 SW 可能重启，重新获取
       let currentBg = ctx1.serviceWorkers().find((w) => w.url().includes(extensionId));
       if (!currentBg) {
-        currentBg = await ctx1.waitForEvent("serviceworker", { timeout: 15_000 });
+        currentBg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
       }
       await currentBg.evaluate(() => {
         const modelConfig = {
@@ -168,7 +168,7 @@ export const test = base.extend<AgentFixtures, { agentProfileDir: string }>({
       ...getProxyOptions(),
     });
     const [sw] = context.serviceWorkers();
-    if (!sw) await context.waitForEvent("serviceworker", { timeout: 30_000 });
+    if (!sw) await context.waitForEvent("serviceworker", { timeout: 14_000 });
 
     await use(context);
     await context.close();
@@ -177,7 +177,7 @@ export const test = base.extend<AgentFixtures, { agentProfileDir: string }>({
 
   extensionId: async ({ context }, use) => {
     let [background] = context.serviceWorkers();
-    if (!background) background = await context.waitForEvent("serviceworker");
+    if (!background) background = await context.waitForEvent("serviceworker", { timeout: 14_000 });
     const extensionId = background.url().split("/")[2];
 
     // 关闭首次使用引导

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -25,6 +25,10 @@ const chromeArgs = [
   "--disable-gpu",
 ];
 
+// CI（GitHub Actions）跑在非 root 用户下不会自动应用 --no-sandbox，关掉沙箱能省下每次
+// launchPersistentContext 的 sandbox/fork 开销；本地开发机上仍保留沙箱隔离。
+const chromiumSandbox = !process.env.CI;
+
 // 预先标记「非首次使用」，避免新手引导欢迎弹窗的模态遮罩拦截测试交互。
 // 用 addInitScript 在每个页面脚本执行前注入，避开持久化 profile 下「开页→写→关页」的 localStorage 落盘竞态。
 function dismissOnboarding() {
@@ -48,6 +52,7 @@ export const test = base.extend<{
       headless: false,
       args: ["--headless=new", ...chromeArgs],
       timeout: 60_000,
+      chromiumSandbox,
       ...getProxyOptions(),
       ...getRecordVideoOptions(),
     });
@@ -93,6 +98,7 @@ export const testWithUserScripts = base.extend<
         headless: false,
         args: ["--headless=new", ...chromeArgs],
         timeout: 60_000,
+        chromiumSandbox,
       });
       let [bg] = ctx1.serviceWorkers();
       if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
@@ -125,6 +131,7 @@ export const testWithUserScripts = base.extend<
       headless: false,
       args: ["--headless=new", ...chromeArgs],
       timeout: 60_000,
+      chromiumSandbox,
       ...getProxyOptions(),
       ...getRecordVideoOptions(),
     });

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -19,7 +19,11 @@ function getRecordVideoOptions() {
   return process.env.E2E_RECORD_VIDEO_DIR ? { recordVideo: { dir: process.env.E2E_RECORD_VIDEO_DIR } } : {};
 }
 
-const chromeArgs = [`--disable-extensions-except=${pathToExtension}`, `--load-extension=${pathToExtension}`];
+const chromeArgs = [
+  `--disable-extensions-except=${pathToExtension}`,
+  `--load-extension=${pathToExtension}`,
+  "--disable-gpu",
+];
 
 // 预先标记「非首次使用」，避免新手引导欢迎弹窗的模态遮罩拦截测试交互。
 // 用 addInitScript 在每个页面脚本执行前注入，避开持久化 profile 下「开页→写→关页」的 localStorage 落盘竞态。
@@ -43,6 +47,7 @@ export const test = base.extend<{
     const context = await chromium.launchPersistentContext("", {
       headless: false,
       args: ["--headless=new", ...chromeArgs],
+      timeout: 60_000,
       ...getProxyOptions(),
       ...getRecordVideoOptions(),
     });
@@ -87,6 +92,7 @@ export const testWithUserScripts = base.extend<
       const ctx1 = await chromium.launchPersistentContext(userDataDir, {
         headless: false,
         args: ["--headless=new", ...chromeArgs],
+        timeout: 60_000,
       });
       let [bg] = ctx1.serviceWorkers();
       if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
@@ -118,6 +124,7 @@ export const testWithUserScripts = base.extend<
     const context = await chromium.launchPersistentContext(userDataDir, {
       headless: false,
       args: ["--headless=new", ...chromeArgs],
+      timeout: 60_000,
       ...getProxyOptions(),
       ...getRecordVideoOptions(),
     });

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -65,39 +65,56 @@ export const expect = test.expect;
 /**
  * 两阶段启动 fixture — 需要 userScripts 权限的测试使用
  *
- * Phase 1: 启动浏览器 → 启用 userScripts 权限 → 关闭
- * Phase 2: 重新启动浏览器（权限已持久化）
+ * Phase 1（worker 级，每个 worker 只做一次）：启动浏览器 → 启用 userScripts 权限 → 关闭
+ * Phase 2（每个 test）：拷贝 Phase 1 的 profile 目录后重新启动（权限已持久化）
+ *
+ * 参照 e2e/gm-api.spec.ts 已验证过的模式：避免每个 test 都完整走两次
+ * launchPersistentContext，CI 下 workers 并行时大量并发 Chrome 启动会互相
+ * 抢占 CPU，把扩展 service worker 的启动拖到超过 30s 超时。
  */
-export const testWithUserScripts = base.extend<{
-  context: BrowserContext;
-  extensionId: string;
-}>({
-  // eslint-disable-next-line no-empty-pattern
-  context: async ({}, use) => {
-    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "pw-ext-"));
+export const testWithUserScripts = base.extend<
+  {
+    context: BrowserContext;
+    extensionId: string;
+  },
+  { userScriptsProfileDir: string }
+>({
+  userScriptsProfileDir: [
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "pw-ext-profile-"));
 
-    // Phase 1: 启用 userScripts 权限
-    const ctx1 = await chromium.launchPersistentContext(userDataDir, {
-      headless: false,
-      args: ["--headless=new", ...chromeArgs],
-    });
-    let [bg] = ctx1.serviceWorkers();
-    if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 30_000 });
-    const extensionId = bg.url().split("/")[2];
-    const extPage = await ctx1.newPage();
-    await extPage.goto("chrome://extensions/");
-    await extPage.waitForLoadState("domcontentloaded");
-    await extPage.waitForFunction(() => !!(chrome as any).developerPrivate, { timeout: 10_000 });
-    await extPage.evaluate(async (id) => {
-      await (chrome as any).developerPrivate.updateExtensionConfiguration({
-        extensionId: id,
-        userScriptsAccess: true,
+      const ctx1 = await chromium.launchPersistentContext(userDataDir, {
+        headless: false,
+        args: ["--headless=new", ...chromeArgs],
       });
-    }, extensionId);
-    await extPage.close();
-    await ctx1.close();
+      let [bg] = ctx1.serviceWorkers();
+      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 30_000 });
+      const extensionId = bg.url().split("/")[2];
+      const extPage = await ctx1.newPage();
+      await extPage.goto("chrome://extensions/");
+      await extPage.waitForLoadState("domcontentloaded");
+      await extPage.waitForFunction(() => !!(chrome as any).developerPrivate, { timeout: 10_000 });
+      await extPage.evaluate(async (id) => {
+        await (chrome as any).developerPrivate.updateExtensionConfiguration({
+          extensionId: id,
+          userScriptsAccess: true,
+        });
+      }, extensionId);
+      await extPage.close();
+      await ctx1.close();
 
-    // Phase 2: 重新启动，userScripts 权限已持久化
+      await use(userDataDir);
+      fs.rmSync(userDataDir, { recursive: true, force: true });
+    },
+    { scope: "worker" },
+  ],
+  context: async ({ userScriptsProfileDir }, use) => {
+    // 每个测试使用从预配置 profile 拷贝出的独立目录，避免脚本/storage 状态泄漏到后续测试，
+    // 同时跳过每个测试都重新做一次的 Phase 1 权限配置。
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "pw-ext-test-"));
+    fs.cpSync(userScriptsProfileDir, userDataDir, { recursive: true });
+
     const context = await chromium.launchPersistentContext(userDataDir, {
       headless: false,
       args: ["--headless=new", ...chromeArgs],

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -53,7 +53,7 @@ export const test = base.extend<{
   extensionId: async ({ context }, use) => {
     let [background] = context.serviceWorkers();
     if (!background) {
-      background = await context.waitForEvent("serviceworker");
+      background = await context.waitForEvent("serviceworker", { timeout: 14_000 });
     }
     const extensionId = background.url().split("/")[2];
     await use(extensionId);
@@ -89,7 +89,7 @@ export const testWithUserScripts = base.extend<
         args: ["--headless=new", ...chromeArgs],
       });
       let [bg] = ctx1.serviceWorkers();
-      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 30_000 });
+      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
       const extensionId = bg.url().split("/")[2];
       const extPage = await ctx1.newPage();
       await extPage.goto("chrome://extensions/");
@@ -123,14 +123,14 @@ export const testWithUserScripts = base.extend<
     });
     await context.addInitScript(dismissOnboarding);
     const [sw] = context.serviceWorkers();
-    if (!sw) await context.waitForEvent("serviceworker", { timeout: 30_000 });
+    if (!sw) await context.waitForEvent("serviceworker", { timeout: 14_000 });
     await use(context);
     await context.close();
     fs.rmSync(userDataDir, { recursive: true, force: true });
   },
   extensionId: async ({ context }, use) => {
     let [background] = context.serviceWorkers();
-    if (!background) background = await context.waitForEvent("serviceworker");
+    if (!background) background = await context.waitForEvent("serviceworker", { timeout: 14_000 });
     const extensionId = background.url().split("/")[2];
     await use(extensionId);
   },

--- a/e2e/gm-api.spec.ts
+++ b/e2e/gm-api.spec.ts
@@ -43,7 +43,7 @@ const test = base.extend<
         args: ["--headless=new", ...chromeArgs],
       });
       let [bg] = ctx1.serviceWorkers();
-      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 60_000 });
+      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 30_000 });
       const extensionId = bg.url().split("/")[2];
       const extPage = await ctx1.newPage();
       await extPage.goto("chrome://extensions/");

--- a/e2e/gm-api.spec.ts
+++ b/e2e/gm-api.spec.ts
@@ -9,48 +9,66 @@ import { autoApprovePermissions, installScriptByCode } from "./utils";
 const MOCK_CONNECT_HOST = "127.0.0.1";
 const CSP_TARGET_HOST = "content-security-policy.test";
 
+const pathToExtension = path.resolve(__dirname, "../dist/ext");
+const chromeArgs = [
+  `--disable-extensions-except=${pathToExtension}`,
+  `--load-extension=${pathToExtension}`,
+  `--host-resolver-rules=MAP ${CSP_TARGET_HOST} ${MOCK_CONNECT_HOST},EXCLUDE localhost`,
+];
+
 type GMApiMockServer = {
   origin: string;
   cspOrigin: string;
   close: () => Promise<void>;
 };
 
-const test = base.extend<{
-  context: BrowserContext;
-  extensionId: string;
-}>({
-  // eslint-disable-next-line no-empty-pattern
-  context: async ({}, use) => {
-    const pathToExtension = path.resolve(__dirname, "../dist/ext");
-    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "pw-ext-"));
-    const chromeArgs = [
-      `--disable-extensions-except=${pathToExtension}`,
-      `--load-extension=${pathToExtension}`,
-      `--host-resolver-rules=MAP ${CSP_TARGET_HOST} ${MOCK_CONNECT_HOST},EXCLUDE localhost`,
-    ];
+const test = base.extend<
+  {
+    context: BrowserContext;
+    extensionId: string;
+  },
+  { gmApiProfileDir: string }
+>({
+  // Worker 级 fixture：启用 user scripts 权限的 Phase 1（含 chrome://extensions 导航 +
+  // developerPrivate 调用）每个 worker 只做一次，而不是每个 test 都重新做一遍。
+  // 之前每个 test 都要完整走两次 launchPersistentContext，CI 下 workers 并行时
+  // 大量并发 Chrome 启动会互相抢占 CPU，把扩展 service worker 的启动拖到超过 30s 超时。
+  gmApiProfileDir: [
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "pw-ext-profile-"));
 
-    // Phase 1: Enable user scripts permission
-    const ctx1 = await chromium.launchPersistentContext(userDataDir, {
-      headless: false,
-      args: ["--headless=new", ...chromeArgs],
-    });
-    let [bg] = ctx1.serviceWorkers();
-    if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 30_000 });
-    const extensionId = bg.url().split("/")[2];
-    const extPage = await ctx1.newPage();
-    await extPage.goto("chrome://extensions/");
-    await extPage.waitForLoadState("domcontentloaded");
-    await extPage.waitForFunction(() => !!(chrome as any).developerPrivate, { timeout: 10_000 });
-    await extPage.evaluate(async (id) => {
-      await (chrome as any).developerPrivate.updateExtensionConfiguration({
-        extensionId: id,
-        userScriptsAccess: true,
+      const ctx1 = await chromium.launchPersistentContext(userDataDir, {
+        headless: false,
+        args: ["--headless=new", ...chromeArgs],
       });
-    }, extensionId);
-    await extPage.close();
-    await ctx1.close();
+      let [bg] = ctx1.serviceWorkers();
+      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 60_000 });
+      const extensionId = bg.url().split("/")[2];
+      const extPage = await ctx1.newPage();
+      await extPage.goto("chrome://extensions/");
+      await extPage.waitForLoadState("domcontentloaded");
+      await extPage.waitForFunction(() => !!(chrome as any).developerPrivate, { timeout: 10_000 });
+      await extPage.evaluate(async (id) => {
+        await (chrome as any).developerPrivate.updateExtensionConfiguration({
+          extensionId: id,
+          userScriptsAccess: true,
+        });
+      }, extensionId);
+      await extPage.close();
+      await ctx1.close();
 
-    // Phase 2: Relaunch with user scripts enabled
+      await use(userDataDir);
+      fs.rmSync(userDataDir, { recursive: true, force: true });
+    },
+    { scope: "worker" },
+  ],
+  context: async ({ gmApiProfileDir }, use) => {
+    // 每个测试使用从预配置 profile 拷贝出的独立目录，避免脚本/storage 状态泄漏到后续测试，
+    // 同时跳过每个测试都重新做一次的 Phase 1 权限配置。
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "pw-ext-test-"));
+    fs.cpSync(gmApiProfileDir, userDataDir, { recursive: true });
+
     const context = await chromium.launchPersistentContext(userDataDir, {
       headless: false,
       args: ["--headless=new", ...chromeArgs],

--- a/e2e/gm-api.spec.ts
+++ b/e2e/gm-api.spec.ts
@@ -17,6 +17,10 @@ const chromeArgs = [
   "--disable-gpu",
 ];
 
+// CI（GitHub Actions）跑在非 root 用户下不会自动应用 --no-sandbox，关掉沙箱能省下每次
+// launchPersistentContext 的 sandbox/fork 开销；本地开发机上仍保留沙箱隔离。
+const chromiumSandbox = !process.env.CI;
+
 type GMApiMockServer = {
   origin: string;
   cspOrigin: string;
@@ -43,6 +47,7 @@ const test = base.extend<
         headless: false,
         args: ["--headless=new", ...chromeArgs],
         timeout: 60_000,
+        chromiumSandbox,
       });
       let [bg] = ctx1.serviceWorkers();
       if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
@@ -75,6 +80,7 @@ const test = base.extend<
       headless: false,
       args: ["--headless=new", ...chromeArgs],
       timeout: 60_000,
+      chromiumSandbox,
     });
     const [sw] = context.serviceWorkers();
     if (!sw) await context.waitForEvent("serviceworker", { timeout: 14_000 });

--- a/e2e/gm-api.spec.ts
+++ b/e2e/gm-api.spec.ts
@@ -43,7 +43,7 @@ const test = base.extend<
         args: ["--headless=new", ...chromeArgs],
       });
       let [bg] = ctx1.serviceWorkers();
-      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 30_000 });
+      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
       const extensionId = bg.url().split("/")[2];
       const extPage = await ctx1.newPage();
       await extPage.goto("chrome://extensions/");
@@ -74,14 +74,14 @@ const test = base.extend<
       args: ["--headless=new", ...chromeArgs],
     });
     const [sw] = context.serviceWorkers();
-    if (!sw) await context.waitForEvent("serviceworker", { timeout: 30_000 });
+    if (!sw) await context.waitForEvent("serviceworker", { timeout: 14_000 });
     await use(context);
     await context.close();
     fs.rmSync(userDataDir, { recursive: true, force: true });
   },
   extensionId: async ({ context }, use) => {
     let [background] = context.serviceWorkers();
-    if (!background) background = await context.waitForEvent("serviceworker");
+    if (!background) background = await context.waitForEvent("serviceworker", { timeout: 14_000 });
     const extensionId = background.url().split("/")[2];
     const initPage = await context.newPage();
     await initPage.goto(`chrome-extension://${extensionId}/src/options.html`);

--- a/e2e/gm-api.spec.ts
+++ b/e2e/gm-api.spec.ts
@@ -14,6 +14,7 @@ const chromeArgs = [
   `--disable-extensions-except=${pathToExtension}`,
   `--load-extension=${pathToExtension}`,
   `--host-resolver-rules=MAP ${CSP_TARGET_HOST} ${MOCK_CONNECT_HOST},EXCLUDE localhost`,
+  "--disable-gpu",
 ];
 
 type GMApiMockServer = {
@@ -41,6 +42,7 @@ const test = base.extend<
       const ctx1 = await chromium.launchPersistentContext(userDataDir, {
         headless: false,
         args: ["--headless=new", ...chromeArgs],
+        timeout: 60_000,
       });
       let [bg] = ctx1.serviceWorkers();
       if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
@@ -72,6 +74,7 @@ const test = base.extend<
     const context = await chromium.launchPersistentContext(userDataDir, {
       headless: false,
       args: ["--headless=new", ...chromeArgs],
+      timeout: 60_000,
     });
     const [sw] = context.serviceWorkers();
     if (!sw) await context.waitForEvent("serviceworker", { timeout: 14_000 });

--- a/e2e/server-fixtures.ts
+++ b/e2e/server-fixtures.ts
@@ -57,7 +57,7 @@ export const test = base.extend<
         args: ["--headless=new", ...chromeArgs],
       });
       let [bg] = ctx1.serviceWorkers();
-      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 30_000 });
+      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
       const extensionId = bg.url().split("/")[2];
       const extPage = await ctx1.newPage();
       await extPage.goto("chrome://extensions/");
@@ -88,14 +88,14 @@ export const test = base.extend<
       args: ["--headless=new", ...chromeArgs],
     });
     const [sw] = context.serviceWorkers();
-    if (!sw) await context.waitForEvent("serviceworker", { timeout: 30_000 });
+    if (!sw) await context.waitForEvent("serviceworker", { timeout: 14_000 });
     await use(context);
     await context.close();
     fs.rmSync(userDataDir, { recursive: true, force: true });
   },
   extensionId: async ({ context }, use) => {
     let [background] = context.serviceWorkers();
-    if (!background) background = await context.waitForEvent("serviceworker");
+    if (!background) background = await context.waitForEvent("serviceworker", { timeout: 14_000 });
     const extensionId = background.url().split("/")[2];
     const initPage = await context.newPage();
     await initPage.goto(`chrome-extension://${extensionId}/src/options.html`);

--- a/e2e/server-fixtures.ts
+++ b/e2e/server-fixtures.ts
@@ -37,36 +37,52 @@ const chromeArgs = [
   hostResolverRule,
 ];
 
-export const test = base.extend<{
-  context: BrowserContext;
-  extensionId: string;
-}>({
-  // eslint-disable-next-line no-empty-pattern
-  context: async ({}, use) => {
-    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "pw-ext-net-"));
+export const test = base.extend<
+  {
+    context: BrowserContext;
+    extensionId: string;
+  },
+  { netProfileDir: string }
+>({
+  // Worker 级 fixture：启用 userScripts 权限的 Phase 1（含 chrome://extensions 导航 +
+  // developerPrivate 调用）每个 worker 只做一次，而不是每个 test 都重新做一遍。
+  // 参照 e2e/gm-api.spec.ts 已验证过的模式。
+  netProfileDir: [
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "pw-ext-net-profile-"));
 
-    // Phase 1: 启用 userScripts 权限
-    const ctx1 = await chromium.launchPersistentContext(userDataDir, {
-      headless: false,
-      args: ["--headless=new", ...chromeArgs],
-    });
-    let [bg] = ctx1.serviceWorkers();
-    if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 30_000 });
-    const extensionId = bg.url().split("/")[2];
-    const extPage = await ctx1.newPage();
-    await extPage.goto("chrome://extensions/");
-    await extPage.waitForLoadState("domcontentloaded");
-    await extPage.waitForFunction(() => !!(chrome as any).developerPrivate, { timeout: 10_000 });
-    await extPage.evaluate(async (id) => {
-      await (chrome as any).developerPrivate.updateExtensionConfiguration({
-        extensionId: id,
-        userScriptsAccess: true,
+      const ctx1 = await chromium.launchPersistentContext(userDataDir, {
+        headless: false,
+        args: ["--headless=new", ...chromeArgs],
       });
-    }, extensionId);
-    await extPage.close();
-    await ctx1.close();
+      let [bg] = ctx1.serviceWorkers();
+      if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 30_000 });
+      const extensionId = bg.url().split("/")[2];
+      const extPage = await ctx1.newPage();
+      await extPage.goto("chrome://extensions/");
+      await extPage.waitForLoadState("domcontentloaded");
+      await extPage.waitForFunction(() => !!(chrome as any).developerPrivate, { timeout: 10_000 });
+      await extPage.evaluate(async (id) => {
+        await (chrome as any).developerPrivate.updateExtensionConfiguration({
+          extensionId: id,
+          userScriptsAccess: true,
+        });
+      }, extensionId);
+      await extPage.close();
+      await ctx1.close();
 
-    // Phase 2: 重新启动，权限已持久化
+      await use(userDataDir);
+      fs.rmSync(userDataDir, { recursive: true, force: true });
+    },
+    { scope: "worker" },
+  ],
+  context: async ({ netProfileDir }, use) => {
+    // 每个测试使用从预配置 profile 拷贝出的独立目录，避免脚本/storage 状态泄漏到后续测试，
+    // 同时跳过每个测试都重新做一次的 Phase 1 权限配置。
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "pw-ext-net-test-"));
+    fs.cpSync(netProfileDir, userDataDir, { recursive: true });
+
     const context = await chromium.launchPersistentContext(userDataDir, {
       headless: false,
       args: ["--headless=new", ...chromeArgs],

--- a/e2e/server-fixtures.ts
+++ b/e2e/server-fixtures.ts
@@ -35,6 +35,7 @@ const chromeArgs = [
   `--disable-extensions-except=${pathToExtension}`,
   `--load-extension=${pathToExtension}`,
   hostResolverRule,
+  "--disable-gpu",
 ];
 
 export const test = base.extend<
@@ -55,6 +56,7 @@ export const test = base.extend<
       const ctx1 = await chromium.launchPersistentContext(userDataDir, {
         headless: false,
         args: ["--headless=new", ...chromeArgs],
+        timeout: 60_000,
       });
       let [bg] = ctx1.serviceWorkers();
       if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
@@ -86,6 +88,7 @@ export const test = base.extend<
     const context = await chromium.launchPersistentContext(userDataDir, {
       headless: false,
       args: ["--headless=new", ...chromeArgs],
+      timeout: 60_000,
     });
     const [sw] = context.serviceWorkers();
     if (!sw) await context.waitForEvent("serviceworker", { timeout: 14_000 });

--- a/e2e/server-fixtures.ts
+++ b/e2e/server-fixtures.ts
@@ -38,6 +38,10 @@ const chromeArgs = [
   "--disable-gpu",
 ];
 
+// CI（GitHub Actions）跑在非 root 用户下不会自动应用 --no-sandbox，关掉沙箱能省下每次
+// launchPersistentContext 的 sandbox/fork 开销；本地开发机上仍保留沙箱隔离。
+const chromiumSandbox = !process.env.CI;
+
 export const test = base.extend<
   {
     context: BrowserContext;
@@ -57,6 +61,7 @@ export const test = base.extend<
         headless: false,
         args: ["--headless=new", ...chromeArgs],
         timeout: 60_000,
+        chromiumSandbox,
       });
       let [bg] = ctx1.serviceWorkers();
       if (!bg) bg = await ctx1.waitForEvent("serviceworker", { timeout: 14_000 });
@@ -89,6 +94,7 @@ export const test = base.extend<
       headless: false,
       args: ["--headless=new", ...chromeArgs],
       timeout: 60_000,
+      chromiumSandbox,
     });
     const [sw] = context.serviceWorkers();
     if (!sw) await context.waitForEvent("serviceworker", { timeout: 14_000 });


### PR DESCRIPTION
## Checklist / 检查清单

* [x] Fixes mentioned issues / 修复已提及的问题
* [x] Code reviewed by human / 代码通过人工检查
* [x] Changes tested / 已完成测试

## 背景

E2E 测试在 CI 中存在较高的 Chromium 启动开销。

部分测试需要通过两阶段流程启用 User Scripts 权限：

1. Phase 1：启动 Chromium，通过 `chrome://extensions/` 和 `developerPrivate` 启用权限；
2. Phase 2：重新启动 Chromium，使用已经持久化权限的 Profile 执行测试。

此前相关 fixture 会为每个测试重复执行 Phase 1 和 Phase 2。多个 Playwright worker 并行运行时，大量 Chromium 进程会同时争抢 CPU 和 I/O，导致 Service Worker 初始化变慢，并可能出现与功能无关的超时。

此外，所有 E2E 测试原本集中在单个 GitHub Actions job 中执行，未充分利用独立 runner 进行并行分片。

## 本次改动

### 1. 将 E2E CI 拆分为 4 个 shard

GitHub Actions 的 E2E job 现在通过 matrix 启动 4 个独立 shard：

```text
1/4
2/4
3/4
4/4
```

每个 shard 使用 Playwright 的 `--shard` 参数执行对应测试，并且：

* 设置 `fail-fast: false`，避免单个 shard 失败后取消其他 shard；
* 为每个 shard 使用独立的测试产物名称；
* 输出 runner CPU 数量，便于分析 CI 执行环境。

### 2. 每个 worker 只配置一次 User Scripts 权限

以下两阶段 E2E fixture 改为使用 worker 级预配置 Profile：

* `e2e/fixtures.ts`
* `e2e/gm-api.spec.ts`
* `e2e/server-fixtures.ts`

每个 Playwright worker 现在会：

1. 创建独立的临时 Profile；
2. 启动 Phase 1 Chromium；
3. 启用 User Scripts 权限；
4. 完整关闭 Chromium，确保配置写入磁盘；
5. 在该 worker 生命周期内保留预配置 Profile。

每个测试仍会从预配置 Profile 复制一份独立目录，并使用副本执行 Phase 2。

这样既可以复用权限配置结果，也可以避免用户脚本、Extension Storage、缓存和页面状态在测试之间泄漏。

假设一个 worker 执行 `N` 个相关测试：

```text
改动前：2 × N 次 Chromium 启动
改动后：N + 1 次 Chromium 启动
```

### 3. 优化 CI 中的 Chromium 启动配置

相关 E2E fixture 统一加入以下启动优化：

* 添加 `--disable-gpu`；
* 在 CI 环境关闭 Chromium sandbox，本地运行仍保留 sandbox；
* 将 `launchPersistentContext` 的启动 timeout 显式设置为 60 秒；
* 将 Service Worker 等待 timeout 统一调整为 14 秒。

这些配置同时应用于普通 fixture、User Scripts fixture、GM API、网络测试和 Agent 测试所使用的 Chromium Context。

### 4. 分层清理临时 Profile

临时目录按照 fixture 生命周期分别清理：

* test 级 Profile 副本在测试完成、Chromium 关闭后删除；
* worker 级预配置 Profile 在该 worker 的全部测试结束后删除。

不同 worker 不会共享 Profile，避免目录锁竞争和并发写入。

## 预期效果

* 减少两阶段 fixture 中重复的 Chromium 启动；
* 通过 4 个独立 runner 并行执行 E2E 测试；
* 降低单个 runner 上的 CPU 和 I/O 竞争；
* 缩短整体 E2E CI 执行时间；
* 减少由 Service Worker 启动延迟导致的偶发超时；
* 保持测试之间的 Profile 和存储状态隔离。

当前一次 CI 执行结果已进入 2 分钟以内；后续运行仍需继续观察稳定性。

## 影响范围

本 PR 仅修改 E2E 测试基础设施和 GitHub Actions 配置。

不会修改：

* 扩展生产代码；
* E2E 测试用例和断言；
* User Scripts 权限的配置方式；
* fixture 对外提供的 `context` 和 `extensionId` 接口。

## 建议审查重点

* 4-way sharding 是否覆盖全部 E2E 测试且不存在遗漏；
* worker 级 fixture 的生命周期是否符合 Playwright 约定；
* Profile 复制后是否可靠继承 User Scripts 权限；
* 每个测试是否仍保持脚本和 Storage 隔离；
* CI-only sandbox 配置是否符合项目安全要求；
* 14 秒 Service Worker timeout 是否适用于所有 CI runner；
* test 级和 worker 级临时目录是否都能在异常情况下正确清理。
