### PR TITLE
fix(dep): [DEP0040] DeprecationWarning: The `punycode` module is deprecated.

### DIFF
--- a/patches/uri-js@4.4.1.patch
+++ b/patches/uri-js@4.4.1.patch
@@ -1,0 +1,24 @@
+diff --git a/dist/esnext/schemes/mailto.js b/dist/esnext/schemes/mailto.js
+index 2553713cde8c8b21fa0d8d5c746824fc7fcdf9c0..df0ecfd7b135d06caa44e0f539ddb627613034af 100755
+--- a/dist/esnext/schemes/mailto.js
++++ b/dist/esnext/schemes/mailto.js
+@@ -1,5 +1,5 @@
+ import { pctEncChar, pctDecChars, unescapeComponent } from "../uri";
+-import punycode from "punycode";
++import punycode from "punycode/";
+ import { merge, subexp, toUpperCase, toArray } from "../util";
+ const O = {};
+ const isIRI = true;
+diff --git a/dist/esnext/uri.js b/dist/esnext/uri.js
+index 659ce2651cea1d928546bbc296f5f0cb97c07b85..1806aa5b313d27b60bb65dba6e6305e49bf203a8 100755
+--- a/dist/esnext/uri.js
++++ b/dist/esnext/uri.js
+@@ -34,7 +34,7 @@
+  */
+ import URI_PROTOCOL from "./regexps-uri";
+ import IRI_PROTOCOL from "./regexps-iri";
+-import punycode from "punycode";
++import punycode from "punycode/";
+ import { toUpperCase, typeOf, assign } from "./util";
+ export const SCHEMES = {};
+ export function pctEncChar(chr) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   happy-dom:
     hash: 86b1a6f00877afcb6d67373ff776e646c72e69fa38fa94f6bde86e7ae9b300da
     path: patches/happy-dom.patch
+  uri-js@4.4.1:
+    hash: afaa23653b7f5bb89d7e0e8dd00b95bf4ab5d556847cf04b92226540e4d67aa4
+    path: patches/uri-js@4.4.1.patch
 
 importers:
 
@@ -6754,7 +6757,7 @@ snapshots:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
-      uri-js: 4.4.1
+      uri-js: 4.4.1(patch_hash=afaa23653b7f5bb89d7e0e8dd00b95bf4ab5d556847cf04b92226540e4d67aa4)
 
   ajv@8.18.0:
     dependencies:
@@ -9722,7 +9725,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  uri-js@4.4.1:
+  uri-js@4.4.1(patch_hash=afaa23653b7f5bb89d7e0e8dd00b95bf4ab5d556847cf04b92226540e4d67aa4):
     dependencies:
       punycode: 2.3.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 minimumReleaseAge: 10080
 patchedDependencies:
   happy-dom: patches/happy-dom.patch
+  uri-js@4.4.1: patches/uri-js@4.4.1.patch


### PR DESCRIPTION
ESLint → @eslint/eslintrc@3.3.1 → ajv@6.14.0 → uri-js@4.4.1 → punycode@2.3.1

---

uri-js 没人维护了
处理 punycode 引用问题的 PR https://github.com/garycourt/uri-js/pull/95 都好几年了，没有人合并。

只好手动处理一下

---

## Example

https://github.com/scriptscat/scriptcat/actions/runs/29186140760/job/86632458745

<img width="1476" height="413" alt="Screenshot 2026-07-12 at 18 14 18" src="https://github.com/user-attachments/assets/b23a46fd-6ff3-43a1-b303-5b9ca8f314e4" />


```
(node:2101) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```