### PR TITLE
🐛 修复 window.focus 窗口聚焦并加强 windowId 校验

### DIFF
--- a/src/app/service/agent/core/tools/tab_tools.ts
+++ b/src/app/service/agent/core/tools/tab_tools.ts
@@ -310,7 +310,7 @@ export function createTabTools(deps: {
       const tab = await chrome.tabs.update(tabId, { active: true });
       if (!tab) throw new Error(`Tab ${tabId} not found`);
       // 也激活对应窗口
-      if (tab.windowId) {
+      if (tab.windowId && Number.isFinite(tab.windowId) && tab.windowId >= 0) {
         await chrome.windows.update(tab.windowId, { focused: true });
       }
       return JSON.stringify({

--- a/src/app/service/agent/service_worker/dom.ts
+++ b/src/app/service/agent/service_worker/dom.ts
@@ -150,6 +150,9 @@ export class AgentDomService {
   private async captureVisibleTab(tabId: number, options?: ScreenshotOptions): Promise<string> {
     const quality = options?.quality ?? 80;
     const tab = await chrome.tabs.get(tabId);
+    if (!tab || !Number.isFinite(tab.windowId) || tab.windowId < 0) {
+      throw new Error(`No windowId for tab ${tabId}`);
+    }
     return chrome.tabs.captureVisibleTab(tab.windowId, {
       format: "jpeg",
       quality,

--- a/src/app/service/service_worker/gm_api/gm_api.test.ts
+++ b/src/app/service/service_worker/gm_api/gm_api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { type IGetSender } from "@Packages/message/server";
 import { type ExtMessageSender } from "@Packages/message/types";
 import GMApi, { ConnectMatch, getConnectMatched, getExtensionSiteAccessOriginPattern } from "./gm_api";
@@ -116,6 +116,27 @@ describe.concurrent("GM API 注册完整性", () => {
     for (const name of agentApis) {
       expect(PermissionVerifyApiGet(name), `${name} 应已注册`).toBeDefined();
     }
+  });
+});
+
+describe("window.focus", () => {
+  it("应同时激活标签页并将其所在窗口置于前台", async () => {
+    const tabsUpdate = vi.fn().mockResolvedValue(undefined);
+    const windowsUpdate = vi.fn().mockResolvedValue(undefined);
+    const originalChrome = globalThis.chrome;
+    vi.stubGlobal("chrome", {
+      ...originalChrome,
+      tabs: { ...originalChrome.tabs, update: tabsUpdate },
+      windows: { ...originalChrome.windows, update: windowsUpdate },
+    });
+    const sender = makeSender();
+    sender.getSender = () => ({ tab: { id: 42, windowId: 7 } as chrome.tabs.Tab });
+
+    await GMApi.prototype["window.focus"]({} as GMApiRequest<void>, sender);
+
+    expect(tabsUpdate).toHaveBeenCalledWith(42, { active: true });
+    expect(windowsUpdate).toHaveBeenCalledWith(7, { focused: true });
+    vi.stubGlobal("chrome", originalChrome);
   });
 });
 

--- a/src/app/service/service_worker/gm_api/gm_api.ts
+++ b/src/app/service/service_worker/gm_api/gm_api.ts
@@ -1503,7 +1503,7 @@ export default class GMApi {
       await chrome.tabs.update(tabId as number, {
         active: true,
       });
-      if (tab && Number.isFinite(tab.windowId)) {
+      if (tab && Number.isFinite(tab.windowId) && tab.windowId >= 0) {
         await chrome.windows.update(tab.windowId as number, {
           focused: true,
         });

--- a/src/app/service/service_worker/gm_api/gm_api.ts
+++ b/src/app/service/service_worker/gm_api/gm_api.ts
@@ -1497,11 +1497,17 @@ export default class GMApi {
 
   @PermissionVerify.API()
   async ["window.focus"](request: GMApiRequest<void>, sender: IGetSender) {
-    const tabId = sender.getSender()?.tab?.id;
+    const tab = sender.getSender()?.tab;
+    const tabId = tab?.id;
     if (Number.isFinite(tabId)) {
       await chrome.tabs.update(tabId as number, {
         active: true,
       });
+      if (tab && Number.isFinite(tab.windowId)) {
+        await chrome.windows.update(tab.windowId as number, {
+          focused: true,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Checklist / 检查清单

* [x] Fixes API Compatibility Issue (GM/TM/VM)
* [x] Code reviewed by human / 代码通过人工检查
* [x] Changes tested / 已完成测试

## 背景

Tampermonkey 的 `window.focus()` 会激活脚本所在标签页，并将其所在的浏览器窗口置于前台。ScriptCat 原实现只激活标签页；当目标窗口处于后台时，浏览器窗口不会被带到前台，因此与 Tampermonkey 的行为不兼容。

另外，部分标签页相关流程可能取得无效的 `windowId`（例如负数窗口 ID）。若直接传给窗口聚焦或截图 API，可能触发异常或产生不明确的行为。

Fixes #1571

## 本次改动

### `window.focus()` GM API

* 保留 `chrome.tabs.update(tabId, { active: true })`，激活脚本所在标签页；
* 当 `windowId` 为有限且非负的有效值时，调用 `chrome.windows.update(windowId, { focused: true })`，将标签页所在窗口置于前台；
* 无效 `windowId` 不再传入 `chrome.windows.update()`。

### Agent 标签页与截图流程

* `tab_tools.ts`：聚焦标签页所在窗口前，增加有限且非负的 `windowId` 校验；
* `dom.ts`：调用 `chrome.tabs.captureVisibleTab()` 前校验标签页和 `windowId`，无效时抛出明确错误。

### 测试

* 新增 `window.focus()` 回归测试，验证标签页激活和浏览器窗口聚焦都会执行。

## 根因

原实现只调用 `chrome.tabs.update(tabId, { active: true })`。激活标签页不会自动将其所在的后台浏览器窗口置于前台，因此缺少窗口级聚焦调用。

同时，仅依赖 truthy 或有限数值判断不足以排除负数窗口 ID，需要统一要求 `windowId` 为有限且非负的值。

## 验证记录

* `pnpm exec vitest run src/app/service/service_worker/gm_api/gm_api.test.ts --reporter=default` — 23 tests passed
* `pnpm run typecheck` — passed
* `pnpm exec prettier --check src/app/service/service_worker/gm_api/gm_api.ts src/app/service/service_worker/gm_api/gm_api.test.ts` — passed
* `pnpm exec eslint src/app/service/service_worker/gm_api/gm_api.ts src/app/service/service_worker/gm_api/gm_api.test.ts` — passed
* `git diff --check` — passed

## Screenshots / 截图

Not applicable.