### PR TITLE
👷 对比分片与未分片 CI 耗时

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,6 +80,32 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
+  benchmark-test-unsharded:
+    runs-on: ubuntu-latest
+    name: Benchmark test unsharded
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+
+      - name: Use Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Setup pnpm
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile
+
+      - name: Run tests without sharding
+        run: >
+          pnpm exec vitest run
+          --coverage
+          --silent
+          --reporter=blob
+
   tests:
     runs-on: ubuntu-latest
     name: Run tests
@@ -178,3 +204,44 @@ jobs:
             test-results/
             playwright-report/
           retention-days: 14
+
+  benchmark-e2e-unsharded:
+    runs-on: ubuntu-latest
+    name: Benchmark E2E unsharded
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
+
+      - name: Use Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Setup pnpm
+        run: corepack enable
+
+      - name: Show runner CPU count
+        run: nproc
+
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-
+
+      - name: Install Playwright Chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm test:e2e:install
+
+      - name: Build extension
+        run: pnpm build
+
+      - name: Run E2E tests without sharding
+        run: pnpm exec playwright test


### PR DESCRIPTION
## 目的

为 #1532 与 #1569 的分片优化提供同一提交、同一 GitHub Actions runner 规格下的 A/B 数据。

## 方法

- 保留现有 Vitest 2-way shard 与 Playwright 4-way shard；
- 新增未分片 Vitest job，使用相同的 coverage、silent、blob reporter 参数；
- 新增未分片 Playwright job，使用相同的依赖安装、浏览器缓存、构建和测试参数；
- 连续执行 3 次同一 workflow，比较 job 首尾墙钟时间；
- 只用于测量，不修改生产代码或测试断言。

## 结果（3 次运行，中位数）

| 对象 | 未分片关键路径 | 分片关键路径 | 墙钟变化 | 未分片累计 runner | 分片累计 runner | runner 变化 |
|---|---:|---:|---:|---:|---:|---:|
| Vitest + coverage 最终汇总 | 117s | 106s | -9.4% | 117s | 160s | +36.8% |
| Playwright E2E | 219s | 93s | -57.5% | 219s | 331s | +51.1% |

原始三轮数据：

- Vitest 未分片：97s / 120s / 117s；2 shards + merge 关键路径：103s / 107s / 106s。
- Vitest 分片累计 runner：158s / 160s / 163s。
- E2E 未分片：219s / 202s / 221s；4 shards 关键路径：93s / 90s / 94s。
- E2E 分片累计 runner：331s / 338s / 329s。

结论：

- #1532 的 2-way Vitest 分片只小幅缩短最终 coverage 可用时间；如果只看两个测试 shard 自身，约 71s，但 coverage merge job 把最终关键路径拉回约 106s。代价是累计 runner 时间增加约 37%。
- #1569 的 4-way E2E 分片明显有效，关键路径缩短约 58%；代价是累计 runner 时间增加约 51%。
