### PR TITLE
🐛 修复开发环境 debug 日志持久化

### DIFF
--- a/src/app/logger/core.test.ts
+++ b/src/app/logger/core.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import LoggerCore, { type Writer } from "./core";
+
+const createWriter = () => ({ write: vi.fn() }) satisfies Writer;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("LoggerCore 持久化日志级别", () => {
+  it("开发环境默认应持久化 debug 但不持久化 trace", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const writer = createWriter();
+    const logger = new LoggerCore({ writer, consoleLevel: "none", labels: {} }).logger();
+
+    logger.trace("trace message");
+    logger.debug("debug message");
+
+    expect(writer.write).toHaveBeenCalledOnce();
+    expect(writer.write).toHaveBeenCalledWith("debug", "debug message", {});
+  });
+
+  it("生产环境默认不应持久化 debug 但应持久化 info", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const writer = createWriter();
+    const logger = new LoggerCore({ writer, consoleLevel: "none", labels: {} }).logger();
+
+    logger.debug("debug message");
+    logger.info("info message");
+
+    expect(writer.write).toHaveBeenCalledOnce();
+    expect(writer.write).toHaveBeenCalledWith("info", "info message", {});
+  });
+
+  it("显式级别应覆盖环境默认值", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const developmentWriter = createWriter();
+    const developmentLogger = new LoggerCore({
+      writer: developmentWriter,
+      level: "info",
+      consoleLevel: "none",
+      labels: {},
+    }).logger();
+
+    developmentLogger.debug("debug message");
+    developmentLogger.info("info message");
+
+    vi.stubEnv("NODE_ENV", "production");
+    const productionWriter = createWriter();
+    const productionLogger = new LoggerCore({
+      writer: productionWriter,
+      level: "debug",
+      consoleLevel: "none",
+      labels: {},
+    }).logger();
+
+    productionLogger.debug("debug message");
+
+    expect(developmentWriter.write).toHaveBeenCalledOnce();
+    expect(developmentWriter.write).toHaveBeenCalledWith("info", "info message", {});
+    expect(productionWriter.write).toHaveBeenCalledOnce();
+    expect(productionWriter.write).toHaveBeenCalledWith("debug", "debug message", {});
+  });
+});

--- a/src/app/logger/core.ts
+++ b/src/app/logger/core.ts
@@ -30,7 +30,7 @@ export default class LoggerCore {
   writer: Writer;
 
   // 日志级别, 会记录在日志文件中
-  level: LogLevel = "info";
+  level: LogLevel;
 
   // 打印在console的等级, 会在控制台输出
   consoleLevel: LogLevel = "warn";
@@ -39,7 +39,7 @@ export default class LoggerCore {
 
   constructor(config: { level?: LogLevel; consoleLevel?: LogLevel; writer: Writer; labels: LogLabel }) {
     this.writer = config.writer;
-    this.level = config.level || this.level;
+    this.level = config.level ?? (process.env.NODE_ENV === "development" ? "debug" : "info");
     this.labels = config.labels || {};
     // 获取日志debug等级, 如果是开发环境, 则默认为debug
     if (config.consoleLevel !== undefined) {

--- a/src/app/logger/core.ts
+++ b/src/app/logger/core.ts
@@ -33,22 +33,16 @@ export default class LoggerCore {
   level: LogLevel;
 
   // 打印在console的等级, 会在控制台输出
-  consoleLevel: LogLevel = "warn";
+  consoleLevel: LogLevel;
 
   labels: LogLabel;
 
   constructor(config: { level?: LogLevel; consoleLevel?: LogLevel; writer: Writer; labels: LogLabel }) {
+    const isDevelopment = process.env.NODE_ENV === "development";
     this.writer = config.writer;
-    this.level = config.level ?? (process.env.NODE_ENV === "development" ? "debug" : "info");
-    this.labels = config.labels || {};
-    // 获取日志debug等级, 如果是开发环境, 则默认为debug
-    if (config.consoleLevel !== undefined) {
-      this.consoleLevel = config.consoleLevel;
-    } else {
-      if (process.env.NODE_ENV === "development") {
-        this.consoleLevel = "debug";
-      }
-    }
+    this.level = config.level ?? (isDevelopment ? "debug" : "info");
+    this.consoleLevel = config.consoleLevel ?? (isDevelopment ? "debug" : "warn");
+    this.labels = config.labels;
     if (!LoggerCore.instance) {
       LoggerCore.instance = this;
     }

--- a/src/app/logger/message_writer.test.ts
+++ b/src/app/logger/message_writer.test.ts
@@ -1,0 +1,28 @@
+import EventEmitter from "eventemitter3";
+import { describe, expect, it, vi } from "vitest";
+import { MockMessage } from "@Packages/message/mock_message";
+import { SenderRuntime, Server } from "@Packages/message/server";
+import MessageWriter from "./message_writer";
+
+describe("MessageWriter 页面日志路由", () => {
+  it("页面调用方应将日志发送到 service worker 的 logger 处理器", () => {
+    const message = new MockMessage(new EventEmitter());
+    const handler = vi.fn();
+    const server = new Server("serviceWorker", message, false);
+    server.on("logger", handler);
+    const writer = MessageWriter.serviceWorker(message);
+
+    writer.write("info", "page message", { env: "options" });
+
+    expect(handler).toHaveBeenCalledWith(
+      {
+        id: 0,
+        level: "info",
+        message: "page message",
+        label: { env: "options" },
+        createtime: expect.any(Number),
+      },
+      expect.any(SenderRuntime)
+    );
+  });
+});

--- a/src/app/logger/message_writer.ts
+++ b/src/app/logger/message_writer.ts
@@ -1,12 +1,18 @@
 import type { LogLabel, LogLevel, Writer } from "./core";
 import type { MessageSend } from "@Packages/message/types";
 
+type LoggerAction = `${"serviceWorker" | "scripting" | "offscreen"}/logger`;
+
 // 通过通讯机制写入日志
 export default class MessageWriter implements Writer {
   constructor(
     private msgSender: MessageSend,
-    private action: string = "logger"
+    private action: LoggerAction
   ) {}
+
+  static serviceWorker(msgSender: MessageSend): MessageWriter {
+    return new MessageWriter(msgSender, "serviceWorker/logger");
+  }
 
   write(level: LogLevel, message: string, label: LogLabel): void {
     this.msgSender.sendMessage({

--- a/src/pages/batchupdate/main.tsx
+++ b/src/pages/batchupdate/main.tsx
@@ -11,7 +11,7 @@ import "@App/index.css";
 
 // 初始化日志组件
 const loggerCore = new LoggerCore({
-  writer: new MessageWriter(message),
+  writer: MessageWriter.serviceWorker(message),
   labels: { env: "batchupdate" },
 });
 

--- a/src/pages/confirm/main.tsx
+++ b/src/pages/confirm/main.tsx
@@ -10,7 +10,7 @@ import "@App/index.css";
 
 // 初始化日志组件
 const loggerCore = new LoggerCore({
-  writer: new MessageWriter(message),
+  writer: MessageWriter.serviceWorker(message),
   labels: { env: "confirm" },
 });
 

--- a/src/pages/import/main.tsx
+++ b/src/pages/import/main.tsx
@@ -11,7 +11,7 @@ import "@App/index.css";
 
 // 初始化日志组件
 const loggerCore = new LoggerCore({
-  writer: new MessageWriter(message),
+  writer: MessageWriter.serviceWorker(message),
   labels: { env: "import" },
 });
 

--- a/src/pages/install/main.tsx
+++ b/src/pages/install/main.tsx
@@ -10,7 +10,7 @@ import "@App/index.css";
 
 // 初始化日志组件
 const loggerCore = new LoggerCore({
-  writer: new MessageWriter(message),
+  writer: MessageWriter.serviceWorker(message),
   labels: { env: "install" },
 });
 

--- a/src/pages/options/main.tsx
+++ b/src/pages/options/main.tsx
@@ -11,7 +11,7 @@ import "@App/index.css";
 
 // 初始化日志组件
 const loggerCore = new LoggerCore({
-  writer: new MessageWriter(message),
+  writer: MessageWriter.serviceWorker(message),
   labels: { env: "options" },
 });
 

--- a/src/pages/popup/main.tsx
+++ b/src/pages/popup/main.tsx
@@ -13,7 +13,7 @@ preloadPopupData();
 
 // 初始化日志组件
 const loggerCore = new LoggerCore({
-  writer: new MessageWriter(message),
+  writer: MessageWriter.serviceWorker(message),
   labels: { env: "popup" },
 });
 


### PR DESCRIPTION
## 修改内容

- 开发构建下将 LoggerCore 默认持久化级别设为 `debug`，生产及其他环境仍为 `info`
- 保留显式 `config.level` 的最高优先级，默认仍不持久化 `trace`
- 修复 React 扩展页面日志缺少 `serviceWorker/` 路由前缀、导致消息静默丢失的问题
- 新增日志级别和页面日志路由回归测试

## 验证

- `pnpm exec vitest run --no-coverage --reporter=verbose src/app/logger/core.test.ts src/app/logger/message_writer.test.ts src/app/service/service_worker/log.test.ts`（3 files / 10 tests passed）
- `pnpm run lint`（Prettier、TypeScript、ESLint 通过）
- `git diff --check`

Fixes #1560