### PR TITLE
🐛 修复展开数量限制未被 Popup 使用的问题

### DIFF
--- a/src/pages/options/routes/Setting/sections/InterfaceSection.tsx
+++ b/src/pages/options/routes/Setting/sections/InterfaceSection.tsx
@@ -67,6 +67,7 @@ export function InterfaceSection({ register }: { register: (id: string) => (el: 
         <Input
           type="number"
           className="w-20"
+          min={0}
           value={(expandNum as number) ?? 0}
           onChange={(e) => setExpandNum(Number(e.target.value))}
         />

--- a/src/pages/popup/usePopupData.ts
+++ b/src/pages/popup/usePopupData.ts
@@ -75,8 +75,6 @@ function filterScripts(list: ScriptMenu[], query: string): ScriptMenu[] {
   return list.filter((s) => s.name.toLowerCase().includes(lower));
 }
 
-const EXPAND_LIMIT = 5;
-
 // ========== Hook ==========
 
 export function usePopupData() {
@@ -361,18 +359,18 @@ export function usePopupData() {
   const filteredScriptList = filterScripts(scriptList, searchQuery);
   const filteredBackScriptList = filterScripts(backScriptList, searchQuery);
   const totalScriptCount = scriptList.length + backScriptList.length;
-  const showSearch = totalScriptCount > EXPAND_LIMIT;
+  const showSearch = totalScriptCount > menuExpandNum;
 
-  const displayScriptList = expandedSections.current ? filteredScriptList : filteredScriptList.slice(0, EXPAND_LIMIT);
+  const displayScriptList = expandedSections.current ? filteredScriptList : filteredScriptList.slice(0, menuExpandNum);
   const remainingCurrentCount = filteredScriptList.length - displayScriptList.length;
   // 超过展示上限即可展开/收起：折叠时显示「显示更多」，展开时显示「收起」
-  const canExpandCurrent = filteredScriptList.length > EXPAND_LIMIT;
+  const canExpandCurrent = filteredScriptList.length > menuExpandNum;
 
   const displayBackScriptList = expandedSections.background
     ? filteredBackScriptList
-    : filteredBackScriptList.slice(0, EXPAND_LIMIT);
+    : filteredBackScriptList.slice(0, menuExpandNum);
   const remainingBackCount = filteredBackScriptList.length - displayBackScriptList.length;
-  const canExpandBack = filteredBackScriptList.length > EXPAND_LIMIT;
+  const canExpandBack = filteredBackScriptList.length > menuExpandNum;
 
   const backRunningCount = backScriptList.filter((s) => s.runStatus === SCRIPT_RUN_STATUS_RUNNING).length;
   const enabledScriptCount = scriptList.filter((s) => s.enable).length;


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

修复展开数量限制无论在设置中设置多少，实际都为 5 的问题。

Fix #1558

## Screenshots / 截图

<img width="683" height="760" alt="image" src="https://github.com/user-attachments/assets/9a9c8ecc-82b8-403b-b804-b4d54409a4b9" />