### PR TITLE
🐛 修复日志定时清理并统一后台业务日志记录

### DIFF
--- a/src/app/service/service_worker/gm_api/gm_api.ts
+++ b/src/app/service/service_worker/gm_api/gm_api.ts
@@ -881,7 +881,7 @@ export default class GMApi {
       try {
         hasOriginPermission = await chrome.permissions.contains({ origins: [originPattern] });
       } catch (e) {
-        console.warn(e);
+        this.logger.warn("check extension origin permission failed", { originPattern }, Logger.E(e));
       }
     }
     const extensionSiteAccessOrigins = hasOriginPermission ? undefined : [originPattern];

--- a/src/app/service/service_worker/index.ts
+++ b/src/app/service/service_worker/index.ts
@@ -25,9 +25,13 @@ import { InfoNotification, shouldAutoOpenChangelog } from "./utils";
 import { AgentService } from "@App/app/service/agent/service_worker/agent";
 import { extensionEnv, getExtensionUserAgentData } from "../extension/extension_env";
 import { cleanupStaleTempStorageEntries } from "./temp";
+import RuntimeLogger from "@App/app/logger/logger";
+import LoggerCore from "@App/app/logger/core";
 
 // service worker的管理器
 export default class ServiceWorkerManager {
+  private serviceLogger = LoggerCore.logger().with({ service: "service_worker" });
+
   constructor(
     private api: Server,
     private mq: IMessageQueue,
@@ -105,7 +109,7 @@ export default class ServiceWorkerManager {
     synchronize.init();
     const subscribe = new SubscribeService(this.api.group("subscribe"), this.mq, script);
     subscribe.init();
-    const log = new LogService(this.api.group("log"));
+    const log = new LogService(this.api.group("log"), systemConfig);
     log.init();
     const system = new SystemService(
       systemConfig,
@@ -143,9 +147,9 @@ export default class ServiceWorkerManager {
               const isRead = items.notice !== data.notice ? false : items.isRead;
               systemConfig.setCheckUpdate({ ...data, isRead: isRead });
             })
-            .catch((e) => console.error("regularExtensionUpdateCheck: Check Error", e));
+            .catch((e) => this.serviceLogger.error("read extension update config failed", RuntimeLogger.E(e)));
         })
-        .catch((e) => console.error("regularExtensionUpdateCheck: Network Error", e));
+        .catch((e) => this.serviceLogger.error("check extension update failed", RuntimeLogger.E(e)));
     };
 
     this.mq.subscribe<any>("msgUpdatePageOpened", () => {
@@ -189,6 +193,11 @@ export default class ServiceWorkerManager {
           break;
         case "cleanupTrash":
           script.cleanupExpiredTrash();
+          break;
+        case "cleanupLogs":
+          log
+            .cleanupExpiredLogs()
+            .catch((e) => this.serviceLogger.error("cleanup expired logs failed", RuntimeLogger.E(e)));
           break;
       }
     });
@@ -269,6 +278,23 @@ export default class ServiceWorkerManager {
       }
     });
 
+    // 定期清理超过保留天数的运行日志。先 get 再 create，避免 SW 冷启动重置倒计时。
+    chrome.alarms.get("cleanupLogs", (alarm) => {
+      const lastError = chrome.runtime.lastError;
+      if (lastError) {
+        console.error("chrome.runtime.lastError in chrome.alarms.get:", lastError);
+      }
+      if (!alarm) {
+        chrome.alarms.create("cleanupLogs", { delayInMinutes: 1, periodInMinutes: 12 * 60 }, () => {
+          const lastError = chrome.runtime.lastError;
+          if (lastError) {
+            console.error("chrome.runtime.lastError in chrome.alarms.create:", lastError);
+            console.error("Chrome alarm is unable to create. Please check whether limit is reached.");
+          }
+        });
+      }
+    });
+
     // 一些只需启动时运行一次的任务
     cacheInstance.getOrSet("extension_initialized", () => {
       // 启动一次云同步
@@ -312,9 +338,7 @@ export default class ServiceWorkerManager {
                     windowId: !tab ? undefined : tab.windowId,
                   });
                 })
-                .catch((e) => {
-                  console.error(e);
-                });
+                .catch((e) => this.serviceLogger.error("open extension changelog failed", { url }, RuntimeLogger.E(e)));
             }
           }
         });

--- a/src/app/service/service_worker/log.test.ts
+++ b/src/app/service/service_worker/log.test.ts
@@ -3,6 +3,7 @@ import EventEmitter from "eventemitter3";
 import { Server, type Group } from "@Packages/message/server";
 import { MockMessage } from "@Packages/message/mock_message";
 import type { LoggerDAO } from "@App/app/repo/logger";
+import type { SystemConfig } from "@App/pkg/config/config";
 import { LogService } from "./log";
 import { LogClient } from "./client";
 
@@ -15,8 +16,15 @@ function fakeDAO(overrides: Partial<LoggerDAO> = {}) {
     queryLogs: vi.fn(() => Promise.resolve([])),
     delete: vi.fn(() => Promise.resolve(1)),
     clear: vi.fn(() => Promise.resolve()),
+    deleteBefore: vi.fn(() => Promise.resolve(0)),
     ...overrides,
   } as unknown as LoggerDAO;
+}
+
+function fakeSystemConfig(days: number) {
+  return {
+    getLogCleanCycle: vi.fn(() => Promise.resolve(days)),
+  } as unknown as SystemConfig;
 }
 
 const fakeGroup = () => ({ on: vi.fn() }) as unknown as Group;
@@ -25,7 +33,7 @@ describe("日志服务 LogService", () => {
   it("getLogs 按时间范围委托 DAO 查询", async () => {
     const sample = [{ id: 1, level: "info", message: "x", label: {}, createtime: 5 }];
     const dao = fakeDAO({ queryLogs: vi.fn(() => Promise.resolve(sample)) as LoggerDAO["queryLogs"] });
-    const svc = new LogService(fakeGroup(), dao);
+    const svc = new LogService(fakeGroup(), fakeSystemConfig(7), dao);
     const res = await svc.getLogs({ start: 10, end: 20 });
     expect(dao.queryLogs).toHaveBeenCalledWith(10, 20);
     expect(res).toBe(sample);
@@ -33,7 +41,7 @@ describe("日志服务 LogService", () => {
 
   it("deleteLogs 逐个按 id 删除", async () => {
     const dao = fakeDAO();
-    const svc = new LogService(fakeGroup(), dao);
+    const svc = new LogService(fakeGroup(), fakeSystemConfig(7), dao);
     await svc.deleteLogs([1, 2, 3]);
     expect(dao.delete).toHaveBeenCalledTimes(3);
     expect(dao.delete).toHaveBeenCalledWith(1);
@@ -42,14 +50,33 @@ describe("日志服务 LogService", () => {
 
   it("clearLogs 清空 DAO", async () => {
     const dao = fakeDAO();
-    const svc = new LogService(fakeGroup(), dao);
+    const svc = new LogService(fakeGroup(), fakeSystemConfig(7), dao);
     await svc.clearLogs();
     expect(dao.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("cleanupExpiredLogs 按配置删除保留天数之前的日志", async () => {
+    const dao = fakeDAO();
+    const systemConfig = fakeSystemConfig(7);
+    const svc = new LogService(fakeGroup(), systemConfig, dao);
+
+    await svc.cleanupExpiredLogs(1_725_811_200_000);
+
+    expect(dao.deleteBefore).toHaveBeenCalledWith(1_725_206_400_000);
+  });
+
+  it("cleanupExpiredLogs 在保留天数为 0 时不删除日志", async () => {
+    const dao = fakeDAO();
+    const svc = new LogService(fakeGroup(), fakeSystemConfig(0), dao);
+
+    await svc.cleanupExpiredLogs(1_725_811_200_000);
+
+    expect(dao.deleteBefore).not.toHaveBeenCalled();
+  });
+
   it("init 注册 getLogs/deleteLogs/clearLogs 三个处理器", () => {
     const group = fakeGroup();
-    new LogService(group, fakeDAO()).init();
+    new LogService(group, fakeSystemConfig(7), fakeDAO()).init();
     expect((group.on as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0])).toEqual([
       "getLogs",
       "deleteLogs",
@@ -62,7 +89,7 @@ describe("日志客户端 LogClient（经消息通道端到端）", () => {
   const wire = (dao: LoggerDAO) => {
     const message = new MockMessage(new EventEmitter<string, any>());
     const server = new Server("serviceWorker", message);
-    new LogService(server.group("log"), dao).init();
+    new LogService(server.group("log"), fakeSystemConfig(7), dao).init();
     return new LogClient(message);
   };
 

--- a/src/app/service/service_worker/log.ts
+++ b/src/app/service/service_worker/log.ts
@@ -1,10 +1,17 @@
 import { type Group } from "@Packages/message/server";
 import { type Logger, LoggerDAO } from "@App/app/repo/logger";
+import { type SystemConfig } from "@App/pkg/config/config";
+import LoggerCore from "@App/app/logger/core";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 // 日志查询服务：供页面通过消息读取/删除/清空本地日志（写入仍走 MessageWriter -> manager.logger）
 export class LogService {
+  private logger = LoggerCore.logger().with({ service: "log" });
+
   constructor(
     private group: Group,
+    private systemConfig: SystemConfig,
     private logDAO: LoggerDAO = new LoggerDAO()
   ) {}
 
@@ -18,6 +25,14 @@ export class LogService {
 
   async clearLogs(): Promise<void> {
     await this.logDAO.clear();
+  }
+
+  async cleanupExpiredLogs(now = Date.now()): Promise<void> {
+    const retentionDays = await this.systemConfig.getLogCleanCycle();
+    if (retentionDays <= 0) return;
+    const count = await this.logDAO.deleteBefore(now - retentionDays * DAY_MS);
+    if (!count) return;
+    this.logger.info("cleanup expired logs", { count, retentionDays });
   }
 
   init() {

--- a/src/app/service/service_worker/regular_updatecheck.ts
+++ b/src/app/service/service_worker/regular_updatecheck.ts
@@ -1,4 +1,5 @@
 import { type SystemConfig } from "@App/pkg/config/config";
+import Logger from "@App/app/logger/logger";
 import { type ScriptService } from "./script";
 import { type SubscribeService } from "./subscribe";
 
@@ -67,12 +68,12 @@ export const watchRegularUpdateCheck = (systemConfig: SystemConfig) => {
   });
 };
 
-const setCheckupdateScriptLasttime = async (t: number) => {
+const setCheckupdateScriptLasttime = async (t: number, logger: Logger) => {
   try {
     // 试一下储存。储存不了也没所谓
     await chrome.storage.local.set({ checkupdate_script_lasttime: t });
   } catch (e: any) {
-    console.error(e);
+    logger.warn("store script update check time failed", Logger.E(e));
   }
 };
 
@@ -99,7 +100,7 @@ export const onRegularUpdateCheckAlarm = async (
   const targetWhen = checkupdate_script_lasttime + updateCycleSecond * 1000;
   if (targetWhen - ALARM_TRIGGER_WINDOW_MS > now) return null; // 已检查过了（alarm触发了）
   const storeTime = Math.floor(now / 2) * 2; // 双数
-  await setCheckupdateScriptLasttime(storeTime); // 双数值：alarm触发了，但不知道有没有真的检查好（例如中途浏览器关了）
+  await setCheckupdateScriptLasttime(storeTime, script.logger); // 双数值：alarm触发了，但不知道有没有真的检查好（例如中途浏览器关了）
   const res = await script.checkScriptUpdate({ checkType: "system" });
   try {
     if (subscribe) {
@@ -108,8 +109,8 @@ export const onRegularUpdateCheckAlarm = async (
       await subscribe.checkSubscribeUpdate(updateCycleSecond, checkDisableScript);
     }
   } catch (e: any) {
-    console.error(e);
+    script.logger.error("check subscribe updates failed", Logger.E(e));
   }
-  await setCheckupdateScriptLasttime(storeTime + 1); // 单数值：alarm触发了，而且真的检查好
+  await setCheckupdateScriptLasttime(storeTime + 1, script.logger); // 单数值：alarm触发了，而且真的检查好
   return res;
 };

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -280,7 +280,7 @@ export class RuntimeService {
       this.injectJsCodePromise = fetch("/src/inject.js")
         .then((res) => res.text())
         .catch((e) => {
-          console.error("Unable to fetch /src/inject.js", e);
+          this.logger.error("load extension runtime script failed", { path: "/src/inject.js" }, Logger.E(e));
           return undefined;
         });
     }
@@ -292,7 +292,7 @@ export class RuntimeService {
       this.contentJsCodePromise = fetch("/src/content.js")
         .then((res) => res.text())
         .catch((e) => {
-          console.error("Unable to fetch /src/content.js", e);
+          this.logger.error("load extension runtime script failed", { path: "/src/content.js" }, Logger.E(e));
           return undefined;
         });
     }
@@ -483,7 +483,11 @@ export class RuntimeService {
         }
       }
     } catch (e) {
-      console.error("pushValueUpdate error", e);
+      this.logger.error(
+        "push value update failed",
+        { uuid: script.uuid, storageName: sendData.storageName },
+        Logger.E(e)
+      );
     }
   }
 
@@ -492,7 +496,7 @@ export class RuntimeService {
       // 让 scripting 存取 chrome.storage.session
       await chrome.storage.session.setAccessLevel({ accessLevel: "TRUSTED_AND_UNTRUSTED_CONTEXTS" });
     } catch (e) {
-      console.error("unable to call chrome.storage.session.setAccessLevel", e);
+      this.logger.error("set session storage access level failed", Logger.E(e));
     }
   }
 
@@ -1012,9 +1016,8 @@ export class RuntimeService {
         await chrome.userScripts.configureWorld({
           messaging: true,
         });
-      } catch (_e) {
-        console.error("chrome.userScripts.configureWorld({messaging:true}) failed.");
-        // do nothing
+      } catch (e) {
+        this.logger.error("configure userScripts world failed", Logger.E(e));
       }
     }
 
@@ -1099,7 +1102,7 @@ export class RuntimeService {
     try {
       await chrome.userScripts.resetWorldConfiguration();
     } catch (e: any) {
-      console.error("chrome.userScripts.resetWorldConfiguration() failed.", e);
+      this.logger.error("reset userScripts world configuration failed", Logger.E(e));
     }
 
     const options = {
@@ -1731,7 +1734,11 @@ export class RuntimeService {
         await chrome.userScripts.unregister({ ids: filteredIds });
       }
     } catch (e) {
-      console.error("unregistryPageScripts error:", e);
+      this.logger.error(
+        "unregister page scripts failed",
+        { count: uuids.length, uuids: uuids.slice(0, 20) },
+        Logger.E(e)
+      );
     }
   }
 }

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -361,7 +361,7 @@ export class ScriptService {
       await openInCurrentTab(installPageUrl);
       return { success: true, msg: "" };
     } catch (err: any) {
-      console.error(err);
+      this.logger.error("open install page failed", { source: options.source }, Logger.E(err));
       return { success: false, msg: err.message };
     }
   }
@@ -375,7 +375,7 @@ export class ScriptService {
       await this.openUpdateOrInstallPage(uuid, url, options, false);
       return `/src/install.html?uuid=${uuid}`;
     } catch (err: any) {
-      console.error(err);
+      this.logger.error("prepare install page failed", { source: options.source }, Logger.E(err));
       return "";
     }
   }
@@ -1300,7 +1300,7 @@ export class ScriptService {
       const code = slienceUpdatesNewCode[i];
       const uuid = entry.uuid;
       const { script } = await prepareScriptByCode(code, url, uuid);
-      console.log("slienceUpdate", script.name);
+      this.logger.info("silent update script", { uuid, name: script.name });
       await this.installScript({
         script,
         code,
@@ -1388,7 +1388,7 @@ export class ScriptService {
       try {
         res = await this._checkScriptUpdate(opts);
       } catch (e) {
-        console.error(e);
+        this.logger.error("check script updates failed", Logger.E(e));
         res = {
           ok: false,
           err: e,
@@ -1613,7 +1613,7 @@ export class ScriptService {
           });
           updated.add(uuid);
         } catch (e) {
-          console.error(e);
+          this.logger.error("install checked script update failed", { uuid }, Logger.E(e));
           res.push({
             uuid,
             success: false,

--- a/src/pages/options/routes/Logger/index.tsx
+++ b/src/pages/options/routes/Logger/index.tsx
@@ -241,6 +241,7 @@ export default function Logger() {
           <span>{t("logs:clean_schedule")}</span>
           <input
             type="number"
+            min={0}
             value={cleanCycle}
             onChange={(e) => setCleanCycle(parseInt(e.target.value, 10) || 0)}
             aria-label={t("logs:clean_schedule")}


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

### 问题

Manifest V3 重构后，日志页面仍可配置“定时清理 n 天前的日志”，`log_clean_cycle` 配置和 `LoggerDAO.deleteBefore()` 也仍然存在，但原有定时触发逻辑没有迁移，导致该功能只保存配置而不会真正清理日志。

同时，Service Worker 中部分可供用户排查的业务异常仍通过 `console.*` 输出，无法在运行日志页面查询。

### 修复

- 新增持久化的 `cleanupLogs` alarm：
  - 首次在 1 分钟后运行；
  - 此后每 12 小时检查一次；
  - 创建前先读取现有 alarm，避免 MV3 Service Worker 冷启动不断重置倒计时。
- 由 `LogService` 读取日志保留天数并调用 `LoggerDAO.deleteBefore()` 删除截止时间之前的日志。
- 将保留天数 `0` 定义为关闭自动清理，避免误删全部日志。
- 日志页面清理天数输入框增加 `min={0}`。
- 仅在实际删除了过期日志时记录清理数量，避免周期性产生“清理 0 条”的无效日志。
- 使用结构化 Logger 记录日志清理失败。

### 后台业务日志整理

将以下明确属于业务流程的 `console.*` 迁移到项目 Logger：

- 扩展版本检查、读取更新配置和打开更新日志页面；
- 脚本安装页准备、脚本更新检查、静默更新和批量安装更新；
- Runtime 内置脚本加载、value 更新广播、session storage 配置、userScripts world 配置及脚本注销；
- 定期更新检查时间写入和订阅更新检查；
- GM API 扩展域名权限检查。

日志使用 `service`、`component`、`uuid`、`path`、`count` 等结构化标签。不会记录脚本 value 内容、网络正文、Cookie、Header 或响应内容。批量 UUID 日志限制为前 20 个，避免单条日志过大。

以下底层输出有意继续使用 console：

- Chrome callback 的 `chrome.runtime.lastError`；
- Logger/DBWriter 自身写入失败；
- Logger 初始化前的启动错误；
- 高频网络/CORS 诊断；
- 注入到页面上下文中的 console 提示。

## Tests / 测试

- `pnpm exec vitest run src/app/service/service_worker/log.test.ts src/app/service/service_worker/script.test.ts src/app/service/service_worker/runtime.test.ts src/app/service/service_worker/regular_updatecheck.test.ts --reporter=dot`
  - 4 个测试文件、93 个测试通过。
- `pnpm run typecheck`
- 相关文件 ESLint
- Prettier 格式检查
- `git diff --check`
- `pnpm test` 全量测试通过

## Screenshots / 截图

无明显 UI 变化，仅为现有日志清理天数输入框增加最小值约束。