### PR TITLE
🐛 修复 async_queue 压力测试在 CI 争抢下的超时误报

### DIFF
--- a/src/pkg/utils/async_queue.test.ts
+++ b/src/pkg/utils/async_queue.test.ts
@@ -265,7 +265,9 @@ describe.concurrent("stackAsyncTask 测试", () => {
   });
 
   /* ------------------- 5. 压力 + 递回 ------------------- */
-  it.sequential("【5】大量任务、递回不死锁 + 返回值正确", async () => {
+  // 3000 个任务的串行 await 链在并发 worker 争抢下单次实测可达 300ms+，
+  // 逼近全局 340ms 预算；对这类真实成本用例给出显式单测预算，不放宽全局超时。
+  it.sequential("【5】大量任务、递回不死锁 + 返回值正确", { timeout: 850 }, async () => {
     const kMass = generateKey("mass");
     const kRecur = generateKey("recur");
     const gMass = setupBlockingTask(kMass);


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

**问题**：`test.yaml` 工作流（run 80078796006）在 `Run tests` job 中失败：

```
FAIL src/pkg/utils/async_queue.test.ts > stackAsyncTask 测试 > 【5】大量任务、递回不死锁 + 返回值正确
Error: Test timed out in 340ms.
```

该用例串行 `await` 3000 个堆叠任务并附带递归链，`vitest.config.ts` 中 "fast" project 的全局
`testTimeout` 为 340ms（针对普通用例的紧凑预算）。本地单测与全量覆盖率运行（`--coverage`）
均稳定通过（约 87–88ms），说明并非逻辑缺陷，而是该用例本身真实耗时较高（约 300ms 级），
在 CI 共享 runner 的并发 worker 争抢下偶发超出预算，属于超时误报。

**方案**：比照仓库中 `encoding.test.ts` 对同类重量级用例（chardet 32KB 采样，同样逼近
340ms 预算）已采用的做法，仅为该用例通过 `it.sequential(name, { timeout: 850 }, fn)`
显式给出 850ms 单测预算，不放宽影响其余全部用例的全局超时。

**验证**：
- `pnpm exec vitest run src/pkg/utils/async_queue.test.ts --project fast` — 7/7 通过，该用例 87ms。
- `pnpm exec vitest run --project fast --coverage` — 126 files / 2092 tests 全部通过。

## Screenshots / 截图

不适用（纯测试配置调整，无 UI 变更）。