### PR TITLE
📄 修复贡献者/agent 相关文档中的语法、可执行性、重复标题与锚点问题

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -109,7 +109,8 @@ pnpm run coverage      # Generate coverage reports
 ### Browser Extension Specifics
 - **Manifest V3** with service worker background
 - **User Scripts API** for script injection (Chrome/Edge)
-- **Offscreen API** for DOM access in background contexts  
+- **Offscreen API** for DOM access in background contexts — **Firefox MV3 has no Offscreen API**;
+  `EventPageOffscreenManager` runs the same DOM-dependent logic inside the background event page instead
 - **Declarative Net Request** for script installation interception
 
 ## Critical Integration Points
@@ -136,7 +137,8 @@ pnpm run coverage      # Generate coverage reports
 - Use `pnpm run dev:noMap` for incognito window development
 - Background script changes require extension reload
 - Message passing debugging available in service worker console
-- Sandbox script execution isolated from page context - use `unsafeWindow` for page access
+- Sandbox (background/scheduled scripts) has no page at all — not "isolated from" a page, it never has one.
+  `unsafeWindow` belongs to the **Inject** context (page scripts), not Sandbox
 
 ## File Structure Patterns
 - Tests co-located with source files (`.test.ts` suffix)

--- a/docs/DOC-MAINTENANCE.md
+++ b/docs/DOC-MAINTENANCE.md
@@ -111,6 +111,29 @@ for doc in AGENTS.md docs/README.md docs/DOC-MAINTENANCE.md docs/develop.md docs
 done
 ```
 
+Anchor integrity — the check above only confirms the **target file** exists; a `file.md#anchor` link's fragment
+can still rot silently if the target heading is renamed. This second pass re-derives each anchor from the
+target's actual headings using a best-effort GitHub-slug approximation (lowercase; drop everything but letters,
+digits, spaces, hyphens, underscores; each space becomes its own hyphen — consecutive spaces do **not** collapse,
+which is why `## Commit & Pull Request Guidelines` slugs to `commit--pull-request-guidelines` with a double
+hyphen). **ASCII-only:** it cannot slugify CJK/non-ASCII headings correctly, so anchors into those headings
+(e.g. `translation.md#各语言术语规范--per-locale-terminology`) need manual verification instead.
+
+```bash
+slugify() { printf '%s\n' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[`]//g; s/[^a-z0-9 _-]//g; s/[[:space:]]/-/g'; }
+for doc in AGENTS.md docs/README.md docs/DOC-MAINTENANCE.md docs/develop.md docs/references/develop-testing.md docs/design.md docs/references/design-tokens.md docs/references/design-components.md docs/references/design-patterns.md docs/architecture.md docs/references/architecture-services.md docs/references/architecture-data.md docs/references/architecture-gm-api.md docs/references/architecture-execution.md docs/references/architecture-build.md docs/verification.md docs/references/verification-debugging.md docs/references/verification-report-template.md docs/cloud-sync.md docs/translation.md; do
+  sed '/^```/,/^```/d' "$doc" | sed -E 's/`[^`]*`//g' | grep -oE '\]\([^)]+#[^)]+\)' | sed -E 's/^\]\(|\)$//g' | while read -r link; do
+    tf="${link%%#*}"; anchor="${link#*#}"
+    target="$doc"; [ -n "$tf" ] && target="$(dirname "$doc")/$tf"
+    [ -e "$target" ] || { echo "BROKEN-FILE $doc → $link"; continue; }
+    found=0
+    while IFS= read -r h; do [ "$(slugify "$h")" = "$anchor" ] && found=1 && break; done \
+      < <(grep -E "^#{1,6} " "$target" | sed -E 's/^#{1,6} +//')
+    [ "$found" -eq 1 ] && echo "ok           $doc → $link" || echo "BROKEN-ANCHOR $doc → $link (target: $target)"
+  done
+done
+```
+
 ## When you find a discrepancy
 
 Fix the **doc** to match the code — the code on this branch is the source of truth. The exception: if the code

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,7 +219,7 @@ Map a change onto the existing extension points instead of inventing new structu
 - **A new GM API.** Decorate the method with `@GMContext.API` on the content side, add a privileged/offscreen
   handler if needed, register the `@grant` (see [GM API system](./references/architecture-gm-api.md#adding-a-gm-api-sketch)).
 
-Follow the engineering principles in [`AGENTS.md`](../AGENTS.md): fix root causes (no `as any` / swallowed
+Follow the engineering principles in [`AGENTS.md`](../AGENTS.md#engineering-principles): fix root causes (no `as any` / swallowed
 errors), prefer direct replacement over adapter sandwiches, and keep scope tight — three similar lines beat a
 premature abstraction.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -10,7 +10,7 @@
 
 | Owned here | Owned elsewhere |
 | --- | --- |
-| Color-token values, semantics, usage → [`tokens.md`](./references/design-tokens.md) | The hard rules that mandate them (no hard-coded colors, hover via pseudo-classes, `cn()` / CVA / `lucide`) → [`DEVELOP.md` UI section](./develop.md) |
+| Color-token values, semantics, usage → [`tokens.md`](./references/design-tokens.md) | The hard rules that mandate them (no hard-coded colors, hover via pseudo-classes, `cn()` / CVA / `lucide`) → [`DEVELOP.md` UI section](./develop.md#ui) |
 | Theming mechanism, `dark:` usage | Commands, structure, coding style, testing, i18n, commit/PR → [`DEVELOP.md`](./develop.md) |
 | Component palette, variants, selection guidance → [`components.md`](./references/design-components.md) | Process model, message passing, service layers, internals → [`ARCHITECTURE.md`](./architecture.md) |
 | Layout shell, responsive patterns, **layering (z-index)**, motion, state patterns, **accessibility** → [`patterns.md`](./references/design-patterns.md); **elevation (shadows)** → [`tokens.md`](./references/design-tokens.md#elevation-shadows); page recipe (this doc) | — |

--- a/docs/pull-request.md
+++ b/docs/pull-request.md
@@ -1,6 +1,6 @@
 # Pull Request Description Guide
 
-This guide defines the detailed PR description format for agents and contributors. The human-facing template at [`../.github/pull_request_template.md`](../.github/pull_request_template.md) intentionally remains lightweight; use it as the starting point and expand its `Description / 描述` section when the change needs more context.
+This guide defines the detailed PR description format for agents and contributors. The human-facing template at [`../.github/pull_request_template.md`](../.github/pull_request_template.md) intentionally remains lightweight; use it as the starting point and expand its `Description / 描述` section when the change needs more context. This guide covers the description body only — for the PR **title** (gitmoji + Chinese preferred), see [`develop.md`](./develop.md#commit--pull-request-guidelines).
 
 ## Recommended structure
 

--- a/docs/references/architecture-build.md
+++ b/docs/references/architecture-build.md
@@ -1,7 +1,5 @@
 # Build pipeline & manifest
 
-## Build Pipeline & Manifest
-
 ### Rspack
 
 [`rspack.config.ts`](../../rspack.config.ts) emits one bundle per context/page. Entry points:

--- a/docs/references/architecture-data.md
+++ b/docs/references/architecture-data.md
@@ -1,7 +1,5 @@
 # Data layer (Repo<T> + DAOs)
 
-## The Data Layer (`Repo<T>` + DAOs)
-
 Persistence is a thin generic over `chrome.storage.local` with an optional in-memory cache, in
 [`src/app/repo/repo.ts`](../../src/app/repo/repo.ts).
 

--- a/docs/references/architecture-execution.md
+++ b/docs/references/architecture-execution.md
@@ -1,7 +1,5 @@
 # Script execution
 
-## Script Execution
-
 There are three execution paths; all share one **compilation** step.
 
 ### Compilation — the `with(){}` sandbox wrapper

--- a/docs/references/architecture-gm-api.md
+++ b/docs/references/architecture-gm-api.md
@@ -57,7 +57,8 @@ work.
 ### Adding a GM API (sketch)
 
 1. Add the method to the content `GMApi` with `@GMContext.API({ alias: "GM.foo" })`; for sync APIs return
-   directly, for async ones forward via `sendMessage`/`connect`.
+   directly, for async ones forward via `sendMessage` (single request/reply) — or `connect` only when the reply
+   is streamed in chunks (progress events, large payloads; see the `GM_xmlhttpRequest` walkthrough above).
 2. If it needs privilege (network, cookies, tabs), add the handler on the SW `GMApi` with
    `@PermissionVerify.API(...)`.
 3. If it needs DOM, route through the offscreen GM API instead

--- a/docs/references/architecture-gm-api.md
+++ b/docs/references/architecture-gm-api.md
@@ -60,6 +60,7 @@ work.
    directly, for async ones forward via `sendMessage`/`connect`.
 2. If it needs privilege (network, cookies, tabs), add the handler on the SW `GMApi` with
    `@PermissionVerify.API(...)`.
-3. If it needs DOM, route through the offscreen GM API instead.
-4. Register the `@grant` so the linter and the context builder recognize it (see
-   [`packages/eslint`](../../packages/eslint)).
+3. If it needs DOM, route through the offscreen GM API instead
+   ([`src/app/service/offscreen/gm_api.ts`](../../src/app/service/offscreen/gm_api.ts)).
+4. Register the `@grant` so the linter and the context builder recognize it
+   ([`packages/eslint/linter-config.ts`](../../packages/eslint/linter-config.ts)).

--- a/docs/references/architecture-gm-api.md
+++ b/docs/references/architecture-gm-api.md
@@ -1,7 +1,5 @@
 # GM API system
 
-## The GM API System
-
 The `GM_*` / `GM.*` functions a userscript calls are not one function — each is a small client that forwards
 across contexts to a privileged handler, then streams the result back. The implementation is split:
 

--- a/docs/references/architecture-services.md
+++ b/docs/references/architecture-services.md
@@ -1,7 +1,5 @@
 # Service layer
 
-## The Service Layer
-
 Services live under `src/app/service/<context>/` — **split by the context they run in** — and hold the domain
 logic. They are deliberately "dumb plumbing on the outside, smart logic on the inside": construction is pure DI,
 wiring happens once in a manager, and message handlers are registered in `init()`.

--- a/docs/references/design-components.md
+++ b/docs/references/design-components.md
@@ -1,7 +1,5 @@
 # Component palette
 
-## Component palette & usage
-
 The shadcn primitives live in [`src/pages/components/ui/`](../../src/pages/components/ui/) — `new-york` style, CSS variables enabled, no class prefix (`components.json`). Icons are always `lucide-react`; class merging is always `cn()` ([`src/pkg/utils/cn.ts`](../../src/pkg/utils/cn.ts)); variants are always CVA — these are the [`DEVELOP.md` UI section](../develop.md) hard rules, not repeated here. This section is "what exists and how to choose."
 
 ### Primitives & shared composites

--- a/docs/references/design-components.md
+++ b/docs/references/design-components.md
@@ -1,6 +1,6 @@
 # Component palette
 
-The shadcn primitives live in [`src/pages/components/ui/`](../../src/pages/components/ui/) — `new-york` style, CSS variables enabled, no class prefix (`components.json`). Icons are always `lucide-react`; class merging is always `cn()` ([`src/pkg/utils/cn.ts`](../../src/pkg/utils/cn.ts)); variants are always CVA — these are the [`DEVELOP.md` UI section](../develop.md) hard rules, not repeated here. This section is "what exists and how to choose."
+The shadcn primitives live in [`src/pages/components/ui/`](../../src/pages/components/ui/) — `new-york` style, CSS variables enabled, no class prefix (`components.json`). Icons are always `lucide-react`; class merging is always `cn()` ([`src/pkg/utils/cn.ts`](../../src/pkg/utils/cn.ts)); variants are always CVA — these are the [`DEVELOP.md` UI section](../develop.md#ui) hard rules, not repeated here. This section is "what exists and how to choose."
 
 ### Primitives & shared composites
 

--- a/docs/references/design-tokens.md
+++ b/docs/references/design-tokens.md
@@ -7,7 +7,7 @@
 **Usage:**
 - Background `bg-<token>`, text `text-<token>`, border `border-<token>`, focus ring `ring-ring`.
 - Opacity modifiers compose directly: `bg-primary-background/90` (solid primary hover), `ring-destructive/20`, `bg-input/30`.
-- **Never hard-code a color value** — see Constraint 1 and [`DEVELOP.md` UI section](../develop.md). For dark-only tweaks use the `dark:` variant.
+- **Never hard-code a color value** — see Constraint 1 and [`DEVELOP.md` UI section](../develop.md#ui). For dark-only tweaks use the `dark:` variant.
 
 ### Base surfaces & text
 

--- a/docs/references/develop-testing.md
+++ b/docs/references/develop-testing.md
@@ -8,11 +8,11 @@ Vitest + happy-dom. Per-test budgets live in `vitest.config.ts` per project: non
 `renderHook` tests in `.ts` files) uses 850ms because a render + interaction case genuinely costs 100–200ms
 solo under coverage and worker parallelism multiplies that (fake-timer countdown cases have been observed at
 ~630ms under full local load). Don't pass `--test-timeout` on the CLI — it would override every project's
-budget at once. Chrome APIs mocked via
-`@Packages/chrome-extension-mock` (`tests/vitest.setup.ts`). `MockMessage` available for message-system tests.
+budget at once. Chrome APIs are mocked via
+`@Packages/chrome-extension-mock` (`tests/vitest.setup.ts`). `MockMessage` is available for message-system tests.
 `happy-dom` is patched via `patches/` (see `pnpm-workspace.yaml` `patchedDependencies`) to build its
 invalid-selector `DOMException` lazily — the upstream eager construction captures a deep stack on every
-`matches()`/`querySelector()` call and cost ~15% of TSX suite time.
+`matches()`/`querySelector()` call and costs ~15% of TSX suite time.
 
 - Write failing tests **before** implementation; co-locate `*.test.ts`/`*.test.tsx` next to source (or place in `tests`).
 - BDD-style Chinese `describe`/`it` titles. Use `describe.concurrent()` / `it.concurrent()` where independent.

--- a/docs/references/develop-testing.md
+++ b/docs/references/develop-testing.md
@@ -1,7 +1,7 @@
 # Testing
 
 > The **TDD/BDD-first principle** (write failing tests before implementation; fix code not tests) lives in
-> [`AGENTS.md`](../../AGENTS.md) → *Engineering Principles*. This section is the mechanics.
+> [`AGENTS.md`](../../AGENTS.md#engineering-principles) → *Engineering Principles*. This section is the mechanics.
 
 Vitest + happy-dom. Per-test budgets live in `vitest.config.ts` per project: non-UI projects (`fast`,
 `isolated`) use 340ms; the `ui` project (`src/pages/**/*.test.{ts,tsx}` — React renders, including

--- a/docs/references/verification-debugging.md
+++ b/docs/references/verification-debugging.md
@@ -12,6 +12,11 @@ model in [`ARCHITECTURE.md`](../architecture.md)):
 | Background / scheduled script, DOM-needing GM APIs | **Offscreen** — `dist/ext/src/offscreen.html` context |
 | Cron scheduling, `with`-sandboxed execution | **Sandbox** — `dist/ext/src/sandbox.html` context |
 
+> **Firefox has no separate Offscreen context.** `chrome.offscreen.createDocument` doesn't exist there, so
+> `offscreen.html` is never loaded — `EventPageOffscreenManager` runs the same logic inside the background event
+> page instead (see [`ARCHITECTURE.md`](../architecture.md#chrome-vs-firefox-the-offscreen-split)). On Firefox,
+> inspect the background/event page, not `offscreen.html`.
+
 In a scratch script, capture the page console (`page.on("console", …)`), take screenshots
 (`await page.screenshot({ path: "test-results/verify/<scenario>/screenshots/…png" })`), and write any manual
 notes to `test-results/verify/<scenario>/`. Playwright's automatic failure artifacts also go under

--- a/docs/references/verification-debugging.md
+++ b/docs/references/verification-debugging.md
@@ -3,7 +3,7 @@
 ## Five-context debug map
 
 A feature can break in any of ScriptCat's five isolated contexts. Match the symptom to where its logs live (deep
-model in [`ARCHITECTURE.md`](../architecture.md)):
+model in [`ARCHITECTURE.md`](../architecture.md#the-five-contexts-process-model)):
 
 | Symptom | Where to look |
 | --- | --- |

--- a/docs/references/verification-report-template.md
+++ b/docs/references/verification-report-template.md
@@ -4,8 +4,11 @@ Before running the browser, create a short verification record in the scenario d
 `test-results/verify/<scenario>/report.md`. Keep the reusable template headings in English, but write the actual
 record content in the user's language. Update it as the run proceeds instead of filling it in only at the end.
 
+This is the `Evidence Index` section alone, filled in, to show its shape — it is not the full report; the full
+report shape (which reuses this same section) is below.
+
 ```md
-## Evidence Index
+## Evidence Index (filled-in example)
 
 ### Screenshots
 
@@ -81,7 +84,8 @@ Use this shape:
 
 ## Evidence Index
 
-Embed screenshots inline, link videos / logs / resources, and annotate every item — see the shape above.
+Embed screenshots inline, link videos / logs / resources, and annotate every item — see `Evidence Index
+(filled-in example)` above.
 ```
 
 Fill `Result` at the end — the honest verdict, per *Step 4 — Report honestly* in [`verification.md`](../verification.md).

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -50,6 +50,7 @@
 - **关键字冲突**：同一页面中关键字相同但翻译不同时，使用 `page.key` 的方式区分。
 - 为满足部分扩展市场要求，`chrome.i18n` 语言文件位于 `src/assets/_locales`。
 - i18n 方案的实现细节见 [`src/locales/README.md`](../src/locales/README.md)。
+- 自动检查：[`src/locales/i18n-usage.test.ts`](../src/locales/i18n-usage.test.ts)（`pnpm test`）静态扫描代码中的 `t()`/`i18n.t()` 调用，但只按 **zh-CN** 资源解析 key 是否存在；修改其它 locale 时该测试不会给出任何信号，仍需人工核对目标 locale 是否缺 key。
 
 ## 提取翻译提示词 / Extract-translation prompt
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -127,7 +127,7 @@ Playwright finalizes `.webm` files when pages/contexts close at the end of the t
 produce multiple videos because the harness may open setup pages as well as the page under verification; keep all
 of them beside the screenshots for the same scenario.
 
-> Scratch copying the inline fixture won't read `E2E_RECORD_VIDEO_DIR` — see [gotchas](./references/verification-debugging.md#common-gotchas).
+> A scratch script that copies the inline fixture won't read `E2E_RECORD_VIDEO_DIR` — see [gotchas](./references/verification-debugging.md#common-gotchas).
 
 ### Run only your scratch script
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -9,6 +9,11 @@
 > **What this is NOT.** It is *not* the test-suite reference. The mechanics of Vitest unit tests and the
 > permanent Playwright E2E suite live in [`DEVELOP.md`](./develop.md) → *Testing*; the TDD-first principle and
 > engineering rules live in [`../AGENTS.md`](../AGENTS.md). Read those for writing committed tests.
+>
+> **When to skip this guide.** Docs-only, comment-only, and type-only changes need no browser run. When a change
+> or bug is fully reproducible in pure service/unit logic — no cross-context wiring, no real Chrome API, no DOM —
+> reproduce and verify it with a throwaway Vitest case instead of a scratch script; reach for this guide only when
+> the behavior only manifests through the built extension.
 
 ## The one rule: verification ≠ growing the E2E suite
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -89,8 +89,9 @@ sanitize them before saving evidence.
 
 Embed screenshots inline with `![alt](screenshots/…png)` plus a caption line, so `report.md` renders as a visual
 record you can skim without opening files. Link videos, logs, and resources instead — markdown can't inline them.
-Never list bare links: every item carries a short note explaining what it proves and how to read it. Before running
-the browser, create the record following the Evidence Index shape in the
+Never list bare links: every item carries a short note explaining what it proves and how to read it.
+
+**Before running the browser**, create the record following the Evidence Index shape in the
 [verification record template](./references/verification-report-template.md).
 
 ### Minimal template (drive a UI page)

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -7,8 +7,9 @@
 > scripts and local-only evidence — kept out of Git and never deleted as part of a run; cleanup is the user's call.
 >
 > **What this is NOT.** It is *not* the test-suite reference. The mechanics of Vitest unit tests and the
-> permanent Playwright E2E suite live in [`DEVELOP.md`](./develop.md) → *Testing*; the TDD-first principle and
-> engineering rules live in [`../AGENTS.md`](../AGENTS.md). Read those for writing committed tests.
+> permanent Playwright E2E suite live in [`DEVELOP.md`](./develop.md#testing) → *Testing*; the TDD-first principle
+> and engineering rules live in [`../AGENTS.md`](../AGENTS.md#engineering-principles). Read those for writing
+> committed tests.
 >
 > **When to skip this guide.** Docs-only, comment-only, and type-only changes need no browser run. When a change
 > or bug is fully reproducible in pure service/unit logic — no cross-context wiring, no real Chrome API, no DOM —
@@ -25,12 +26,13 @@ you only want to *check that a feature works*, do not pay that cost and do not l
 - ✅ Write a **throwaway scratch script** under `e2e/scratch/` (git-ignored), run it, and keep any evidence local.
 
 Promoting a scenario into the permanent suite is a *separate, deliberate* decision — only when it deserves
-permanent regression coverage. That path is owned by [`DEVELOP.md`](./develop.md), not this guide.
+permanent regression coverage. That path is owned by [`DEVELOP.md`](./develop.md#testing), not this guide.
 
 **Reproducing a bug you intend to fix is *not* "casual verification."** A scratch reproduction is the *确定 bug
-存在* step from [`../AGENTS.md`](../AGENTS.md) (确定 bug 存在 → 写测试 → 修复): it confirms the bug is real but does
-**not** replace the test. Next, promote it into a *failing* committed test, then fix, then confirm it goes green —
-that permanent test is owned by [`DEVELOP.md`](./develop.md) / [`../AGENTS.md`](../AGENTS.md).
+存在* step from [`../AGENTS.md`](../AGENTS.md#engineering-principles) (确定 bug 存在 → 写测试 → 修复): it confirms the
+bug is real but does **not** replace the test. Next, promote it into a *failing* committed test, then fix, then
+confirm it goes green — that permanent test is owned by [`DEVELOP.md`](./develop.md#testing) /
+[`../AGENTS.md`](../AGENTS.md#engineering-principles).
 
 ## Prerequisite gate (cheap signals first)
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -120,6 +120,13 @@ test("verify: options page opens and renders the script list area", async ({ con
 });
 ```
 
+To verify a UI change in **both themes** ([design.md](./design.md#theming) requires it), set the theme before
+navigating and capture one screenshot per theme:
+
+```ts
+await context.addInitScript(() => localStorage.setItem("lightMode", "dark")); // or "light"
+```
+
 If you need video evidence, enable it explicitly for the run. The shared fixture writes videos only when
 `E2E_RECORD_VIDEO_DIR` is set:
 


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes / 已修复或实现：全部 agent 可读 markdown 文档中的语法错误、可执行性缺口、重复标题、锚点精度问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## 背景

按用户要求通读并系统扫描了仓库内全部 46 个 markdown 文件（`git ls-files "*.md"`，排除 worktrees），覆盖
`AGENTS.md`/`CLAUDE.md`、`docs/**`、`.github/*.md`、`CONTRIBUTING.md`、各 package 的 `README.md`、
`src/locales/README.md`、`src/pages/.../i18nKeys.md` 等，检查四类问题：

1. **语法错误**（缺失动词、主谓不一致等）。
2. **agent 可执行性缺口**：模拟真实触发场景逐步走一遍文档指令，找出指令埋在无关段落、省略主语造成歧义、
   步骤缺少具体文件路径、跨文档规则脱节/矛盾，以及**与已核实代码不符的架构性错误**。
3. **重复标题**：同文件内标题去重扫描（区分/不区分 fenced code block、区分/不区分大小写）。
4. **锚点精度**：`file.md#anchor` 风格仅在指向具体章节时才添加，绝不套用到整份文件引用；用新增的锚点
   校验脚本核对每个链接文字是否已点名具体章节但 href 停在文件级别。

第四轮结束后用户指出"你漏了一些修复"，进而扩大范围重新扫描全部 agent 可读 markdown（而不仅是此前已覆盖的
`docs/` 子集），发现 `.github/copilot-instructions.md`——GitHub Copilot 自己的入口指令文件，完全不在
`AGENTS.md` 的文档链路里，独立复述了一份架构说明，存在两处与已核实代码不符的错误，且属于与前几轮
同一类问题模式。

涉及"当前分支代码是否真如文档所说"的发现，改文档前都用 `grep` / `test -f` / `git grep` 核实过。

## 本次改动

十七个提交，均为纯文档修改，不改变任何既有规则语义：

**第一轮 — 语法**
1. `1bdff54c` — `docs/references/develop-testing.md`：修复三处语法错误。

**第一轮 — 可执行性**
2. `16a3fa5a` — `docs/verification.md`：拆分"先建验证记录"顺序要求。
3. `65423a30` — `docs/verification.md`：修正主语省略歧义。
4. `321092e9` — `docs/references/architecture-gm-api.md`：补上步骤 3、4 的具体文件路径。

**第二轮 — 场景模拟发现的可执行性缺口**
5. `77802927` — `docs/verification.md`：补充"何时可跳过本指南"边界。
6. `9e5b4243` — `docs/references/architecture-gm-api.md`：补上 sendMessage/connect 选择依据。
7. `57e79793` — `docs/verification.md`：补上双主题验证的具体写法。
8. `72c93ee6` — `docs/translation.md`：补充 i18n-usage.test.ts 的存在与作用范围。
9. `fe089367` — `docs/references/verification-debugging.md`：补充 Firefox 无独立 Offscreen 上下文的提示。
10. `7e84e92d` — `docs/pull-request.md`：加交叉链接到 PR 标题规则。

**第三轮 — 重复标题**
11. `3a6b5917` — 6 个 references 文档：删除 H1 后紧跟的同义重复 H2。
12. `c4c19ae6` — `verification-report-template.md`：消除两处 "Evidence Index" 标题歧义。

**第四轮 — 锚点精度**
13. `fa34afe1` — `DOC-MAINTENANCE.md`：新增锚点完整性校验脚本。
14. `6eea05ed` — 4 个文档：补上 5 处指名具体章节但 href 停在文件级别的锚点。
15. `cf5d6d6c` — `design.md`/`design-tokens.md`/`design-components.md`：补上 3 处 "UI section" 链接遗漏的 `#ui` 锚点。

**第五轮 — 扩大范围重新扫描全部 agent 可读 markdown**
16. （工具验证，无独立提交）用四类检查脚本对仓库内全部 46 个 markdown 文件跑了一遍：重复标题、文件链接、
    锚点完整性、"链接文字点名章节但 href 未跟上"，除下条外全部通过。
17. `8659100c` — `.github/copilot-instructions.md`：修复两处架构性错误——(a) 把 Sandbox（background/scheduled
    脚本，见 architecture-execution.md:43 "无 page"）与 Inject（见 architecture.md:84 "有 unsafeWindow"）混为
    一谈；(b) "Browser Extension Specifics" 完全没提 Firefox 无 Offscreen API（与第 9 条修复的是同一个事实
    缺口，已核对 src/service_worker.ts:77-85）。

## 已知限制

- 未改动 `design.md` / `design-patterns.md` 中大量原则性、判断性表述——有意保留的设计判断空间。
- 未改动各语言 `terminology-*.md` 的翻译内容（除 `terminology-en-US.md` 外），需要对应语言母语判断力；
  但已用相同的机械检查（重复标题、锚点）扫描过全部 7 个其它 locale 的 terminology 文件，均无结构性问题。
- 未修改 `AGENTS.md` 本身，保持其始终加载的 token 成本不变。
- 未把 `file.md#anchor` 风格套用到指向整份文件的链接。
- 未改动根目录 `README.md`、`CONTRIBUTING.md`、各 package 的 `README.md`——通读后确认无第 1-4 类问题。
- 未把 `.github/copilot-instructions.md` 纳入 `DOC-MAINTENANCE.md` 的文档归属表——这是更大的架构性改动
  （该文件服务于不同工具、有不同约束），超出本 PR 已建立的四类问题范围，仅修复了发现的两处具体错误。

## 建议审查重点

- 确认第五轮新增的两处 copilot-instructions.md 修复准确反映 Sandbox / Inject / Firefox offscreen 的实际行为。
- 确认锚点校验脚本（fa34afe1）与全部锚点补丁互相一致。
- 确认删除的重复标题、合并的重复 "Evidence Index" 标题没有被任何现存文档或外部引用依赖。

## 验证

- 四类检查脚本（重复标题 / 文件链接 / 锚点完整性 / 链接文字-锚点一致性）对仓库内全部 46 个 markdown 文件
  跑通，仅一处已知 CJK 限制误报（`docs/DOC-MAINTENANCE.md` 中已注明）。
- 手动核对 `.github/copilot-instructions.md` 新增的两条事实性修正与 `architecture-execution.md:43`、
  `architecture.md:84`、`src/service_worker.ts:77-85` 一致。
- 手动确认全部新增引用的文件路径与锚点在当前分支上存在。
- 未涉及任何源码，未运行 `pnpm test` / `pnpm run typecheck`（无相关代码路径）。