### PR TITLE
🐛 修复保存脚本改名后浏览器标签页标题未同步更新

### DIFF
--- a/src/pages/options/routes/ScriptEditor/index.tsx
+++ b/src/pages/options/routes/ScriptEditor/index.tsx
@@ -148,16 +148,18 @@ export default function ScriptEditor() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadingList, params.uuid]);
 
-  // 激活标签 → 同步 URL + 标题
+  const activeTab = useMemo(() => state.tabs.find((x) => x.uuid === state.activeUuid), [state.tabs, state.activeUuid]);
+  const activeTabScriptName = activeTab?.script && i18nName(activeTab.script);
+
+  // 激活标签或其脚本数据变化(如保存后改名) → 同步 URL + 标题
   useEffect(() => {
     if (!state.activeUuid) return;
     if (params.uuid !== state.activeUuid) {
       void navigate(`/script/editor/${state.activeUuid}`, { replace: true });
     }
-    const tab = state.tabs.find((x) => x.uuid === state.activeUuid);
-    if (tab) document.title = `${i18nName(tab.script)} - Script Editor`;
+    if (activeTabScriptName) document.title = `${activeTabScriptName} - Script Editor`;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.activeUuid]);
+  }, [state.activeUuid, activeTabScriptName]);
 
   // 切换标签后把焦点恢复到对应编辑器(各标签实例常驻,仅丢失键盘焦点)
   useActiveEditorFocus(state.activeUuid, editorsRef);
@@ -175,7 +177,6 @@ export default function ScriptEditor() {
     return () => window.removeEventListener("beforeunload", onBeforeUnload);
   }, [anyChanged]);
 
-  const activeTab = useMemo(() => state.tabs.find((x) => x.uuid === state.activeUuid), [state.tabs, state.activeUuid]);
   const subView = activeTab?.subView ?? "code";
   // 仅后台/定时脚本可运行；普通脚本隐藏「运行」入口（与脚本列表/弹窗一致）
   const canRun = !!activeTab && activeTab.script.type !== SCRIPT_TYPE_NORMAL;


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes 保存脚本改名后浏览器标签页标题未同步更新 / 已修复脚本编辑器保存改名后浏览器标签标题不更新的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## 背景

在脚本编辑器中修改脚本的 `// @name` 并保存后，编辑器内部的标签栏（`EditorTabs`）会立即显示新名称，但浏览器实际的标签页标题（`document.title`）仍停留在旧名称，直到用户切换到其他标签再切回来，或刷新页面，标题才会更新。

根因：`src/pages/options/routes/ScriptEditor/index.tsx` 中负责同步 `document.title` 的 `useEffect` 只依赖 `state.activeUuid`，仅在切换激活标签时重新计算标题；保存脚本后 `activeUuid` 本身不变，因此该 effect 不会重新执行。

## 本次改动

- 将 `activeTab` 的 `useMemo` 提前声明，并新增 `activeTabScriptName`（已解析的 i18n 名称字符串）。
- 标题同步的 `useEffect` 依赖数组由 `[state.activeUuid]` 改为 `[state.activeUuid, activeTabScriptName]`，使其在保存改名后立即重新计算 `document.title`，同时避免了直接依赖整个 `state.tabs` 数组导致在每次按键编辑时都触发该 effect（因为 `markChanged` action 每次按键都会产出新的 `tabs` 数组引用）。

## 验证

- `npx eslint src/pages/options/routes/ScriptEditor/index.tsx` — 无报错
- `npx tsc --noEmit -p .` — 无新增报错（仅有与本次改动无关的 `tests/mocks/network.ts` 预置类型声明缺失）
- 用户已在真实浏览器中人工测试确认：编辑脚本名称并保存后，浏览器标签页标题立即同步更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)