### PR TITLE
🐛 迁移测试端点从 httpbun.com 到 mockhttp.org

### DIFF
--- a/e2e/gm-api.spec.ts
+++ b/e2e/gm-api.spec.ts
@@ -125,6 +125,7 @@ async function startGMApiMockServer(): Promise<GMApiMockServer> {
       res.end(
         JSON.stringify({
           url: `http://${req.headers.host}${url.pathname}`,
+          method: req.method,
           args,
         })
       );
@@ -221,14 +222,14 @@ function patchGMApiTestCode(code: string, mockOrigin: string): string {
   const mockHost = new URL(mockOrigin).host;
   return code
     .replace(/^\/\/\s*@connect\s+api\.github\.com$/gm, `// @connect      ${MOCK_CONNECT_HOST}`)
-    .replace(/^\/\/\s*@connect\s+httpbun\.com$/gm, `// @connect      ${MOCK_CONNECT_HOST}`)
+    .replace(/^\/\/\s*@connect\s+mockhttp\.org$/gm, `// @connect      ${MOCK_CONNECT_HOST}`)
     .replace(/https:\/\/api\.github\.com\/repos\/scriptscat\/scriptcat/g, `${mockOrigin}/repos/scriptscat/scriptcat`)
-    .replace(/https:\/\/httpbun\.com\/get/g, `${mockOrigin}/get`)
-    .replace(/https:\/\/httpbun\.com\/bytes\/64/g, `${mockOrigin}/bytes/64`)
-    .replace(/https:\/\/httpbun\.com\/delay\/5/g, `${mockOrigin}/delay/5`)
+    .replace(/https:\/\/mockhttp\.org\/get/g, `${mockOrigin}/get`)
+    .replace(/https:\/\/mockhttp\.org\/bytes\/64/g, `${mockOrigin}/bytes/64`)
+    .replace(/https:\/\/mockhttp\.org\/delay\/5/g, `${mockOrigin}/delay/5`)
     .replace(/https:\/\/www\.tampermonkey\.net\/favicon\.ico/g, `${mockOrigin}/favicon.ico`)
     .replace(/api\.github\.com\/repos\/scriptscat\/scriptcat/g, `${mockHost}/repos/scriptscat/scriptcat`)
-    .replace(/httpbun\.com\/get/g, `${mockHost}/get`);
+    .replace(/mockhttp\.org\/get/g, `${mockHost}/get`);
 }
 
 async function runTestScript(

--- a/example/crontab/crontab.js
+++ b/example/crontab/crontab.js
@@ -7,26 +7,26 @@
 // @crontab      */15 14-16 * * *
 // @grant        GM_log
 // @grant        GM_xmlhttpRequest
-// @connect      httpbun.com
+// @connect      mockhttp.org
 // ==/UserScript==
 
 return new Promise((resolve, reject) => {
   GM_log("下午两点至四点每十五分钟运行一次");
 
   GM_xmlhttpRequest({
-    url: "https://httpbun.com/get",
+    url: "https://mockhttp.org/get",
     method: "GET",
     responseType: "json",
     anonymous: true,
 
     onload(resp) {
       const data = resp.response;
-      if (resp.status !== 200 || data?.url !== "https://httpbun.com/get") {
+      if (resp.status !== 200 || resp.finalUrl !== "https://mockhttp.org/get" || data?.method !== "GET") {
         reject("服务器回应错误。");
         return;
       }
 
-      GM_log(`定时请求成功：\n${data.url}`);
+      GM_log(`定时请求成功：\n${resp.finalUrl}`);
       resolve();
     },
     onerror() {

--- a/example/tests/gm_api_async_test.js
+++ b/example/tests/gm_api_async_test.js
@@ -24,7 +24,7 @@
 // @grant        unsafeWindow
 // @require      https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js#sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK
 // @resource     testCSS https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css#sha256=62f74b1cf824a89f03554c638e719594c309b4d8a627a758928c0516fa7890ab
-// @connect      httpbun.com
+// @connect      mockhttp.org
 // @connect      example.com
 // @run-at       document-start
 // ==/UserScript==
@@ -192,7 +192,7 @@
     return new Promise((resolve, reject) => {
       GM.xmlHttpRequest({
         method: "GET",
-        url: "https://httpbun.com/get",
+        url: "https://mockhttp.org/get",
         timeout: 10000,
         onload: (response) => {
           try {
@@ -200,8 +200,9 @@
             assert(true, !!response.responseText, "响应内容不应为空");
             const data = JSON.parse(response.responseText);
             assert("object", typeof data, "应该返回有效的 JSON 对象");
-            assert("https://httpbun.com/get", data.url, "响应应该包含 url 字段");
-            console.log("httpbun 响应信息:", data.url);
+            assert("GET", data.method, "响应应该包含 method 字段");
+            assert(true, response.finalUrl.includes("mockhttp.org/get"), "finalUrl 应指向请求的地址");
+            console.log("mockhttp 响应信息:", response.finalUrl);
             resolve();
           } catch (error) {
             reject(error);
@@ -220,7 +221,7 @@
   await testAsync("GM.xmlHttpRequest - 返回控制对象", async () => {
     const controller = GM.xmlHttpRequest({
       method: "GET",
-      url: "https://httpbun.com/get",
+      url: "https://mockhttp.org/get",
       timeout: 10000,
       onload: () => {},
       onerror: () => {},

--- a/example/tests/gm_api_sync_test.js
+++ b/example/tests/gm_api_sync_test.js
@@ -28,7 +28,7 @@
 // @grant        unsafeWindow
 // @require      https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js#sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK
 // @resource     testCSS https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css#sha256=62f74b1cf824a89f03554c638e719594c309b4d8a627a758928c0516fa7890ab
-// @connect      httpbun.com
+// @connect      mockhttp.org
 // @connect      example.com
 // @run-at       document-start
 // ==/UserScript==
@@ -308,7 +308,7 @@
       return new Promise((resolve, reject) => {
         GM_xmlhttpRequest({
           method: "GET",
-          url: "https://httpbun.com/get",
+          url: "https://mockhttp.org/get",
           timeout: 10000,
           onload: (response) => {
             try {
@@ -316,8 +316,9 @@
               assert(true, !!response.responseText, "响应内容不应为空");
               const data = JSON.parse(response.responseText);
               assert("object", typeof data, "应该返回有效的 JSON 对象");
-              assert("https://httpbun.com/get", data.url, "响应应该包含 url 字段");
-              console.log("httpbun 响应信息:", data.url);
+              assert("GET", data.method, "响应应该包含 method 字段");
+              assert(true, response.finalUrl.includes("mockhttp.org/get"), "finalUrl 应指向请求的地址");
+              console.log("mockhttp 响应信息:", response.finalUrl);
               resolve();
             } catch (error) {
               reject(error);

--- a/example/tests/gm_download_test.js
+++ b/example/tests/gm_download_test.js
@@ -11,7 +11,7 @@
 // @grant        GM_setValue
 // @grant        GM_getValue
 // @grant        GM_info
-// @connect      httpbun.com
+// @connect      mockhttp.org
 // @connect      raw.githubusercontent.com
 // @connect      cdn.jsdelivr.net
 // @connect      ipv4.download.thinkbroadband.com
@@ -136,8 +136,8 @@ const enableTool = true;
   // File extends Blob; useful to verify the URL-object branch handles File too.
   const TEXT_FILE = new File([TEXT_BLOB], "ignored-by-api.txt", { type: "text/plain" });
 
-  // httpbun deterministic endpoint — returns N random bytes.
-  const HB = "https://httpbun.com";
+  // mockhttp deterministic endpoint — returns N random bytes.
+  const HB = "https://mockhttp.org";
 
   // ---------- Panel ----------
   const panel = h(
@@ -697,7 +697,7 @@ const enableTool = true;
     skip(`(visual check) you should see both uniquify-target.txt and uniquify-target (1).txt`);
   });
 
-  // 13) headers honored in native mode — httpbun /headers echoes request headers
+  // 13) headers honored in native mode — mockhttp /headers echoes request headers
   autoTest("headers passed to backend xhr (native mode)", async () => {
     // We can't easily inspect what hit the server because the response is
     // streamed to disk. So instead: ask /headers, which RESPONDS with the headers

--- a/example/tests/gm_xhr_redirect_test.js
+++ b/example/tests/gm_xhr_redirect_test.js
@@ -200,7 +200,15 @@ const enableTool = true;
           gmRequest({ method: "GET", url, redirect: "manual", fetch }),
           new Promise(resolve => setTimeout(resolve, 4000)),
         ]);
-        assertEq(res?.status, 302, "status is 302");
+        // NOT actually testing the server's real redirect status here: with
+        // redirect: "manual", GM_xhr routes through fetch()'s opaqueredirect
+        // response, whose real status the Fetch spec makes unreadable from
+        // JS. ScriptCat's fetch_xhr.ts hardcodes 301 in that branch as a
+        // fallback regardless of what the server actually sent - confirmed
+        // the live server returns 302 here (verified with curl), yet GM_xhr
+        // still reports 301. This assertion pins down ScriptCat's own known
+        // fallback value, not mockhttp.org's behavior.
+        assertEq(res?.status, 301, "status is 301 (ScriptCat's fixed fallback for opaque manual redirects, not the server's real code)");
         assertEq(res?.finalUrl, url, "finalUrl is original url");
         assertEq(typeof res?.responseHeaders === "string" && res?.responseHeaders !== "", true, "responseHeaders ok");
         assertEq(objectProps(res), "ok", "Object Props OK");

--- a/example/tests/gm_xhr_redirect_test.js
+++ b/example/tests/gm_xhr_redirect_test.js
@@ -152,9 +152,13 @@ const enableTool = true;
       name: "Redirect handling (finalUrl changes) [default]",
       async run(fetch) {
         const target = `${HB}/get?z=92`;
-        const { res } = await gmRequest({ method: "GET", url: `${HB}/redirect-to?url=${encodeURIComponent(target)}`, fetch });
+        const { res } = await gmRequest({ method: "GET", url: `${HB}/redirect-to?url=${encodeURIComponent(target)}`, responseType: "json", fetch });
         assertEq(res.status, 200, "status after redirect is 200");
         assertEq(res.finalUrl, target, "finalUrl is redirected target");
+        // finalUrl alone only proves the client thinks it followed the
+        // redirect - confirm the server actually served /get's response.
+        assertEq(res.response?.method, "GET", "redirected request reached /get as GET");
+        assertEq(res.response?.queryParams?.z, "92", "redirected response echoes the target's query");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -162,9 +166,11 @@ const enableTool = true;
       name: "Redirect handling (finalUrl changes) [follow]",
       async run(fetch) {
         const target = `${HB}/get?z=94`;
-        const { res } = await gmRequest({ method: "GET", url: `${HB}/redirect-to?url=${encodeURIComponent(target)}`, redirect: "follow", fetch });
+        const { res } = await gmRequest({ method: "GET", url: `${HB}/redirect-to?url=${encodeURIComponent(target)}`, redirect: "follow", responseType: "json", fetch });
         assertEq(res.status, 200, "status after redirect is 200");
         assertEq(res.finalUrl, target, "finalUrl is redirected target");
+        assertEq(res.response?.method, "GET", "redirected request reached /get as GET");
+        assertEq(res.response?.queryParams?.z, "94", "redirected response echoes the target's query");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },

--- a/example/tests/gm_xhr_redirect_test.js
+++ b/example/tests/gm_xhr_redirect_test.js
@@ -201,14 +201,15 @@ const enableTool = true;
           new Promise(resolve => setTimeout(resolve, 4000)),
         ]);
         // NOT actually testing the server's real redirect status here: with
-        // redirect: "manual", GM_xhr routes through fetch()'s opaqueredirect
-        // response, whose real status the Fetch spec makes unreadable from
-        // JS. ScriptCat's fetch_xhr.ts hardcodes 301 in that branch as a
-        // fallback regardless of what the server actually sent - confirmed
-        // the live server returns 302 here (verified with curl), yet GM_xhr
-        // still reports 301. This assertion pins down ScriptCat's own known
-        // fallback value, not mockhttp.org's behavior.
-        assertEq(res?.status, 301, "status is 301 (ScriptCat's fixed fallback for opaque manual redirects, not the server's real code)");
+        // redirect: "manual", implementations of this option commonly route
+        // through fetch()'s opaqueredirect response, whose real status the
+        // Fetch spec makes unreadable from JS - so a manager typically falls
+        // back to a fixed status (often 301) rather than the server's actual
+        // code. Confirmed the live server here returns 302 (verified with
+        // curl), yet the reported status is 301 regardless. This assertion
+        // pins down that fixed fallback value, not mockhttp.org's behavior -
+        // if your manager reports a different fallback, adjust accordingly.
+        assertEq(res?.status, 301, "status is 301 (manager's fixed fallback for opaque manual redirects, not the server's real code)");
         assertEq(res?.finalUrl, url, "finalUrl is original url");
         assertEq(typeof res?.responseHeaders === "string" && res?.responseHeaders !== "", true, "responseHeaders ok");
         assertEq(objectProps(res), "ok", "Object Props OK");

--- a/example/tests/gm_xhr_redirect_test.js
+++ b/example/tests/gm_xhr_redirect_test.js
@@ -6,7 +6,7 @@
 // @author       you
 // @match        *://*/*?GM_XHR_REDIRECT_TEST_SC
 // @grant        GM_xmlhttpRequest
-// @connect      httpbun.com
+// @connect      mockhttp.org
 // @noframes
 // ==/UserScript==
 
@@ -104,7 +104,7 @@ const enableTool = true;
     });
   }
 
-  const HB = "https://httpbun.com";
+  const HB = "https://mockhttp.org";
 
   // ---------- Assertion utils ----------
   function assertEq(a, b, msg) {
@@ -131,9 +131,9 @@ const enableTool = true;
       async run(fetch) {
         const { res } = await gmRequest({ method: "GET", url: `${HB}/get?testing=234&abc=567`, responseType: "json", fetch });
         assertEq(res.status, 200, "status 200");
-        assertEq(res.response?.args?.testing, "234", "response ok");
-        assertEq(res.response?.args?.abc, "567", "response ok");
-        assertEq(res.response?.url, `${HB}/get?testing=234&abc=567`, "response ok");
+        assertEq(res.response?.queryParams?.testing, "234", "response ok");
+        assertEq(res.response?.queryParams?.abc, "567", "response ok");
+        assertEq(res.finalUrl, `${HB}/get?testing=234&abc=567`, "response ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -142,9 +142,9 @@ const enableTool = true;
       async run(fetch) {
         const { res } = await gmRequest({ method: "GET", url: `${HB}/get?abc=567&testing=234`, responseType: "json", fetch });
         assertEq(res.status, 200, "status 200");
-        assertEq(res.response?.args?.testing, "234", "response ok");
-        assertEq(res.response?.args?.abc, "567", "response ok");
-        assertEq(res.response?.url, `${HB}/get?abc=567&testing=234`, "response ok");
+        assertEq(res.response?.queryParams?.testing, "234", "response ok");
+        assertEq(res.response?.queryParams?.abc, "567", "response ok");
+        assertEq(res.finalUrl, `${HB}/get?abc=567&testing=234`, "response ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -194,7 +194,7 @@ const enableTool = true;
           gmRequest({ method: "GET", url, redirect: "manual", fetch }),
           new Promise(resolve => setTimeout(resolve, 4000)),
         ]);
-        assertEq(res?.status, 301, "status is 301");
+        assertEq(res?.status, 302, "status is 302");
         assertEq(res?.finalUrl, url, "finalUrl is original url");
         assertEq(typeof res?.responseHeaders === "string" && res?.responseHeaders !== "", true, "responseHeaders ok");
         assertEq(objectProps(res), "ok", "Object Props OK");

--- a/example/tests/gm_xhr_test.js
+++ b/example/tests/gm_xhr_test.js
@@ -450,10 +450,11 @@ const enableTool = true;
     return body.args || body.query || body.queryParams || body.params || {};
   }
 
-  const encodedBase64 =
-    "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZy4gVGhpcyBzZW50ZW5jZSBjb250YWlucyBldmVyeSBsZXR0ZXIgb2YgdGhlIEVuZ2xpc2ggYWxwaGFiZXQgYW5kIGlzIG9mdGVuIHVzZWQgZm9yIHR5cGluZyBwcmFjdGljZSwgZm9udCB0ZXN0aW5nLCBhbmQgZW5jb2RpbmcgZXhwZXJpbWVudHMuIEJhc2U2NCBlbmNvZGluZyB0cmFuc2Zvcm1zIHRoaXMgcmVhZGFibGUgdGV4dCBpbnRvIGEgc2VxdWVuY2Ugb2YgQVNDSUkgY2hhcmFjdGVycyB0aGF0IGNhbiBzYWZlbHkgYmUgdHJhbnNtaXR0ZWQgb3Igc3RvcmVkIGluIHN5c3RlbXMgdGhhdCBoYW5kbGUgdGV4dC1vbmx5IGRhdGEu";
-  const decodedBase64 =
-    "The quick brown fox jumps over the lazy dog. This sentence contains every letter of the English alphabet and is often used for typing practice, font testing, and encoding experiments. Base64 encoding transforms this readable text into a sequence of ASCII characters that can safely be transmitted or stored in systems that handle text-only data.";
+  // mockhttp.org's /base64/{value} route rejects path segments longer than
+  // ~100 characters with a 404 (undocumented limit, verified empirically), so
+  // the payload here must stay short unlike httpbun's unbounded /base64 route.
+  const encodedBase64 = "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZy4gUGFjayBteSBib3gh";
+  const decodedBase64 = "The quick brown fox jumps over the lazy dog. Pack my box!";
 
   // ---------- Tests ----------
   const basicTests = [

--- a/example/tests/gm_xhr_test.js
+++ b/example/tests/gm_xhr_test.js
@@ -6,7 +6,7 @@
 // @author       you
 // @match        *://*/*?GM_XHR_TEST_SC
 // @grant        GM_xmlhttpRequest
-// @connect      httpbun.com
+// @connect      mockhttp.org
 // @connect      nonexistent-domain-abcxyz.test
 // @connect      raw.githubusercontent.com
 // @connect      translate.googleapis.com
@@ -18,11 +18,12 @@
   --------------
   - Builds an in-page test runner panel.
   - Runs a battery of tests probing GM_xmlhttpRequest options, callbacks, and edge/abnormal paths.
-  - Uses httpbin.org endpoints for deterministic echo/response behavior.
+  - Uses mockhttp.org endpoints for deterministic echo/response behavior.
   - Prints a summary and a detailed per-test log with assertions.
 
-  NOTE: Endpoints now point to https://httpbun.com (a faster httpbin-like service).
-        See https://httpbun.com for docs and exact paths. (Also supports /get, /post, /bytes/{n}, /delay/{s}, /status/{code}, /redirect-to, /headers, /any, etc.)
+  NOTE: Endpoints point to https://mockhttp.org (open source, https://github.com/jaredwray/mockhttp).
+        See https://mockhttp.org for docs and exact paths. (Supports /get, /post, /put, /patch, /delete,
+        /anything, /bytes/{n}, /delay/{s}, /status/{code}, /redirect-to, /headers, /ip, /basic-auth, etc.)
 */
 
 /*
@@ -31,7 +32,7 @@
   ✓ method (GET/POST/PUT/DELETE/HEAD/OPTIONS)
   ✓ url & redirects (finalUrl)
   ✓ headers (custom headers echoed by server)
-  ✓ data (form-encoded, JSON, and raw/binary body)
+  ✓ data (JSON body; mockhttp.org only accepts application/json bodies)
   ✓ responseType: '', 'json', 'arraybuffer', 'blob'
   ✓ overrideMimeType
   ✓ timeout + ontimeout
@@ -39,7 +40,7 @@
   ✓ onload (non-2xx still onload)
   ✓ onerror (DNS/blocked host)
   ✓ onabort (manual abort)
-  ✓ anonymous (no cookies)
+  ✓ anonymous (basic-auth only; mockhttp.org's /cookies routes are stubs, see notes below)
   ✓ basic auth (user/password)
   ✓ edge cases: huge headers trimmed? invalid method; invalid URL; missing @connect domain triggers onerror
 */
@@ -439,14 +440,14 @@ const enableTool = true;
     });
   }
 
-  // Switched base host from httpbin to httpbun (faster).
-  // See: https://httpbun.com (endpoints: /get, /post, /bytes/{n}, /delay/{s}, /status/{code}, /redirect-to, /headers, /any, etc.)
-  const HB = "https://httpbun.com";
+  // Switched base host from httpbun to mockhttp.org (open source, more stable).
+  // See: https://mockhttp.org (endpoints: /get, /post, /bytes/{n}, /delay/{s}, /status/{code}, /redirect-to, /headers, /anything, etc.)
+  const HB = "https://mockhttp.org";
 
-  // Helper: handle minor schema diffs between httpbin/httpbun for query echo
+  // Helper: handle schema diffs across httpbin/httpbun/mockhttp for query echo
+  // (mockhttp's /get uses "queryParams"; /anything uses "args" like httpbin).
   function getQueryObj(body) {
-    // httpbin uses "args", httpbun may use "query" (and still often provides "args" for compatibility).
-    return body.args || body.query || body.params || {};
+    return body.args || body.query || body.queryParams || body.params || {};
   }
 
   const encodedBase64 =
@@ -602,8 +603,8 @@ const enableTool = true;
           fetch,
         });
         assertEq(res.status, 200, "status 200");
-        assertEq(`${res.responseText}`.includes('"code": 200'), true, "responseText ok");
-        assertEq(`${res.response}`.includes('"code": 200'), true, "response ok");
+        assertEq(`${res.responseText}`.includes("Response with status code 200"), true, "responseText ok");
+        assertEq(`${res.response}`.includes("Response with status code 200"), true, "response ok");
         assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
@@ -619,8 +620,8 @@ const enableTool = true;
           fetch,
         });
         assertEq(res.status, 200, "status 200");
-        assertEq(`${res.responseText}`.includes('"code": 200'), true, "responseText ok");
-        assertEq(`${res.response}`.includes('"code": 200'), true, "response ok");
+        assertEq(`${res.responseText}`.includes("Response with status code 200"), true, "responseText ok");
+        assertEq(`${res.response}`.includes("Response with status code 200"), true, "response ok");
         assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
@@ -636,8 +637,8 @@ const enableTool = true;
           fetch,
         });
         assertEq(res.status, 200, "status 200");
-        assertEq(`${res.responseText}`.includes('"code": 200'), true, "responseText ok");
-        assertEq(`${res.response}`.includes('"code": 200'), true, "response ok");
+        assertEq(`${res.responseText}`.includes("Response with status code 200"), true, "responseText ok");
+        assertEq(`${res.response}`.includes("Response with status code 200"), true, "response ok");
         assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
@@ -653,8 +654,12 @@ const enableTool = true;
           fetch,
         });
         assertEq(res.status, 200, "status 200");
-        assertEq(`${res.responseText}`.includes('"code": 200'), true, "responseText ok");
-        assertEq(typeof res.response === "object" && res.response?.code === 200, true, "response ok");
+        assertEq(`${res.responseText}`.includes("Response with status code 200"), true, "responseText ok");
+        assertEq(
+          typeof res.response === "object" && `${res.response?.status}`.includes("200"),
+          true,
+          "response ok"
+        );
         assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
@@ -670,7 +675,7 @@ const enableTool = true;
           fetch,
         });
         assertEq(res.status, 200, "status 200");
-        assertEq(`${res.responseText}`.includes('"code": 200'), true, "responseText ok");
+        assertEq(`${res.responseText}`.includes("Response with status code 200"), true, "responseText ok");
         assertEq(res.response instanceof XMLDocument, true, "response ok");
         assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
@@ -704,7 +709,7 @@ const enableTool = true;
           fetch,
         });
         assertEq(res.status, 200, "status 200");
-        assertEq(`${res.responseText}`.includes('"code": 200'), true, "responseText ok");
+        assertEq(`${res.responseText}`.includes("Response with status code 200"), true, "responseText ok");
         assertEq(res.response instanceof ArrayBuffer, true, "response ok");
         assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
@@ -721,7 +726,7 @@ const enableTool = true;
           fetch,
         });
         assertEq(res.status, 200, "status 200");
-        assertEq(`${res.responseText}`.includes('"code": 200'), true, "responseText ok");
+        assertEq(`${res.responseText}`.includes("Response with status code 200"), true, "responseText ok");
         assertEq(res.response instanceof Blob, true, "response ok");
         assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
@@ -955,30 +960,15 @@ const enableTool = true;
           }),
           new Promise((resolve) => setTimeout(resolve, 4000)),
         ]);
-        assertEq(res?.status, 301, "status is 301");
+        assertEq(res?.status, 302, "status is 302");
         assertEq(res?.finalUrl, url, "finalUrl is original url");
         assertEq(typeof res?.responseHeaders === "string" && res?.responseHeaders !== "", true, "responseHeaders ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
-    {
-      name: "POST form-encoded data",
-      async run(fetch) {
-        const params = new URLSearchParams({ a: "1", b: "two" }).toString();
-        const { res } = await gmRequest({
-          method: "POST",
-          url: `${HB}/post`,
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          data: params,
-          fetch,
-        });
-        const body = JSON.parse(res.responseText);
-        assertEq(res.status, 200);
-        assertEq((body.form || {}).a, "1", "form a");
-        assertEq((body.form || {}).b, "two", "form b");
-        assertEq(objectProps(res), "ok", "Object Props OK");
-      },
-    },
+    // Note: mockhttp.org's /post rejects application/x-www-form-urlencoded bodies
+    // with 415 Unsupported Media Type, so the form-encoded POST case from the
+    // httpbun/httpbin era can no longer be exercised against this server.
     {
       name: "POST JSON body",
       async run(fetch) {
@@ -992,27 +982,13 @@ const enableTool = true;
         });
         const body = JSON.parse(res.responseText);
         assertEq(res.status, 200);
-        assertDeepEq(body.json, payload, "JSON echo matches");
+        assertDeepEq(body.body, payload, "JSON echo matches");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
-    {
-      name: "Send binary body (Uint8Array) + responseType text",
-      async run(fetch) {
-        const bytes = new Uint8Array([1, 2, 3, 4, 5]);
-        const { res } = await gmRequest({
-          method: "POST",
-          url: `${HB}/post`,
-          binary: true,
-          data: bytes,
-          fetch,
-        });
-        const body = JSON.parse(res.responseText);
-        assertEq(res.status, 200);
-        assert(body.data && body.data.length > 0, "server received some data");
-        assertEq(objectProps(res), "ok", "Object Props OK");
-      },
-    },
+    // Note: mockhttp.org's /post (and /anything) reject any request body whose
+    // Content-Type is not application/json with 415 Unsupported Media Type, so
+    // raw/binary body upload can no longer be exercised against this server.
     {
       name: "responseType=arraybuffer (download bytes)",
       async run(fetch) {
@@ -1055,7 +1031,7 @@ const enableTool = true;
         assertEq(buf.byteLength, size, "byte length matches");
         assert(progressCounter >= 1, "progressCounter >= 1");
         assertEq(objectProps(res), "ok", "Object Props OK");
-        // Do not assert image MIME; httpbun returns octet-stream here.
+        // Do not assert image MIME; mockhttp returns octet-stream here.
       },
     },
     {
@@ -1070,7 +1046,7 @@ const enableTool = true;
         });
         assertEq(res.status, 200);
         assert(res.response && typeof res.response === "object", "parsed JSON object");
-        assert(res.response.origin, "has JSON fields");
+        assert(res.response.ip, "has JSON fields");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -1320,11 +1296,12 @@ const enableTool = true;
       async run(fetch) {
         const { res } = await gmRequest({
           method: "OPTIONS",
-          url: `${HB}/any`,
+          url: `${HB}/anything`,
           fetch,
         });
-        // httpbun commonly returns 200 for OPTIONS
-        assert(res.status === 200 || res.status === 204, "200/204 on OPTIONS");
+        // mockhttp.org has no OPTIONS route registered on any endpoint (returns 404),
+        // unlike httpbun which commonly returned 200 for OPTIONS.
+        assertEq(res.status, 404, "404 on OPTIONS (no route registered)");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -1342,116 +1319,10 @@ const enableTool = true;
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
-    {
-      name: 'anonymous TEST - set cookie "abc"',
-      async run(fetch) {
-        // httpbin echoes Cookie header in headers
-        const { res } = await gmRequest({
-          method: "GET",
-          url: `${HB}/cookies/set/abc/123`,
-          fetch,
-        });
-      },
-    },
-    {
-      name: "anonymous TEST - get cookie",
-      async run(fetch) {
-        // httpbin echoes Cookie header in headers
-        const { res } = await gmRequest({
-          method: "GET",
-          url: `${HB}/cookies`,
-          fetch,
-        });
-        assertEq(res.status, 200);
-        const body = JSON.parse(res.responseText);
-        const cookieABC = body.cookies.abc;
-        assertEq(cookieABC, "123", "cookie abc=123");
-        assertEq(objectProps(res), "ok", "Object Props OK");
-      },
-    },
-    {
-      name: "anonymous: true (no cookies sent)",
-      async run(fetch) {
-        // httpbin echoes Cookie header in headers
-        const { res } = await gmRequest({
-          method: "GET",
-          url: `${HB}/headers`,
-          anonymous: true,
-          fetch,
-        });
-        const body = JSON.parse(res.responseText);
-        const cookies = body.headers.Cookie || body.headers.cookie;
-        assert(!`${cookies}`.includes("abc=123"), "no Cookie header when anonymous");
-        assertEq(objectProps(res), "ok", "Object Props OK");
-      },
-    },
-    {
-      name: "anonymous: false (cookies sent)",
-      async run(fetch) {
-        // httpbin echoes Cookie header in headers
-        const { res } = await gmRequest({
-          method: "GET",
-          url: `${HB}/headers`,
-          fetch,
-        });
-        const body = JSON.parse(res.responseText);
-        const cookies = body.headers.Cookie || body.headers.cookie;
-        assert(`${cookies}`.includes("abc=123"), "Cookie header");
-        assertEq(objectProps(res), "ok", "Object Props OK");
-      },
-    },
-    {
-      name: "anonymous TEST - delete cookies",
-      async run(fetch) {
-        // httpbin echoes Cookie header in headers
-        const { res } = await gmRequest({
-          method: "GET",
-          url: `${HB}/cookies/delete`,
-          anonymous: true,
-          fetch,
-        });
-      },
-    },
-    {
-      name: 'anonymous: true[2] - set cookie "def"',
-      async run(fetch) {
-        // httpbin echoes Cookie header in headers
-        const { res } = await gmRequest({
-          method: "GET",
-          url: `${HB}/cookies/set/def/456`,
-          anonymous: true,
-          fetch,
-        });
-      },
-    },
-    {
-      name: "anonymous: true[2] (no cookies sent)",
-      async run(fetch) {
-        // httpbin echoes Cookie header in headers
-        const { res } = await gmRequest({
-          method: "GET",
-          url: `${HB}/headers`,
-          anonymous: true,
-          fetch,
-        });
-        const body = JSON.parse(res.responseText);
-        const cookies = body.headers.Cookie || body.headers.cookie;
-        assert(!cookies, "no Cookie header when anonymous");
-        assertEq(objectProps(res), "ok", "Object Props OK");
-      },
-    },
-    {
-      name: "anonymous TEST - delete cookies",
-      async run(fetch) {
-        // httpbin echoes Cookie header in headers
-        const { res } = await gmRequest({
-          method: "GET",
-          url: `${HB}/cookies/delete`,
-          anonymous: true,
-          fetch,
-        });
-      },
-    },
+    // Note: mockhttp.org's /cookies/set and /cookies/delete don't actually emit a
+    // Set-Cookie header (its /cookies routes are stubs, unlike httpbin/httpbun),
+    // so the anonymous-mode cookie round-trip suite can no longer be verified
+    // against this server and was removed.
     {
       name: "Basic auth with user/password",
       async run(fetch) {
@@ -1485,15 +1356,17 @@ const enableTool = true;
       },
     },
     {
-      name: "Invalid method -> expected server 405 or 200 echo",
+      name: "Invalid method -> expected server error/echo",
       async run(fetch) {
-        // httpbun accepts any method on /headers (per docs), so status may be 200
+        // mockhttp.org's edge (Cloudflare) doesn't recognize non-standard HTTP
+        // methods and returns a 502, rather than routing them to the app like
+        // httpbun did (which echoed 200/405 depending on the route).
         const { res } = await gmRequest({
           method: "FOOBAR",
           url: `${HB}/headers`,
           fetch,
         });
-        assert([200, 405].includes(res.status), "200 or 405 depending on server handling");
+        assert([200, 404, 405, 502].includes(res.status), "200/404/405/502 depending on server handling");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -1612,8 +1485,12 @@ const enableTool = true;
           onprogress() {},
         });
         assertEq(res.status, 200, "status 200");
-        assertEq(`${res.responseText}`.includes('"code": 200'), true, "responseText ok");
-        assertEq(typeof res.response === "object" && res.response?.code === 200, true, "response ok");
+        assertEq(`${res.responseText}`.includes("Response with status code 200"), true, "responseText ok");
+        assertEq(
+          typeof res.response === "object" && `${res.response?.status}`.includes("200"),
+          true,
+          "response ok"
+        );
         assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
@@ -1633,8 +1510,12 @@ const enableTool = true;
           },
         });
         assertEq(res.status, 200, "status 200");
-        assertEq(`${res.responseText}`.includes('"code": 200'), true, "responseText ok");
-        assertEq(typeof res.response === "object" && res.response?.code === 200, true, "response ok");
+        assertEq(`${res.responseText}`.includes("Response with status code 200"), true, "responseText ok");
+        assertEq(
+          typeof res.response === "object" && `${res.response?.status}`.includes("200"),
+          true,
+          "response ok"
+        );
         assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
         assertDeepEq(readyStateList, fetch ? [2, 4] : [1, 2, 3, 4], "status 200");
         assertEq(objectProps(res), "ok", "Object Props OK");

--- a/example/tests/gm_xhr_test.js
+++ b/example/tests/gm_xhr_test.js
@@ -900,6 +900,13 @@ const enableTool = true;
         });
         assertEq(res.status, 200, "status after redirect is 200");
         assertEq(res.finalUrl, target, "finalUrl is redirected target");
+        // finalUrl alone only proves the client thinks it followed the
+        // redirect - confirm the server actually served /get's response,
+        // not e.g. a cached/stale/error body that happens to carry a 200.
+        const body = JSON.parse(res.responseText);
+        assertEq(body.method, "GET", "redirected request reached /get as GET");
+        const q = getQueryObj(body);
+        assertEq(q.z, "92", "redirected response echoes the target's query");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -916,6 +923,10 @@ const enableTool = true;
         });
         assertEq(res.status, 200, "status after redirect is 200");
         assertEq(res.finalUrl, target, "finalUrl is redirected target");
+        const body = JSON.parse(res.responseText);
+        assertEq(body.method, "GET", "redirected request reached /get as GET");
+        const q = getQueryObj(body);
+        assertEq(q.z, "94", "redirected response echoes the target's query");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },

--- a/example/tests/gm_xhr_test.js
+++ b/example/tests/gm_xhr_test.js
@@ -470,7 +470,10 @@ const enableTool = true;
         assertEq(res.status, 200, "status 200");
         assertEq(res.responseText, decodedBase64, "responseText ok");
         assertEq(res.response, decodedBase64, "response ok");
-        assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
+        // mockhttp.org serves /base64 as text/html (unlike httpbun's plain
+        // text), so GM_xhr correctly parses responseXML as an HTMLDocument
+        // rather than an XMLDocument - check the common base class instead.
+        assertEq(res.responseXML instanceof Document, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -487,7 +490,7 @@ const enableTool = true;
         assertEq(res.status, 200, "status 200");
         assertEq(res.responseText, decodedBase64, "responseText ok");
         assertEq(res.response, decodedBase64, "response ok");
-        assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
+        assertEq(res.responseXML instanceof Document, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -504,7 +507,7 @@ const enableTool = true;
         assertEq(res.status, 200, "status 200");
         assertEq(res.responseText, decodedBase64, "responseText ok");
         assertEq(res.response, decodedBase64, "response ok");
-        assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
+        assertEq(res.responseXML instanceof Document, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -522,7 +525,7 @@ const enableTool = true;
         assertEq(res.status, 200, "status 200");
         assertEq(res.responseText, decodedBase64, "responseText ok");
         assertEq(res.response, undefined, "response ok");
-        assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
+        assertEq(res.responseXML instanceof Document, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -538,8 +541,8 @@ const enableTool = true;
         });
         assertEq(res.status, 200, "status 200");
         assertEq(res.responseText, decodedBase64, "responseText ok");
-        assertEq(res.response instanceof XMLDocument, true, "response ok");
-        assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
+        assertEq(res.response instanceof Document, true, "response ok");
+        assertEq(res.responseXML instanceof Document, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -573,7 +576,7 @@ const enableTool = true;
         assertEq(res.status, 200, "status 200");
         assertEq(res.responseText, decodedBase64, "responseText ok");
         assertEq(res.response instanceof ArrayBuffer, true, "response ok");
-        assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
+        assertEq(res.responseXML instanceof Document, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -590,7 +593,7 @@ const enableTool = true;
         assertEq(res.status, 200, "status 200");
         assertEq(res.responseText, decodedBase64, "responseText ok");
         assertEq(res.response instanceof Blob, true, "response ok");
-        assertEq(res.responseXML instanceof XMLDocument, true, "responseXML ok");
+        assertEq(res.responseXML instanceof Document, true, "responseXML ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
@@ -972,7 +975,16 @@ const enableTool = true;
           }),
           new Promise((resolve) => setTimeout(resolve, 4000)),
         ]);
-        assertEq(res?.status, 302, "status is 302");
+        // NOT actually testing the server's real redirect status here: with
+        // redirect: "manual", GM_xhr routes through fetch()'s opaqueredirect
+        // response, whose real status the Fetch spec makes unreadable from
+        // JS. ScriptCat's fetch_xhr.ts hardcodes 301 in that branch as a
+        // fallback (see src/pkg/utils/xhr/fetch_xhr.ts) regardless of what
+        // the server actually sent - confirmed the live server returns 302
+        // here (verified with curl), yet GM_xhr still reports 301. This
+        // assertion is really pinning down ScriptCat's own known fallback
+        // value, not mockhttp.org's behavior.
+        assertEq(res?.status, 301, "status is 301 (ScriptCat's fixed fallback for opaque manual redirects, not the server's real code)");
         assertEq(res?.finalUrl, url, "finalUrl is original url");
         assertEq(typeof res?.responseHeaders === "string" && res?.responseHeaders !== "", true, "responseHeaders ok");
         assertEq(objectProps(res), "ok", "Object Props OK");
@@ -1078,8 +1090,15 @@ const enableTool = true;
       },
     },
     {
-      name: "responseType=document(parser error)",
+      name: "responseType=document(binary content doesn't throw)",
       async run(fetch) {
+        // mockhttp.org serves /base64 as text/html (unlike whatever content
+        // type httpbun used), so GM_xhr parses this in HTML mode, not XML
+        // mode. HTML parsing never fails/produces a <parsererror> element
+        // the way XML parsing of malformed content does - it's maximally
+        // lenient by design - so this can no longer test the XML
+        // parser-error path. What's still worth verifying: binary garbage
+        // parses gracefully as HTML instead of throwing.
         const { res } = await gmRequest({
           method: "GET",
           url: `${HB}/base64/AAAAAAEAAQA=`,
@@ -1087,9 +1106,8 @@ const enableTool = true;
           fetch,
         });
         assertEq(res.status, 200);
-        assert(res.response instanceof Document, "xml present");
-        assert(res.responseXML !== null, "xml OK");
-        assert(!!res.responseXML.querySelector("parsererror"), "xml content ok");
+        assert(res.response instanceof Document, "document present");
+        assert(res.responseXML !== null, "responseXML present");
       },
     },
     {
@@ -1204,7 +1222,13 @@ const enableTool = true;
         let progressEvents = 0;
         let lastLoaded = 0;
         let response = null;
-        // Use drip endpoint to stream bytes
+        // Use drip endpoint to stream bytes. Note: mockhttp.org is fronted by
+        // Cloudflare, which buffers the entire response server-side before
+        // releasing it - verified directly (a raw socket read showed all
+        // bytes arriving in one burst at the very end, regardless of the
+        // requested drip duration/delay). So unlike a truly incremental
+        // download, this can't be expected to produce multiple progress
+        // events; only that progress fires at least once, at completion.
         const { res } = await new Promise((resolve, reject) => {
           const start = performance.now();
           GM_xmlhttpRequest({
@@ -1224,7 +1248,7 @@ const enableTool = true;
           });
         });
         assertEq(res.status, 200);
-        assert(progressEvents >= 4, "received at least 4 progress events");
+        assert(progressEvents >= 1, "received at least 1 progress event");
         // `progress` is guaranteed to fire only in the Fetch API.
         assert(fetch ? lastLoaded > 0 : lastLoaded >= 0, "progress loaded captured");
         assert(!response, "no response");
@@ -1237,7 +1261,12 @@ const enableTool = true;
         let progressEvents = 0;
         let lastLoaded = 0;
         let response = null;
-        // Use drip endpoint to stream bytes
+        // Use drip endpoint to stream bytes. Note: mockhttp.org is fronted by
+        // Cloudflare, which buffers the entire response server-side before
+        // releasing it - verified directly (a raw socket read showed all
+        // bytes arriving in one burst at the very end, regardless of the
+        // requested drip duration/delay). So the reader below is expected to
+        // see the whole payload in essentially one read(), not several.
         const { res } = await new Promise((resolve, reject) => {
           const start = performance.now();
           GM_xmlhttpRequest({
@@ -1268,7 +1297,7 @@ const enableTool = true;
           });
         });
         assertEq(res.status, 200);
-        assert(progressEvents >= 4, "received at least 4 progress events");
+        assert(progressEvents >= 1, "received at least 1 progress event");
         // `progress` is guaranteed to fire only in the Fetch API.
         assert(fetch ? lastLoaded > 0 : lastLoaded >= 0, "progress loaded captured");
         assert(response instanceof ReadableStream && typeof response.getReader === "function", "response");

--- a/example/tests/gm_xhr_test.js
+++ b/example/tests/gm_xhr_test.js
@@ -40,7 +40,7 @@
   ✓ onload (non-2xx still onload)
   ✓ onerror (DNS/blocked host)
   ✓ onabort (manual abort)
-  ✓ anonymous (basic-auth only; mockhttp.org's /cookies routes are stubs, see notes below)
+  ✓ anonymous (no cookies)
   ✓ basic auth (user/password)
   ✓ edge cases: huge headers trimmed? invalid method; invalid URL; missing @connect domain triggers onerror
 */
@@ -1319,10 +1319,123 @@ const enableTool = true;
         assertEq(objectProps(res), "ok", "Object Props OK");
       },
     },
-    // Note: mockhttp.org's /cookies/set and /cookies/delete don't actually emit a
-    // Set-Cookie header (its /cookies routes are stubs, unlike httpbin/httpbun),
-    // so the anonymous-mode cookie round-trip suite can no longer be verified
-    // against this server and was removed.
+    // Note: mockhttp.org has a single REST-style /cookies resource (POST to set,
+    // GET to read, DELETE?name= to clear one), unlike httpbin/httpbun's
+    // /cookies/set/{name}/{value} and /cookies/delete path-style routes.
+    {
+      name: 'anonymous TEST - set cookie "abc"',
+      async run(fetch) {
+        // mockhttp echoes Set-Cookie for a POST /cookies {name, value} body
+        const { res } = await gmRequest({
+          method: "POST",
+          url: `${HB}/cookies`,
+          headers: { "Content-Type": "application/json" },
+          data: JSON.stringify({ name: "abc", value: "123" }),
+          fetch,
+        });
+      },
+    },
+    {
+      name: "anonymous TEST - get cookie",
+      async run(fetch) {
+        // mockhttp echoes the request's Cookie header via GET /cookies
+        const { res } = await gmRequest({
+          method: "GET",
+          url: `${HB}/cookies`,
+          fetch,
+        });
+        assertEq(res.status, 200);
+        const body = JSON.parse(res.responseText);
+        const cookieABC = body.cookies.abc;
+        assertEq(cookieABC, "123", "cookie abc=123");
+        assertEq(objectProps(res), "ok", "Object Props OK");
+      },
+    },
+    {
+      name: "anonymous: true (no cookies sent)",
+      async run(fetch) {
+        // mockhttp echoes Cookie header in headers
+        const { res } = await gmRequest({
+          method: "GET",
+          url: `${HB}/headers`,
+          anonymous: true,
+          fetch,
+        });
+        const body = JSON.parse(res.responseText);
+        const cookies = body.headers.Cookie || body.headers.cookie;
+        assert(!`${cookies}`.includes("abc=123"), "no Cookie header when anonymous");
+        assertEq(objectProps(res), "ok", "Object Props OK");
+      },
+    },
+    {
+      name: "anonymous: false (cookies sent)",
+      async run(fetch) {
+        // mockhttp echoes Cookie header in headers
+        const { res } = await gmRequest({
+          method: "GET",
+          url: `${HB}/headers`,
+          fetch,
+        });
+        const body = JSON.parse(res.responseText);
+        const cookies = body.headers.Cookie || body.headers.cookie;
+        assert(`${cookies}`.includes("abc=123"), "Cookie header");
+        assertEq(objectProps(res), "ok", "Object Props OK");
+      },
+    },
+    {
+      name: "anonymous TEST - delete cookies",
+      async run(fetch) {
+        // mockhttp deletes one named cookie per call via DELETE /cookies?name=
+        const { res } = await gmRequest({
+          method: "DELETE",
+          url: `${HB}/cookies?name=abc`,
+          anonymous: true,
+          fetch,
+        });
+      },
+    },
+    {
+      name: 'anonymous: true[2] - set cookie "def"',
+      async run(fetch) {
+        // mockhttp echoes Set-Cookie for a POST /cookies {name, value} body
+        const { res } = await gmRequest({
+          method: "POST",
+          url: `${HB}/cookies`,
+          headers: { "Content-Type": "application/json" },
+          data: JSON.stringify({ name: "def", value: "456" }),
+          anonymous: true,
+          fetch,
+        });
+      },
+    },
+    {
+      name: "anonymous: true[2] (no cookies sent)",
+      async run(fetch) {
+        // mockhttp echoes Cookie header in headers
+        const { res } = await gmRequest({
+          method: "GET",
+          url: `${HB}/headers`,
+          anonymous: true,
+          fetch,
+        });
+        const body = JSON.parse(res.responseText);
+        const cookies = body.headers.Cookie || body.headers.cookie;
+        assert(!cookies, "no Cookie header when anonymous");
+        assertEq(objectProps(res), "ok", "Object Props OK");
+      },
+    },
+    {
+      name: "anonymous TEST - delete cookies",
+      async run(fetch) {
+        // mockhttp deletes one named cookie per call via DELETE /cookies?name=
+        const { res } = await gmRequest({
+          method: "DELETE",
+          url: `${HB}/cookies?name=def`,
+          anonymous: true,
+          fetch,
+        });
+      },
+    },
     {
       name: "Basic auth with user/password",
       async run(fetch) {

--- a/example/tests/gm_xhr_test.js
+++ b/example/tests/gm_xhr_test.js
@@ -976,15 +976,15 @@ const enableTool = true;
           new Promise((resolve) => setTimeout(resolve, 4000)),
         ]);
         // NOT actually testing the server's real redirect status here: with
-        // redirect: "manual", GM_xhr routes through fetch()'s opaqueredirect
-        // response, whose real status the Fetch spec makes unreadable from
-        // JS. ScriptCat's fetch_xhr.ts hardcodes 301 in that branch as a
-        // fallback (see src/pkg/utils/xhr/fetch_xhr.ts) regardless of what
-        // the server actually sent - confirmed the live server returns 302
-        // here (verified with curl), yet GM_xhr still reports 301. This
-        // assertion is really pinning down ScriptCat's own known fallback
-        // value, not mockhttp.org's behavior.
-        assertEq(res?.status, 301, "status is 301 (ScriptCat's fixed fallback for opaque manual redirects, not the server's real code)");
+        // redirect: "manual", implementations of this option commonly route
+        // through fetch()'s opaqueredirect response, whose real status the
+        // Fetch spec makes unreadable from JS - so a manager typically falls
+        // back to a fixed status (often 301) rather than the server's actual
+        // code. Confirmed the live server here returns 302 (verified with
+        // curl), yet the reported status is 301 regardless. This assertion
+        // pins down that fixed fallback value, not mockhttp.org's behavior -
+        // if your manager reports a different fallback, adjust accordingly.
+        assertEq(res?.status, 301, "status is 301 (manager's fixed fallback for opaque manual redirects, not the server's real code)");
         assertEq(res?.finalUrl, url, "finalUrl is original url");
         assertEq(typeof res?.responseHeaders === "string" && res?.responseHeaders !== "", true, "responseHeaders ok");
         assertEq(objectProps(res), "ok", "Object Props OK");

--- a/example/tests/window_message_test.js
+++ b/example/tests/window_message_test.js
@@ -9,7 +9,7 @@
 // @grant        GM_xmlhttpRequest
 // @grant        GM.setClipboard
 // @grant        unsafeWindow
-// @connect      httpbun.com
+// @connect      mockhttp.org
 // @run-at       document-end
 // @noframes
 // ==/UserScript==
@@ -94,20 +94,21 @@
     const response = await withTimeout(
       GM.xmlHttpRequest({
         method: "GET",
-        url: `https://httpbun.com/get?marker=${encodeURIComponent(marker)}`,
+        url: `https://mockhttp.org/get?marker=${encodeURIComponent(marker)}`,
         responseType: "json",
       }),
       "GM.xmlHttpRequest",
     );
 
     assertSame(200, response.status, "status should be 200");
-    assertTrue(response.finalUrl.includes("httpbun.com/get"), "finalUrl should be populated");
+    assertTrue(response.finalUrl.includes("mockhttp.org/get"), "finalUrl should be populated");
     assertTrue(typeof response.responseHeaders === "string", "responseHeaders should be a string");
     assertTrue(response.response && typeof response.response === "object", "JSON response should be parsed");
 
     const args =
       response.response.args ||
       response.response.query ||
+      response.response.queryParams ||
       response.response.params ||
       {};
     assertSame(marker, args.marker, "query marker should round-trip through the response");
@@ -119,7 +120,7 @@
       new Promise((resolve, reject) => {
         GM_xmlhttpRequest({
           method: "GET",
-          url: "https://httpbun.com/bytes/64",
+          url: "https://mockhttp.org/bytes/64",
           onreadystatechange: (res) => {
             states.push(res.readyState);
           },
@@ -142,7 +143,7 @@
       new Promise((resolve, reject) => {
         const request = GM_xmlhttpRequest({
           method: "GET",
-          url: "https://httpbun.com/delay/5",
+          url: "https://mockhttp.org/delay/5",
           onload: () => reject(new Error("request loaded before abort")),
           onerror: reject,
           ontimeout: reject,

--- a/src/app/service/service_worker/gm_api/mv3_utils.ts
+++ b/src/app/service/service_worker/gm_api/mv3_utils.ts
@@ -14,8 +14,8 @@ type TbgMarkerMapEntry = {
 const bgMarkerMap = new Map<string, TbgMarkerMapEntry>();
 export const normalizeBackgroundRequestUrl = (url: string) => {
   const u = new URL(url);
-  // input "https://user:passwd@httpbun.com/basic-auth/user/passwd?q=1&r=2"
-  // output "https://httpbun.com/basic-auth/user/passwd?q=1&r=2"
+  // input "https://user:passwd@mockhttp.org/basic-auth/user/passwd?q=1&r=2"
+  // output "https://mockhttp.org/basic-auth/user/passwd?q=1&r=2"
   return `${u.origin}${u.pathname}${u.search}`;
 };
 

--- a/tests/example/crontab.test.ts
+++ b/tests/example/crontab.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 type RequestDetails = {
   url: string;
-  onload: (response: { status: number; response: unknown }) => void;
+  onload: (response: { status: number; finalUrl: string; response: unknown }) => void;
 };
 
 const source = readFileSync(resolve(process.cwd(), "example/crontab/crontab.js"), "utf8");
@@ -14,23 +14,24 @@ const runExample = new Function("GM_log", "GM_xmlhttpRequest", source) as (
 ) => Promise<void>;
 
 describe("定时脚本示例", () => {
-  it("定时请求 httpbun 并记录响应 URL", async () => {
+  it("定时请求 mockhttp 并记录响应 URL", async () => {
     const log = vi.fn();
     let requestDetails: RequestDetails | undefined;
     const result = runExample(log, (details) => {
       requestDetails = details;
     });
 
-    expect(requestDetails?.url).toBe("https://httpbun.com/get");
+    expect(requestDetails?.url).toBe("https://mockhttp.org/get");
 
     requestDetails?.onload({
       status: 200,
+      finalUrl: "https://mockhttp.org/get",
       response: {
-        url: "https://httpbun.com/get",
+        method: "GET",
       },
     });
 
     await expect(result).resolves.toBeUndefined();
-    expect(log).toHaveBeenCalledWith("定时请求成功：\nhttps://httpbun.com/get");
+    expect(log).toHaveBeenCalledWith("定时请求成功：\nhttps://mockhttp.org/get");
   });
 });


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 已修复或实现
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## 背景

httpbun.com 近期频繁出现 502 错误，导致相关测试不稳定。改用开源、可自托管的 [mockhttp.org](https://github.com/jaredwray/mockhttp)（更稳定）。mockhttp.org 并非 httpbun/httpbin 的行为复刻，实测发现两者在多个端点上的响应结构、状态码、内容协商等方面存在真实差异——本 PR 不是单纯替换域名字符串，而是对每一处差异逐一核实（curl / 原始 TLS socket 抓包 / 实际浏览器运行测试脚本）并相应调整断言。

## 本次改动

**域名替换**：`example/tests/*.js`、`example/crontab/crontab.js`、`e2e/gm-api.spec.ts`、`src/app/service/service_worker/gm_api/mv3_utils.ts` 中的 `httpbun.com` 全部替换为 `mockhttp.org`。`e2e/gm-api.spec.ts` 中用于替换 `@connect`/URL 的正则同步更新；本地 mock server 的 `/get` 响应新增 `method` 字段，以配合 sync/async GM API 测试新增的 `finalUrl`/`method` 断言。

**响应结构差异适配**：
- `/get` 返回 `queryParams` 字段而非 httpbin 风格的 `url`/`args`，相关测试改用 `finalUrl`（XHR 框架自带字段）或 `queryParams` 校验。
- `/status/:code` 响应体格式不同（`{"status":"..."}` 而非 httpbin 风格的 `{"code":...}`），已同步调整字符串匹配。
- `/base64/:value` 以 `Content-Type: text/html` 提供内容（httpbun 并非如此），`GM_xhr` 按自身 MIME 类型表（`docParseTypes`，见 `src/app/service/content/gm_api/gm_xhr.ts`）正确地以 HTML 模式解析 `responseXML`，得到 `HTMLDocument` 而非 `XMLDocument`——涉及的 7 项 `GET basic [responseType: *]` 断言已从 `instanceof XMLDocument` 改为 `instanceof Document`。
- `responseType=document(parser error)` 用例原依赖 XML 解析失败产生 `<parsererror>` 元素，但 HTML 解析模式永远不会产生该元素；已重写为验证二进制垃圾数据以 HTML 模式解析不会抛出异常，而非依赖已不可复现的解析错误路径。
- `/redirect-to` 默认返回 `302`（而非 httpbun 的 `301`）；重定向后续 `[default]`/`[follow]` 用例此前只校验 `finalUrl`，未校验响应体内容——已补充校验重定向目标的响应体 `method`/`queryParams`，确保验证的是"服务端确实返回了正确响应"而非仅"客户端认为自己跟随了重定向"。
- `/cookies` 是单一 REST 资源（`POST` 设置、`GET` 读取、`DELETE?name=` 清除单个），而非 httpbin 风格的 `/cookies/set/{name}/{value}` 路径式接口。初版误判该端点为无状态桩并整体移除了相关测试，后经 curl 逐步验证真实的 `Set-Cookie`/`Cookie` 往返行为后，按正确的接口形状恢复了完整的匿名 cookie 测试集群。
- `/post` 仅接受 `application/json` 请求体（表单编码/二进制请求体会返回 415），已移除无法在新端点验证的用例并注明原因（对应 mockhttp 侧的修复见下方"关联"）。
- 全站无 `OPTIONS` 路由（统一 404），自定义 HTTP 方法会在边缘节点返回 502，已放宽相应断言的预期状态码集合。

**根据实际浏览器运行结果修复**（用户执行 `gm_xhr_test.js` v1.3.0 后反馈 112 通过 / 22 失败，逐项排查根因）：
- `Redirect handling [manual]`：更正了此前的错误判断——这并非 mockhttp 302 vs httpbun 301 的服务端差异，而是 ScriptCat/Tampermonkey 自身的已知行为：`redirect: "manual"` 会走 fetch 路径，Fetch 规范使 `opaqueredirect` 响应的真实状态码不可从 JS 读取，管理器通常会硬编码一个回退状态码（常见为 301）而非服务器真实返回值（已用 curl 反复确认 mockhttp.org 该端点始终返回 302，但 `GM_xmlhttpRequest` 仍报告 301）。断言改回 `301` 并补充准确注释；相关表述已泛化，避免点名具体管理器或内部实现路径（该测试脚本本身可在 ScriptCat 或 Tampermonkey 下运行）。
- `onprogress fires while downloading [stream]/[arraybuffer]`：用原始 TLS socket 抓包确认 mockhttp.org（经 Cloudflare 代理）会把整个响应体在服务端缓冲后一次性下发，不会按 `/drip` 参数真正分批下发字节，因此 `onprogress` 不可能触发 4 次以上。断言从 `>=4` 放宽为 `>=1` 并在注释中记录抓包证据。

## 已知限制

- `onprogress` 断言目前为 `>=1`（而非原先针对 httpbun 的 `>=4`），因为 mockhttp.org 的公共实例（Cloudflare + Google Cloud Run）会缓冲整个响应体后一次性下发，与 `/drip` 声明的分批下发时长无关。已向 mockhttp 提交 [jaredwray/mockhttp#164](https://github.com/jaredwray/mockhttp/pull/164) 增加 `unbuffered` 参数尝试绕过代理缓冲；该 PR 尚未合并/部署，即便合并后也需要该仓库测试脚本改用该参数才能恢复 `>=4` 断言，本 PR 暂不依赖其结果。
- 表单编码 POST、二进制 POST body 相关测试用例已移除（保留说明性注释），因为 mockhttp.org 当前对非 `application/json` 请求体统一返回 415。已提交 [jaredwray/mockhttp#161](https://github.com/jaredwray/mockhttp/pull/161)（表单编码支持）与 [#163](https://github.com/jaredwray/mockhttp/pull/163)（原始/二进制 body 支持），均尚未合并；一旦合并部署，可考虑恢复这些用例。
- `OPTIONS request` 测试当前预期 404（`/anything` 无 `OPTIONS` 路由）。已提交 [jaredwray/mockhttp#162](https://github.com/jaredwray/mockhttp/pull/162) 为 `/anything` 增加 `OPTIONS` 支持，尚未合并；合并部署后需将该断言改回 200，否则会转为失败。
- `Redirect handling [manual]` 断言的是 ScriptCat/Tampermonkey 自身对 `redirect: "manual"` 的已知回退行为（固定报告 301），而非 mockhttp.org 的真实状态码；这是一个独立于本次迁移的产品行为，已作为后续任务跟进（`fetch_xhr.ts` 是否可通过 `chrome.webRequest` 拿到真实状态码），不在本 PR 范围内修复。
- `example/tests/gm_xhr_test.js` 与 `gm_xhr_redirect_test.js` 属于手动验证脚本（`docs/verification.md` 工作流），不在自动化 CI（`e2e/gm-api.spec.ts`）覆盖范围内——CI 覆盖的 `gm_api_sync_test.js`/`gm_api_async_test.js`/`window_message_test.js` 均通过本地 mock server 运行，不受 mockhttp.org 真实端点行为影响。

## 建议审查重点

- `example/tests/gm_xhr_test.js` 中 `responseXML`/`response` 从 `instanceof XMLDocument` 改为 `instanceof Document` 的 7 处改动，是否符合预期（`docParseTypes` 判定逻辑见 `src/app/service/content/gm_api/gm_xhr.ts:121-129,374-393`）。
- `Redirect handling [manual]` 断言维持 `301` 而非 `302` 的注释是否清晰易懂——这是在验证管理器自身的已知回退值，而非服务器真实状态码。
- 移除的表单编码/二进制 body 测试用例、cookie 测试集群的恢复方式，是否符合 "只做当前端点能验证的事" 的取舍。

## 关联

配合本次迁移，已向 [jaredwray/mockhttp](https://github.com/jaredwray/mockhttp) 提交以下上游 PR（均为独立问题，未合并；不影响本 PR 的可合并性）：
- [#160](https://github.com/jaredwray/mockhttp/pull/160) `/base64/:value` 路径参数超过约 100 字符时静默 404（find-my-way 默认 `maxParamLength`）
- [#161](https://github.com/jaredwray/mockhttp/pull/161) `/post`、`/anything` 支持 `application/x-www-form-urlencoded` 请求体
- [#162](https://github.com/jaredwray/mockhttp/pull/162) `/anything` 支持 `OPTIONS` 方法
- [#163](https://github.com/jaredwray/mockhttp/pull/163) `/post`、`/anything` 支持原始/二进制请求体
- [#164](https://github.com/jaredwray/mockhttp/pull/164) `/drip` 增加 `unbuffered` 参数，尝试绕过反向代理缓冲

## 验证

- `pnpm exec vitest run tests/example/crontab.test.ts` — 通过
- `pnpm exec tsc --noEmit` — 无相关错误
- `pnpm exec eslint` / `pnpm exec prettier --check` — 无相关错误
- `pnpm build && npx playwright test e2e/gm-api.spec.ts` — 全部 7 个用例通过（sync/async GM API、WindowMessage、CSP、sandbox、inject、unwrap）
- 对 mockhttp.org 各端点（`/get`、`/post`、`/anything`、`/bytes`、`/delay`、`/status`、`/redirect-to`、`/basic-auth`、`/headers`、`/ip`、`/cookies`、`/drip`、`/base64`）逐一 curl 及原始 TLS socket 抓包验证实际行为，确认迁移后测试脚本的断言与真实响应一致
- 由用户在真实浏览器扩展中实际执行 `gm_xhr_test.js` v1.3.0（`example/tests/`），首次运行反馈 ✅112 ❌22；后续针对 22 处失败逐项排查根因并修复，均已通过对照 mockhttp.org 真实响应验证，但修复后未再次于浏览器中完整重跑该手动测试脚本进行最终确认
