### PR TITLE
✨ 图标服务新增「禁用」档，彻底关闭 favicon 获取

### DIFF
--- a/src/locales/de-DE/settings.json
+++ b/src/locales/de-DE/settings.json
@@ -124,6 +124,7 @@
   },
   "favicon_service": "Favicon-Dienst",
   "favicon_service_desc": "Dienst zum Abrufen von Website-Symbolen auswählen",
+  "favicon_service_none": "Deaktiviert",
   "favicon_service_scriptcat": "ScriptCat",
   "favicon_service_google": "Google",
   "favicon_service_duckduckgo": "DuckDuckGo",

--- a/src/locales/en-US/settings.json
+++ b/src/locales/en-US/settings.json
@@ -124,6 +124,7 @@
   },
   "favicon_service": "Favicon Service",
   "favicon_service_desc": "Choose the service for fetching website icons",
+  "favicon_service_none": "Disabled",
   "favicon_service_scriptcat": "ScriptCat",
   "favicon_service_google": "Google",
   "favicon_service_duckduckgo": "DuckDuckGo",

--- a/src/locales/ja-JP/settings.json
+++ b/src/locales/ja-JP/settings.json
@@ -124,6 +124,7 @@
   },
   "favicon_service": "Favicon サービス",
   "favicon_service_desc": "ウェブサイトアイコンの取得サービスを選択",
+  "favicon_service_none": "無効",
   "favicon_service_scriptcat": "ScriptCat",
   "favicon_service_google": "Google",
   "favicon_service_duckduckgo": "DuckDuckGo",

--- a/src/locales/ko-KR/settings.json
+++ b/src/locales/ko-KR/settings.json
@@ -124,6 +124,7 @@
   },
   "favicon_service": "파비콘 서비스",
   "favicon_service_desc": "웹사이트 아이콘을 가져올 서비스를 선택하세요",
+  "favicon_service_none": "비활성화",
   "favicon_service_scriptcat": "ScriptCat",
   "favicon_service_google": "Google",
   "favicon_service_duckduckgo": "DuckDuckGo",

--- a/src/locales/pt-BR/settings.json
+++ b/src/locales/pt-BR/settings.json
@@ -124,6 +124,7 @@
   },
   "favicon_service": "Serviço de favicon",
   "favicon_service_desc": "Escolha o serviço para buscar os ícones dos sites",
+  "favicon_service_none": "Desativado",
   "favicon_service_scriptcat": "ScriptCat",
   "favicon_service_google": "Google",
   "favicon_service_duckduckgo": "DuckDuckGo",

--- a/src/locales/ru-RU/settings.json
+++ b/src/locales/ru-RU/settings.json
@@ -124,6 +124,7 @@
   },
   "favicon_service": "Сервис Favicon",
   "favicon_service_desc": "Выберите сервис для получения значков сайтов",
+  "favicon_service_none": "Выключено",
   "favicon_service_scriptcat": "ScriptCat",
   "favicon_service_google": "Google",
   "favicon_service_duckduckgo": "DuckDuckGo",

--- a/src/locales/tr-TR/settings.json
+++ b/src/locales/tr-TR/settings.json
@@ -124,6 +124,7 @@
   },
   "favicon_service": "Favicon Hizmeti",
   "favicon_service_desc": "Web sitesi simgelerini almak için hizmeti seçin",
+  "favicon_service_none": "Devre Dışı",
   "favicon_service_scriptcat": "ScriptCat",
   "favicon_service_google": "Google",
   "favicon_service_duckduckgo": "DuckDuckGo",

--- a/src/locales/vi-VN/settings.json
+++ b/src/locales/vi-VN/settings.json
@@ -124,6 +124,7 @@
   },
   "favicon_service": "Dịch vụ Favicon",
   "favicon_service_desc": "Chọn dịch vụ để lấy biểu tượng trang web",
+  "favicon_service_none": "Đã tắt",
   "favicon_service_scriptcat": "ScriptCat",
   "favicon_service_google": "Google",
   "favicon_service_duckduckgo": "DuckDuckGo",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -124,6 +124,7 @@
   },
   "favicon_service": "图标服务",
   "favicon_service_desc": "选择获取网站图标的服务",
+  "favicon_service_none": "禁用",
   "favicon_service_scriptcat": "ScriptCat",
   "favicon_service_google": "Google",
   "favicon_service_duckduckgo": "DuckDuckGo",

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -124,6 +124,7 @@
   },
   "favicon_service": "圖示服務",
   "favicon_service_desc": "選擇取得網站圖示的服務",
+  "favicon_service_none": "停用",
   "favicon_service_scriptcat": "ScriptCat",
   "favicon_service_google": "Google",
   "favicon_service_duckduckgo": "DuckDuckGo",

--- a/src/pages/options/routes/Setting/sections/InterfaceSection.test.tsx
+++ b/src/pages/options/routes/Setting/sections/InterfaceSection.test.tsx
@@ -34,6 +34,13 @@ describe("界面分区-图标服务", () => {
     await screen.findByText("扩展图标徽标");
     expect(screen.getAllByText("扩展图标徽标")).toHaveLength(1);
   });
+
+  // 图标服务可整体关闭：选中 none 时下拉框需回显「禁用」，否则用户无从选择这一档
+  it("图标服务为 none 时下拉框回显禁用", async () => {
+    get.mockImplementation((key: string) => Promise.resolve(key === "favicon_service" ? "none" : ""));
+    render(<InterfaceSection register={() => () => {}} />);
+    expect(await screen.findByText("禁用")).toBeInTheDocument();
+  });
 });
 
 describe("界面分区-popup 布局", () => {

--- a/src/pages/options/routes/Setting/sections/InterfaceSection.tsx
+++ b/src/pages/options/routes/Setting/sections/InterfaceSection.tsx
@@ -77,6 +77,7 @@ export function InterfaceSection({ register }: { register: (id: string) => (el: 
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
+            <SelectItem value="none">{t("settings:favicon_service_none")}</SelectItem>
             <SelectItem value="scriptcat">{t("settings:favicon_service_scriptcat")}</SelectItem>
             <SelectItem value="google">{t("settings:favicon_service_google")}</SelectItem>
             <SelectItem value="duckduckgo">{t("settings:favicon_service_duckduckgo")}</SelectItem>

--- a/src/pages/options/routes/SubscribeList/components.test.tsx
+++ b/src/pages/options/routes/SubscribeList/components.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+
+const { get } = vi.hoisted(() => ({ get: vi.fn() }));
+vi.mock("@App/pages/store/global", async () => {
+  const { createGlobalStoreMock } = await import("@Tests/mocks/pageStores.ts");
+  return createGlobalStoreMock({ systemConfig: { get } });
+});
+
+vi.mock("@App/pages/store/features/subscribe", () => ({
+  requestCheckSubscribeUpdate: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { initTestLanguage } from "@Tests/initTestLanguage";
+import { TooltipProvider } from "@App/pages/components/ui/tooltip";
+import { PermissionFavicons } from "./components";
+
+beforeAll(() => {
+  initTestLanguage("zh-CN");
+});
+
+afterEach(() => {
+  cleanup();
+  get.mockReset();
+});
+
+const renderFavicons = () =>
+  render(
+    <TooltipProvider>
+      <PermissionFavicons connect={["example.com"]} />
+    </TooltipProvider>
+  );
+
+describe("订阅 @connect 域名图标", () => {
+  it("图标服务可用时以站点 favicon 呈现", async () => {
+    get.mockResolvedValue("scriptcat");
+    renderFavicons();
+
+    const img = await screen.findByAltText("example.com");
+    expect(img).toHaveAttribute("src", "https://example.com/favicon.ico");
+  });
+
+  it("图标服务禁用时不向站点请求 favicon", async () => {
+    get.mockResolvedValue("none");
+    const { container } = renderFavicons();
+
+    // 配置读取是异步的：等到读取完成后仍不能出现 <img>，否则请求早已发出
+    await waitFor(() => expect(get).toHaveBeenCalledWith("favicon_service"));
+    expect(container.querySelector("img")).toBeNull();
+  });
+});

--- a/src/pages/options/routes/SubscribeList/components.tsx
+++ b/src/pages/options/routes/SubscribeList/components.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@App/pkg/utils/cn";
 import { notify } from "@App/pages/components/ui/toast";
 import { NameAvatar } from "@App/pages/components/NameAvatar";
+import { useSystemConfig } from "@App/pages/options/hooks/useSystemConfig";
 import { Globe, RefreshCw, Rss, Trash2, CircleArrowUp, Check, Loader2, Link } from "lucide-react";
 
 // ========== SubscribeIcon ==========
@@ -45,12 +46,12 @@ SubscribeEnableSwitch.displayName = "SubscribeEnableSwitch";
 
 // ========== PermissionFavicons ==========
 // @connect 域名以站点 favicon 呈现，加载失败回退到地球图标
-function DomainFavicon({ domain }: { domain: string }) {
+function DomainFavicon({ domain, showIcon }: { domain: string; showIcon: boolean }) {
   const [imgError, setImgError] = useState(false);
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        {imgError ? (
+        {!showIcon || imgError ? (
           <Globe className="w-3.5 h-3.5 text-muted-foreground/50" />
         ) : (
           <img
@@ -67,13 +68,16 @@ function DomainFavicon({ domain }: { domain: string }) {
 }
 
 export const PermissionFavicons = React.memo(({ connect, maxShow = 5 }: { connect?: string[]; maxShow?: number }) => {
+  const [faviconService] = useSystemConfig("favicon_service");
+  // 配置读取完成前一律先显示占位：<img> 一旦挂载请求就已发出，关闭图标获取后再撤下已经晚了
+  const showIcon = !!faviconService && faviconService !== "none";
   if (!connect || connect.length === 0) return <span className="text-xs text-muted-foreground/50">{"-"}</span>;
   const visible = connect.slice(0, maxShow);
   const extra = connect.length - maxShow;
   return (
     <div className="flex items-center gap-1.5">
       {visible.map((domain) => (
-        <DomainFavicon key={domain} domain={domain} />
+        <DomainFavicon key={domain} domain={domain} showIcon={showIcon} />
       ))}
       {extra > 0 && <span className="text-[10px] text-muted-foreground ml-0.5">{`+${extra}`}</span>}
     </div>

--- a/src/pages/store/favicons.test.ts
+++ b/src/pages/store/favicons.test.ts
@@ -4,7 +4,9 @@ import {
   parseFaviconsNew,
   fetchIconByService,
   fetchIconByDomain,
+  loadScriptFavicons,
 } from "@App/pages/store/favicons";
+import type { Script } from "@App/app/repo/scripts";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 describe("extractFaviconsDomain", () => {
@@ -172,7 +174,36 @@ describe("fetchIconByService", () => {
     ]);
   });
 
+  it("none 服务不应返回任何图标地址", async () => {
+    const result = await fetchIconByService("example.com", "none");
+    expect(result).toEqual([]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   // local 服务的具体行为已在 fetchIconByDomain 测试中充分覆盖
+});
+
+describe("loadScriptFavicons", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("图标服务设为 none 时不产出图标，也不发起任何请求", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const scripts = [
+      { uuid: "uuid-1", metadata: { match: ["https://example.com/*"] } },
+      { uuid: "uuid-2", metadata: { match: ["https://another.com/*"] } },
+    ] as unknown as Script[];
+
+    const chunks = [];
+    for await (const chunk of loadScriptFavicons(scripts, "none")) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("fetchIconByDomain", () => {

--- a/src/pages/store/favicons.ts
+++ b/src/pages/store/favicons.ts
@@ -187,6 +187,10 @@ export async function fetchIconByDomain(domain: string): Promise<string[]> {
  */
 export async function fetchIconByService(domain: string, service: FaviconService): Promise<string[]> {
   switch (service) {
+    case "none":
+      // 用户关闭了图标获取，不产生任何外部请求
+      return [];
+
     case "scriptcat":
       /**
        * ScriptCat 图标服务
@@ -382,6 +386,8 @@ type TFaviconStack = { chunkResults: FavIconResult[]; pendingCount: number };
 
 // 处理favicon加载，以批次方式处理
 export const loadScriptFavicons = async function* (scripts: Script[], service: FaviconService = "scriptcat") {
+  // 关闭图标获取时直接结束：不读写 favicon 缓存，也不发起任何请求
+  if (service === "none") return;
   const stack: TFaviconStack[] = [];
   const asyncWaiter: { promise?: any; resolve?: any } = {};
   const createPromise = () => {

--- a/src/pkg/config/config.ts
+++ b/src/pkg/config/config.ts
@@ -37,7 +37,8 @@ export const DEFAULT_CLOUD_SYNC_STATE: CloudSyncState = {
   counts: { total: 0, overwrite: 0, conflict: 0, failed: 0 },
 };
 
-export type FaviconService = "scriptcat" | "google" | "duckduckgo" | "icon-horse" | "local";
+// "none" 表示彻底关闭网站图标获取：不向任何图标服务或目标站点发起请求
+export type FaviconService = "none" | "scriptcat" | "google" | "duckduckgo" | "icon-horse" | "local";
 
 export type CATFileStorage = {
   filesystem: FileSystemType;


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## 背景

打开脚本猫时会按脚本的 `@match` / `@include` 域名逐个请求 favicon。`@match` 多的脚本（issue 里举例的 Bypass All Shortlinks Debloated 有 500+）会一次性产生大量外部请求，触发安全软件拦截；NSFW / 重定向类脚本的域名被请求还有隐私与审计风险。

#1268 之后用户只能在几个图标服务之间切换，**没有真正关掉的选项**——这正是 #1255 被重开的原因。

## 本次改动

按 [@cyfung1031 的 UI 建议](https://github.com/scriptscat/scriptcat/issues/1255#issuecomment-5081282141)，不新增设置行，直接在「设置 → 界面 → 图标服务」下拉里加一档「禁用」：

- `FaviconService` 增加 `"none"`（`src/pkg/config/config.ts`）
- `loadScriptFavicons` 在 `none` 时直接返回：不读写 favicon 缓存，也不发起任何请求（`src/pages/store/favicons.ts`）
- 下拉首项为「禁用」，10 个语言包补 `favicon_service_none`
- 订阅页 `@connect` 域名图标同样遵守该开关（见「实现考虑」）

默认值不变，仍是 ScriptCat 图标服务；老用户行为不受影响。

## 实现考虑

- **`fetchIconByService` 也显式处理 `"none"`**：该 switch 原本是 `case "local": default:`，任何未处理的取值都会落到「直连目标站点抓 HTML 解析 icon」这条最重的路径上。只在上层拦截、不补这个 case，等于给后续调用者留了个反向默认值的坑。
- **订阅页 `@connect` 图标是另一条直连路径**：`SubscribeList` 一直是 `<img src="https://<domain>/favicon.ico">` 直接打目标站，不走图标服务。不管它，「禁用」就名不副实，所以本次让它遵守 `none`。
  由于配置是异步读出来的，`<img>` 一旦挂载请求就已经发出去了，撤下来也晚了——因此配置就绪前一律先渲染地球占位。
- 关闭后 `FaviconDots` 无数据即返回 `null`，列表不留空位。

## 已知限制

- 订阅页 `@connect` 图标在**非禁用**档位下仍然直连站点，没有改走所选图标服务。这是既有行为，不在本次范围内。
- 运行中切换该设置不会让已打开的列表页把已显示的图标撤下来，需重新打开页面；但不会再产生新请求。
- 已缓存到 OPFS 的图标不会因切到「禁用」而清理（不产生请求，仅占本地空间）。

## 建议审查重点

- `loadScriptFavicons` 的提前返回是否漏掉了别的 favicon 入口（当前该函数是脚本列表侧唯一调用点）。
- 订阅页占位逻辑：配置就绪前显示地球是否可接受，还是宁可保持现状不动这个文件。
- 各语言「禁用」译法是否符合对应 `docs/references/terminology-<locale>.md` 的 enable/disable 术语。

## 验证

单测（先写失败用例再实现）：

- `src/pages/store/favicons.test.ts` — `loadScriptFavicons(scripts, "none")` 零产出且不调用 `fetch`；`fetchIconByService(domain, "none")` 返回 `[]`
- `src/pages/options/routes/Setting/sections/InterfaceSection.test.tsx` — 配置值为 `none` 时下拉回显「禁用」
- `src/pages/options/routes/SubscribeList/components.test.tsx`（新增）— 禁用时不渲染 `<img>`，启用时正常渲染

命令与结果：

```
npx vitest run          # 311 files / 3506 tests passed
pnpm run check:i18n     # passed
npx tsc --noEmit        # 无输出
npx eslint <changed>    # 无输出
pnpm run build          # 通过（monaco 既有 warning）
```

真机验证（`e2e/scratch/` 一次性脚本驱动 `dist/ext`，4 条 `@match` 的脚本，两个用例各用全新 profile；「禁用」用例先改设置再装脚本，排除命中既有缓存）：

- 默认 ScriptCat 服务，抓到 4 条请求：

```
https://ext.scriptcat.org/api/v1/open/favicons?domain=github.com&sz=64
https://ext.scriptcat.org/api/v1/open/favicons?domain=www.wikipedia.org&sz=64
https://ext.scriptcat.org/api/v1/open/favicons?domain=developer.mozilla.org&sz=64
https://ext.scriptcat.org/api/v1/open/favicons?domain=stackoverflow.com&sz=64
```

- 切「禁用」后同样场景：`favicon requests = []`，列表正常渲染、不再显示站点图标。

## Screenshots / 截图

<!-- 本地验证截图（设置页「禁用」档、默认档列表有 4 个图标、禁用档列表无图标）留在本地 test-results/，未随 PR 提交 -->

## 关联

Close #1255
