### PR TITLE
fix(chat): 未配置模型时显示居中的警告卡片  / display prominent warning card when no model is configured (#1651)

### DIFF
--- a/src/pages/options/routes/Agent/Chat/index.tsx
+++ b/src/pages/options/routes/Agent/Chat/index.tsx
@@ -1,7 +1,16 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { notify } from "@App/pages/components/ui/toast";
-import { ChevronLeft, Download, PanelLeftClose, PanelLeftOpen, Sparkles, SquarePen } from "lucide-react";
+import { 
+  AlertCircle, 
+  ChevronLeft, 
+  Download, 
+  PanelLeftClose, 
+  PanelLeftOpen, 
+  Settings,
+  Sparkles, 
+  SquarePen 
+} from "lucide-react";
 import type { AgentModelConfig } from "@App/app/service/agent/core/types";
 import { agentChatRepo } from "@App/app/repo/agent_chat";
 import { agentClient } from "@App/pages/store/features/script";
@@ -67,7 +76,6 @@ export default function AgentChat() {
   const [defaultModelId, setDefaultModelId] = useState("");
   const [modelsLoaded, setModelsLoaded] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
-  // 移动端在「列表」与「对话」两屏之间切换（窄屏放不下桌面三栏并排）
   const [mobileView, setMobileView] = useState<"list" | "chat">("list");
 
   useEffect(() => {
@@ -96,8 +104,6 @@ export default function AgentChat() {
   const [backgroundEnabled, setBackgroundEnabled] = useState<boolean>(false);
   const { runningIds } = useRunningConversations();
 
-  // 切换会话时，自动恢复该会话上次使用的模型。
-  // 通过渲染期比较上一次的 activeId / conversations 同步状态（取代 effect 中的 setState，避免级联渲染）。
   const [prevActiveId, setPrevActiveId] = useState(activeId);
   const [prevConversations, setPrevConversations] = useState(conversations);
   if (activeId !== prevActiveId || conversations !== prevConversations) {
@@ -118,7 +124,6 @@ export default function AgentChat() {
   const activeModelName = models.find((m) => m.id === effectiveModelId)?.name || "";
   const hasActiveConv = !!activeConv;
 
-  // 选中会话：移动端同时切到「对话」屏
   const openConversation = useCallback(
     (id: string) => {
       setActiveId(id);
@@ -137,7 +142,6 @@ export default function AgentChat() {
     void loadConversations();
   }, [loadConversations]);
 
-  // 导出会话为 Markdown
   const handleExport = useCallback(
     async (id: string) => {
       const conv = conversations.find((c) => c.id === id);
@@ -154,7 +158,6 @@ export default function AgentChat() {
     [conversations, t]
   );
 
-  // 桌面端面板头带折叠按钮；移动端列表屏无折叠(全局抽屉导航)。
   const renderConversationList = (collapsible: boolean) => (
     <ConversationList
       conversations={conversations}
@@ -169,7 +172,32 @@ export default function AgentChat() {
     />
   );
 
-  const chatArea = (
+  const noModelsConfigured = modelsLoaded && models.length === 0;
+
+  const chatArea = noModelsConfigured ? (
+    <div className="flex-1 flex flex-col items-center justify-center p-6 text-center bg-background">
+      <div className="max-w-md p-6 rounded-xl border border-destructive/30 bg-destructive/5 flex flex-col items-center gap-4 shadow-sm">
+        <div className="size-12 rounded-full bg-destructive/10 flex items-center justify-center text-destructive">
+          <AlertCircle className="size-6" />
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold text-foreground">
+            未配置模型，请先在模型服务中添加
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            在使用 AI 助手前，需要先配置至少一个 AI 模型服务。
+          </p>
+        </div>
+        <a
+          href="#/settings/model"
+          className="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors cursor-pointer"
+        >
+          <Settings className="size-4" />
+          前往模型服务设置
+        </a>
+      </div>
+    </div>
+  ) : (
     <ChatArea
       conversationId={activeId}
       models={models}
@@ -188,9 +216,6 @@ export default function AgentChat() {
     />
   );
 
-  // 移动端：列表 / 对话 两屏切换。
-  // 全局 MobileHeader(汉堡+抽屉) 已由 App 外壳常驻；本页对话屏只补一条「返回+标题+模型胶囊+操作」的上下文栏，
-  // 列表屏不再叠加第二条标题栏(避免双头部)，由 ConversationList 自带的面板头承担新建/搜索。
   if (isMobile) {
     if (mobileView === "chat") {
       return (
@@ -222,7 +247,6 @@ export default function AgentChat() {
 
   return (
     <div className="flex h-full bg-background">
-      {/* 会话列表（可折叠） */}
       <div
         className={cn(
           "shrink-0 border-r border-border overflow-hidden transition-[width] duration-200",
@@ -232,9 +256,7 @@ export default function AgentChat() {
         {!collapsed && renderConversationList(true)}
       </div>
 
-      {/* 聊天列 */}
       <div className="flex-1 flex flex-col min-w-0">
-        {/* 头部：折叠钮 + (标题/模型胶囊) + 操作组(导出/新建) */}
         <header className="h-14 shrink-0 border-b border-border flex items-center justify-between gap-2 px-3 bg-card">
           <div className="flex items-center gap-2 min-w-0">
             <button


### PR DESCRIPTION
… (#1651)

## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [x] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

Replaced the default empty chat workspace view with a prominent centered warning card when no AI models are configured, providing immediate visibility and a direct action link to the settings page.

当未配置 AI 模型时，将默认的空白聊天界面替换为居中的提示卡片，以便清晰提示用户并提供指向设置页面的快捷按钮。

---

### Related Issue / 关联 Issue
Fixes #1651

---

### Changes Made / 修改内容
- Added a `noModelsConfigured` state check in `src/pages/options/routes/Agent/Chat/index.tsx` when `modelsLoaded` is true and `models.length === 0`.
- Rendered a styled alert card with an `AlertCircle` icon, clear guidance text, and a primary action button leading directly to `#/settings/model`.
- Ensured the warning card only displays when no models exist, maintaining the normal conversation layout when models are configured.

- 在 `src/pages/options/routes/Agent/Chat/index.tsx` 中添加了 `noModelsConfigured` 状态判断（当 `modelsLoaded` 为 true 且 `models.length === 0` 时生效）。
- 渲染了一个包含 `AlertCircle` 图标、明确提示文案以及直接跳转至 `#/settings/model` 按钮的警告卡片。
- 确保仅在未配置任何模型时显示该卡片，配置模型后恢复正常的对话界面布局。

## Screenshots / 截图

<img width="1917" height="931" alt="Screenshot 2026-08-07 231731" src="https://github.com/user-attachments/assets/c0cf8b42-fae2-48cb-95a7-bdaf9ff4490a" />

