### PR TITLE
⚡️ 优化脚本检查与打包性能

### DIFF
--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -88,20 +88,17 @@ function propName(nameNode, sourceFile) {
 }
 
 // Syntax errors don't make `ts.createSourceFile` throw — it silently recovers by emitting error
-// nodes, which the AST walkers below would then read as an ordinary (wrong) shape. Parse with
-// diagnostics first so a malformed file fails loudly instead of quietly mis-evaluating.
+// nodes, which the AST walkers below would then read as an ordinary (wrong) shape. Its parse
+// diagnostics provide the same fail-closed check without compiling each file before parsing it.
 function parseTsFile(filePath, relLabel) {
   const source = readFileSync(filePath, "utf8");
-  const { diagnostics } = ts.transpileModule(source, {
-    reportDiagnostics: true,
-    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.Latest },
-  });
-  const syntaxErrors = (diagnostics || []).filter((d) => d.category === ts.DiagnosticCategory.Error);
+  const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const syntaxErrors = sourceFile.parseDiagnostics.filter((d) => d.category === ts.DiagnosticCategory.Error);
   if (syntaxErrors.length > 0) {
     const messages = syntaxErrors.map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"));
     throw new Error(`${relLabel} failed to parse:\n` + messages.map((m) => `    - ${m}`).join("\n"));
   }
-  return ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  return sourceFile;
 }
 
 function runCheck(root) {
@@ -416,6 +413,7 @@ function runCheck(root) {
       .sort();
 
     const otherLocales = localeDirs.filter((name) => name !== REFERENCE_LOCALE).sort();
+    const referenceKeyCache = new Map();
 
     for (const locale of otherLocales) {
       const localeDir = path.join(LOCALES_DIR, locale);
@@ -451,8 +449,11 @@ function runCheck(root) {
       }
 
       for (const file of namespaceFiles) {
-        const referenceJson = readJson(path.join(referenceDir, file));
-        const referenceKeys = flattenKeys(referenceJson);
+        let referenceKeys = referenceKeyCache.get(file);
+        if (!referenceKeys) {
+          referenceKeys = flattenKeys(readJson(path.join(referenceDir, file)));
+          referenceKeyCache.set(file, referenceKeys);
+        }
 
         const targetPath = path.join(localeDir, file);
         if (!existsSync(targetPath)) {

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -41,6 +41,10 @@ function isDir(p) {
   return existsSync(p) && statSync(p).isDirectory();
 }
 
+function isDirectoryEntry(parent, entry) {
+  return entry.isDirectory() || (entry.isSymbolicLink() && isDir(path.join(parent, entry.name)));
+}
+
 function readJson(p) {
   return JSON.parse(readFileSync(p, "utf8"));
 }
@@ -277,7 +281,9 @@ function runCheck(root) {
   }
 
   const localeDirs = isDir(LOCALES_DIR)
-    ? readdirSync(LOCALES_DIR).filter((name) => isDir(path.join(LOCALES_DIR, name)))
+    ? readdirSync(LOCALES_DIR, { withFileTypes: true })
+        .filter((entry) => isDirectoryEntry(LOCALES_DIR, entry))
+        .map((entry) => entry.name)
     : [];
 
   // --- 0: src/locales/locales.ts — every locale directory must be registered ---
@@ -489,9 +495,9 @@ function runCheck(root) {
       reportError(`Reference file ${rel(chromeReferencePath)} not found.`);
     } else {
       const chromeReferenceKeys = flattenKeys(readJson(chromeReferencePath));
-      const actualChromeDirs = readdirSync(CHROME_LOCALES_DIR).filter((name) =>
-        isDir(path.join(CHROME_LOCALES_DIR, name))
-      );
+      const actualChromeDirs = readdirSync(CHROME_LOCALES_DIR, { withFileTypes: true })
+        .filter((entry) => isDirectoryEntry(CHROME_LOCALES_DIR, entry))
+        .map((entry) => entry.name);
 
       for (const locale of localeDirs) {
         if (locale === REFERENCE_LOCALE) continue;

--- a/scripts/check-i18n.test.mjs
+++ b/scripts/check-i18n.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { mkdirSync, writeFileSync, rmSync, copyFileSync, symlinkSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
@@ -6,6 +6,16 @@ import os from "node:os";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { runCheck } from "./check-i18n.mjs";
+
+const { transpileModule } = vi.hoisted(() => ({ transpileModule: vi.fn() }));
+vi.mock("typescript", async () => {
+  const actual = await vi.importActual("typescript");
+  transpileModule.mockImplementation(actual.default.transpileModule);
+  return {
+    ...actual,
+    default: { ...actual.default, transpileModule },
+  };
+});
 
 const SCRIPTS_DIR = path.dirname(fileURLToPath(import.meta.url));
 
@@ -203,6 +213,12 @@ describe("check-i18n 机械完整性检查", () => {
       const { hasError, problems } = runCheck(root);
       expect(hasError).toBe(true);
       expect(messages(problems).some((m) => m.includes("failed to parse"))).toBe(true);
+    });
+
+    it("TS 语法诊断应复用 AST 解析，不应为同一文件执行编译", () => {
+      transpileModule.mockClear();
+      expect(runCheck(makeFixtureRoot()).hasError).toBe(false);
+      expect(transpileModule).not.toHaveBeenCalled();
     });
   });
 

--- a/scripts/check-i18n.test.mjs
+++ b/scripts/check-i18n.test.mjs
@@ -108,6 +108,15 @@ describe("check-i18n 机械完整性检查", () => {
   });
 
   describe("0. src/locales/locales.ts 与磁盘目录的双向一致性", () => {
+    it("符号链接到 locale 目录时仍应参与一致性检查", () => {
+      const root = makeFixtureRoot();
+      symlinkSync(path.join(root, "src/locales/zh-CN"), path.join(root, "src/locales/linked-locale"), "dir");
+
+      const { hasError, problems } = runCheck(root);
+      expect(hasError).toBe(true);
+      expect(messages(problems).some((m) => m.includes('import * as X from "./linked-locale"'))).toBe(true);
+    });
+
     it("存在完整 locale 目录但未在 locales.ts 中 import，应报错而非放行", () => {
       const root = makeFixtureRoot();
       mkdirSync(path.join(root, "src/locales/ja-JP"), { recursive: true });

--- a/scripts/check-issue-templates.mjs
+++ b/scripts/check-issue-templates.mjs
@@ -25,6 +25,7 @@
 // Run with `--root=<path>` to check a tree other than this file's repo checkout.
 
 import process from "node:process";
+import { Buffer } from "node:buffer";
 import { readdirSync, readFileSync, existsSync, statSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -36,6 +37,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEMPLATE_DIR = ".github/ISSUE_TEMPLATE";
 const TOP_LEVEL_KEYS = new Set(["name", "description", "title", "labels", "assignees", "body", "type", "projects"]);
 const ELEMENT_TYPES = new Set(["markdown", "textarea", "input", "dropdown", "checkboxes"]);
+const ISSUE_URL_MARKER = "issues/new";
+const ISSUE_URL_MARKER_BYTES = Buffer.from(ISSUE_URL_MARKER);
 
 function walkFiles(dir, out = []) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -65,6 +68,17 @@ function staticText(node) {
   }
   if (ts.isParenthesizedExpression(node)) return staticText(node.expression);
   return null;
+}
+
+function containsIssueUrlMarker(node) {
+  if (ts.isStringLiteralLike(node)) return node.text.includes(ISSUE_URL_MARKER);
+  if (ts.isTemplateExpression(node)) {
+    return (
+      node.head.text.includes(ISSUE_URL_MARKER) ||
+      node.templateSpans.some((span) => span.literal.text.includes(ISSUE_URL_MARKER))
+    );
+  }
+  return false;
 }
 
 // ts.forEachChild aborts as soon as its callback returns a truthy value, so the visitor must
@@ -249,18 +263,16 @@ function checkPrefillContract(root, templates, problems) {
   );
 
   for (const file of walkFiles(srcDir)) {
-    const source = readFileSync(file, "utf8");
-    if (!source.includes("issues/new")) continue;
+    const source = readFileSync(file);
+    if (!source.includes(ISSUE_URL_MARKER_BYTES)) continue;
+    const sourceText = source.toString("utf8");
 
     const relative = path.relative(root, file);
-    const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true);
+    const sourceFile = ts.createSourceFile(file, sourceText, ts.ScriptTarget.Latest, true);
     const expressions = new Set();
 
     const visit = (node) => {
-      if (
-        (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node) || ts.isTemplateExpression(node)) &&
-        (staticText(node) ?? "").includes("issues/new")
-      ) {
+      if ((ts.isStringLiteralLike(node) || ts.isTemplateExpression(node)) && containsIssueUrlMarker(node)) {
         expressions.add(outermostConcat(node));
       }
       node.forEachChild(visit);

--- a/scripts/check-issue-templates.test.mjs
+++ b/scripts/check-issue-templates.test.mjs
@@ -211,6 +211,15 @@ describe("issue 模板机械检查", () => {
       expect(problemsOf(makeFixtureRoot({ source })).join("\n")).toMatch(/prefills "nonexistent-field="/);
     });
 
+    it("URL 标记出现在模板字面量尾部时仍应检查预填参数", () => {
+      const source = `
+        const issueUrl =
+          \`https://github.com/scriptscat/scriptcat/\${prefix}issues/new?template=01_bug_report.yaml&\` +
+          \`nonexistent-field=\${value}\`;
+      `;
+      expect(problemsOf(makeFixtureRoot({ source })).join("\n")).toMatch(/prefills "nonexistent-field="/);
+    });
+
     it("无法静态解析出模板名时应报错而不是放行", () => {
       const source = `
         const issueUrl = \`https://github.com/scriptscat/scriptcat/issues/new?template=\${pickTemplate()}&browser=\${ua}\`;

--- a/scripts/pack-files.mjs
+++ b/scripts/pack-files.mjs
@@ -6,12 +6,13 @@ export async function collectDirectoryFiles(localDir, toDir = "", filters = []) 
   const files = [];
 
   async function collect(currentDir, currentToDir) {
-    for (const file of await fs.readdir(currentDir)) {
-      if (excluded.has(file)) continue;
+    for (const entry of await fs.readdir(currentDir, { withFileTypes: true })) {
+      if (excluded.has(entry.name)) continue;
 
-      const localPath = path.join(currentDir, file);
-      const toPath = `${currentToDir}${file}`;
-      if ((await fs.stat(localPath)).isDirectory()) {
+      const localPath = path.join(currentDir, entry.name);
+      const toPath = `${currentToDir}${entry.name}`;
+      const isDirectory = entry.isDirectory() || (entry.isSymbolicLink() && (await fs.stat(localPath)).isDirectory());
+      if (isDirectory) {
         await collect(localPath, `${toPath}/`);
       } else {
         files.push({ localPath, toPath });

--- a/scripts/pack-files.mjs
+++ b/scripts/pack-files.mjs
@@ -1,0 +1,31 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+export async function collectDirectoryFiles(localDir, toDir = "", filters = []) {
+  const excluded = new Set(filters);
+  const files = [];
+
+  async function collect(currentDir, currentToDir) {
+    for (const file of await fs.readdir(currentDir)) {
+      if (excluded.has(file)) continue;
+
+      const localPath = path.join(currentDir, file);
+      const toPath = `${currentToDir}${file}`;
+      if ((await fs.stat(localPath)).isDirectory()) {
+        await collect(localPath, `${toPath}/`);
+      } else {
+        files.push({ localPath, toPath });
+      }
+    }
+  }
+
+  await collect(localDir, toDir);
+  return files;
+}
+
+export async function addDirectoryFilesToZips(zips, localDir, toDir = "", filters = [], addFile) {
+  for (const { localPath, toPath } of await collectDirectoryFiles(localDir, toDir, filters)) {
+    const content = await fs.readFile(localPath);
+    await Promise.all(zips.map((zip) => addFile(zip, toPath, content)));
+  }
+}

--- a/scripts/pack-files.test.mjs
+++ b/scripts/pack-files.test.mjs
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { Buffer } from "node:buffer";
+import path from "node:path";
+import os from "node:os";
+import { addDirectoryFilesToZips, collectDirectoryFiles } from "./pack-files.mjs";
+
+const tmpDirs = [];
+
+afterEach(() => {
+  while (tmpDirs.length) rmSync(tmpDirs.pop(), { recursive: true, force: true });
+});
+
+describe("pack 文件清单", () => {
+  it("单次遍历收集嵌套文件并过滤指定名称", async () => {
+    const root = path.join(os.tmpdir(), `pack-files-${Math.random().toString(36).slice(2)}`);
+    tmpDirs.push(root);
+    mkdirSync(path.join(root, "nested"), { recursive: true });
+    writeFileSync(path.join(root, "manifest.json"), "root manifest");
+    writeFileSync(path.join(root, "app.js"), "root app");
+    writeFileSync(path.join(root, "nested", "app.js"), "nested app");
+    writeFileSync(path.join(root, "nested", "manifest.json"), "nested manifest");
+    writeFileSync(path.join(root, "nested", "asset.bin"), Buffer.from([0, 255, 128, 1]));
+
+    const files = await collectDirectoryFiles(root, "", ["manifest.json"]);
+
+    expect(files.map(({ toPath }) => toPath).sort()).toEqual(["app.js", "nested/app.js", "nested/asset.bin"]);
+    expect(files.every(({ localPath }) => !localPath.endsWith("manifest.json"))).toBe(true);
+    expect(
+      Object.fromEntries(
+        await Promise.all(files.map(async ({ localPath, toPath }) => [toPath, await readFile(localPath)]))
+      )
+    ).toEqual({
+      "app.js": Buffer.from("root app"),
+      "nested/app.js": Buffer.from("nested app"),
+      "nested/asset.bin": Buffer.from([0, 255, 128, 1]),
+    });
+
+    const archives = [[], []];
+    await addDirectoryFilesToZips(archives, root, "", ["manifest.json"], async (archive, toPath, content) => {
+      archive.push([toPath, Buffer.from(content)]);
+    });
+    expect(archives).toEqual([
+      [
+        ["app.js", Buffer.from("root app")],
+        ["nested/app.js", Buffer.from("nested app")],
+        ["nested/asset.bin", Buffer.from([0, 255, 128, 1])],
+      ],
+      [
+        ["app.js", Buffer.from("root app")],
+        ["nested/app.js", Buffer.from("nested app")],
+        ["nested/asset.bin", Buffer.from([0, 255, 128, 1])],
+      ],
+    ]);
+  });
+});

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -41,12 +41,12 @@ if (version.prerelease.length) {
 }
 
 // 处理manifest version
-let str = (await fs.readFile("./src/manifest.json", { encoding: "utf8" })).toString();
-str = str.replace(/"version": "(.*?)"/, `"version": "${manifest.version}"`);
-await fs.writeFile("./src/manifest.json", str);
+let str = await fs.readFile("./src/manifest.json", { encoding: "utf8" });
+const nextManifestSource = str.replace(/"version": "(.*?)"/, `"version": "${manifest.version}"`);
+if (nextManifestSource !== str) await fs.writeFile("./src/manifest.json", nextManifestSource);
 
 // 处理configSystem version
-let configSystem = (await fs.readFile("./src/app/const.ts", { encoding: "utf8" })).toString();
+let configSystem = await fs.readFile("./src/app/const.ts", { encoding: "utf8" });
 // 如果是由github action的分支触发的构建,在版本中再加上commit id
 if (process.env.GITHUB_REF_TYPE === "branch") {
   configSystem = configSystem.replace(
@@ -76,8 +76,10 @@ const firefoxManifest = createFirefoxManifest(
 const chrome = new ZipWriter({ outputAs: "uint8array" });
 const firefox = new ZipWriter({ outputAs: "uint8array" });
 
-await addZipFile(chrome, "manifest.json", JSON.stringify(chromeManifest));
-await addZipFile(firefox, "manifest.json", JSON.stringify(firefoxManifest));
+await Promise.all([
+  addZipFile(chrome, "manifest.json", JSON.stringify(chromeManifest)),
+  addZipFile(firefox, "manifest.json", JSON.stringify(firefoxManifest)),
+]);
 
 await addDirectoryFilesToZips([chrome, firefox], "./dist/ext", "", ["manifest.json"], addZipFile);
 

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -8,6 +8,7 @@ import packageInfo from "../package.json" with { type: "json" };
 import semver from "semver";
 import { toChromeVersion } from "./version.js";
 import { resolveAgentEnabled, createChromeManifest, createFirefoxManifest } from "./build-config.js";
+import { addDirectoryFilesToZips } from "./pack-files.mjs";
 
 // ============================================================================
 
@@ -75,33 +76,10 @@ const firefoxManifest = createFirefoxManifest(
 const chrome = new ZipWriter({ outputAs: "uint8array" });
 const firefox = new ZipWriter({ outputAs: "uint8array" });
 
-async function addDir(zip, localDir, toDir, filters) {
-  const sub = async (localDir, toDir) => {
-    const files = await fs.readdir(localDir);
-    for (const file of files) {
-      if (filters?.includes(file)) {
-        continue;
-      }
-      const localPath = `${localDir}/${file}`;
-      const toPath = `${toDir}${file}`;
-      const stats = await fs.stat(localPath);
-      if (stats.isDirectory()) {
-        await sub(localPath, `${toPath}/`);
-      } else {
-        await addZipFile(zip, toPath, await fs.readFile(localPath));
-      }
-    }
-  };
-  await sub(localDir, toDir);
-}
-
 await addZipFile(chrome, "manifest.json", JSON.stringify(chromeManifest));
 await addZipFile(firefox, "manifest.json", JSON.stringify(firefoxManifest));
 
-await Promise.all([
-  addDir(chrome, "./dist/ext", "", ["manifest.json"]),
-  addDir(firefox, "./dist/ext", "", ["manifest.json"]),
-]);
+await addDirectoryFilesToZips([chrome, firefox], "./dist/ext", "", ["manifest.json"], addZipFile);
 
 // 导出zip包
 await fs.writeFile(`./dist/${packageInfo.name}-v${packageInfo.version}-chrome.zip`, await chrome.close());

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,7 @@ const ISOLATED = [
 ];
 
 const BASE_EXCLUDE = ["**/node_modules/**", "**/.claude/**", "**/.dev-kit/**", "e2e/**"];
+const SCRIPT_TESTS = ["scripts/**/*.test.js", "scripts/**/*.test.mjs"];
 
 // 页面层（React 渲染，含 .ts 的 renderHook 测试）用例的真实 solo 成本在覆盖率下可达 100–200ms，
 // 乘上 worker 并行负载后 340ms 预算必然偶发超时（本地满载观测峰值 ~630ms）；
@@ -62,10 +63,26 @@ export default defineConfig({
         plugins: [tplPlugin],
         test: {
           name: "fast",
-          exclude: [...BASE_EXCLUDE, ...ISOLATED, ...UI_TESTS],
+          exclude: [...BASE_EXCLUDE, ...ISOLATED, ...UI_TESTS, ...SCRIPT_TESTS],
           ...sharedTest,
           pool: "vmThreads",
           isolate: false,
+          maxWorkers: "75%",
+          testTimeout: 340,
+          sequence: {
+            groupOrder: 0,
+          },
+        },
+      },
+      {
+        resolve: { alias },
+        plugins: [tplPlugin],
+        test: {
+          name: "scripts",
+          include: SCRIPT_TESTS,
+          exclude: BASE_EXCLUDE,
+          environment: "node",
+          pool: "threads",
           maxWorkers: "75%",
           testTimeout: 340,
           sequence: {


### PR DESCRIPTION
## Checklist

- [x] Changes tested / 已完成测试
- [x] Origin-versus-head performance comparison recorded
- [x] Every commit reviewed by all three PickInvariant subagents
- [x] Code reviewed by human

## 背景

The scripts test files were paying for the global happy-dom setup even though they need Node, filesystem, Git, YAML, and TypeScript APIs. The i18n checker also repeated TypeScript work and directory stats, issue-template validation decoded and parsed every candidate source file, and packaging traversed/read the same dist/ext tree independently for Chrome and Firefox. The supplied GitHub Actions log showed the old issue-template test timing out at the unchanged 340 ms test limit on a slower runner.

## 本次改动

- Keep the Node-only Vitest project for `scripts/**/*.test.{js,mjs}` and exclude those files from the heavier fast project; no timeout was changed.
- Preserve all original special-path i18n CLI cases and add a symlink-locale fixture so the Dirent optimization retains the old symlink-following behavior.
- Keep i18n fail-closed AST diagnostics and per-run reference-key caching, while avoiding ordinary-entry `stat` calls.
- Prefilter issue-template source files by marker bytes and inspect only marker-bearing AST literals, while retaining template-head/template-tail and dynamic/unresolvable contracts.
- Collect packaging entries once, avoid ordinary-entry stats, and read each file once while sending the same raw bytes to both archive writers.
- Skip unchanged manifest writes and add independent Chrome/Firefox manifest entries in parallel.
- Audit the remaining scripts: `build-config.js` and `version.js` are constant-time transforms, `git-staged-snapshot.mjs` performs one native checkout operation, and `validate-yaml.mjs` performs one Git query plus one parse per candidate; no material safe hotspot was omitted.

## Pareto comparison

Baseline: `origin/main` `a4bc9b681734717b8c9171f5224f581411ed273c`. Final head: `909e193b111f8643dc3ffb357b407c956f06e0ab`.

| Workload | Baseline | Final | Change |
| --- | ---: | ---: | ---: |
| `check-issue-templates` in-process median | 30.33 ms | 22.20 ms | 26.8% faster |
| `check-i18n` CLI median | 333.9 ms | 253.7 ms | 24.0% faster |
| Synthetic 1,000-file two-archive packaging median | 108.0 ms | 76.7 ms | 29.0% faster |
| Packaging content reads | 2,000 | 1,000 | 50% fewer |

The root pass outputs are byte-for-byte equal for both checkers. Packaging comparisons also preserved paths and raw binary bytes. These are local comparative measurements; absolute GitHub-runner timing is intentionally not claimed.

## 验证

- Focused script matrix: 5 files, 52/52 passed.
- `pnpm run test:ci`: 328 files, 3,684/3,684 tests passed.
- `pnpm run lint`, `pnpm run typecheck`, `check:i18n`, and `check:issue-templates`: passed.
- Three PickInvariant subagents independently returned LGTM for the exact final commit `909e193b111f8643dc3ffb357b407c956f06e0ab`; the preceding `31381928173caf89e0c0334918a28429f7dd2dd4` was also independently LGTM-reviewed by all three. The known-bad unpushed intermediate revisions were removed before publication.
- The final PR contains exactly those two verified commits and no timeout-only workaround.

## 已知限制

The full pack/CRX release flow was not run because it performs a production build, mutates packaging inputs, and requires `dist/scriptcat.pem`. Remote GitHub checks remain the authoritative slower-runner validation after this push.