### PR TITLE
docs: enable DeepWiki auto refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ScriptCat
 [![Build Status](https://github.com/scriptscat/scriptcat/actions/workflows/build.yaml/badge.svg?branch=main)](https://github.com/scriptscat/scriptcat)
 [![codecov](https://codecov.io/gh/scriptscat/scriptcat/branch/main/graph/badge.svg?token=G1A6ZGDQTY)](https://codecov.io/gh/scriptscat/scriptcat)
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/scriptscat/scriptcat.svg?label=version)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/scriptscat/scriptcat)
 [![Chrome](https://img.shields.io/badge/chrome-success-brightgreen?logo=google%20chrome)](https://chromewebstore.google.com/detail/scriptcat/ndcooeababalnlpkfedmmbbbgkljhpjf)
 [![Edge](https://img.shields.io/badge/edge-success-brightgreen?logo=microsoft%20edge)](https://microsoftedge.microsoft.com/addons/detail/scriptcat/liilgpjgabokdklappibcjfablkpcekh)
 [![FireFox](https://img.shields.io/badge/firefox-success-brightgreen?logo=firefox)](https://addons.mozilla.org/en/firefox/addon/scriptcat/)


### PR DESCRIPTION
## Summary

- add the official **Ask DeepWiki** badge to the root README
- link the badge to `scriptscat/scriptcat` on DeepWiki
- enable DeepWiki's documented automatic refresh behavior for repositories that include the badge

## Why

DeepWiki documents that it auto-refreshes DeepWikis when the repository README contains its badge. This keeps ScriptCat's generated DeepWiki documentation in sync without adding a custom GitHub Actions workflow or application code.

## Validation

- compared `main` with this branch
- confirmed the diff is limited to one added line in `README.md`
