### PR TITLE
修复安装更新页关闭并升级至 v1.5.0-beta.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ yarn.lock
 .claude
 .codex
 .omc
+.opskat/
 # 不带尾斜杠：linked worktree 里的 .dev-kit 是符号链接，`.dev-kit/` 只匹配真目录会漏掉它
 .dev-kit
 .superpowers/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scriptcat",
-  "version": "1.5.0-beta.2",
+  "version": "1.5.0-beta.3",
   "description": "脚本猫,一个可以执行用户脚本的浏览器扩展,万物皆可脚本化,让你的浏览器可以做更多的事情!",
   "author": "CodFrm",
   "license": "GPLv3",

--- a/src/app/service/service_worker/client.ts
+++ b/src/app/service/service_worker/client.ts
@@ -52,7 +52,7 @@ export class ScriptClient extends Client {
 
   // 获取安装信息
   getInstallInfo(uuid: string) {
-    return this.do<[boolean, ScriptInfo, { byWebRequest?: boolean }]>("getInstallInfo", uuid);
+    return this.do<[boolean, ScriptInfo, { byWebRequest?: boolean; openedInNewTab?: boolean }]>("getInstallInfo", uuid);
   }
 
   install(params: TScriptInstallParam): Promise<TScriptInstallReturn> {

--- a/src/app/service/service_worker/client.ts
+++ b/src/app/service/service_worker/client.ts
@@ -52,7 +52,7 @@ export class ScriptClient extends Client {
 
   // 获取安装信息
   getInstallInfo(uuid: string) {
-    return this.do<[boolean, ScriptInfo, { byWebRequest?: boolean; openedInNewTab?: boolean }]>("getInstallInfo", uuid);
+    return this.do<[boolean, ScriptInfo, { byWebRequest?: boolean }]>("getInstallInfo", uuid);
   }
 
   install(params: TScriptInstallParam): Promise<TScriptInstallReturn> {

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -323,6 +323,8 @@ export class ScriptService {
         action: {
           type: "redirect" as chrome.declarativeNetRequest.RuleActionType,
           redirect: {
+            // 直接 URL 入口不经过 UUID 暂存；byWebRequest 只在暂存链路中用于脚本身份匹配，
+            // 不能再作为安装页 history.back()/window.close() 的来源标记。
             regexSubstitution: `${installPageURL}?url=\\1`,
           },
         },

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -323,7 +323,7 @@ export class ScriptService {
         action: {
           type: "redirect" as chrome.declarativeNetRequest.RuleActionType,
           redirect: {
-            regexSubstitution: `${installPageURL}?byWebRequest=1&url=\\1`,
+            regexSubstitution: `${installPageURL}?url=\\1`,
           },
         },
         condition: condition,

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -74,6 +74,12 @@ export type TScriptInstallReturn = {
   updatetime: number | undefined; // 实际生效的更新时间（时间戳，毫秒）
 };
 
+type InstallPageOptions = {
+  source: InstallSource;
+  byWebRequest?: boolean;
+  openedInNewTab?: boolean;
+};
+
 export type TRestoreResult = {
   restored: string[];
   conflicts: { uuid: string; name: string }[];
@@ -137,7 +143,7 @@ export class ScriptService {
         // 读取脚本url内容, 进行安装
         const logger = this.logger.with({ url: targetUrl });
         logger.debug("install script");
-        this.openInstallPageByUrl(targetUrl, { source: "user", byWebRequest: true })
+        this.openInstallPageByUrl(targetUrl, { source: "user", byWebRequest: true, openedInNewTab: true })
           .catch((e) => {
             logger.error("install script error", Logger.E(e));
             // 不再重定向当前url
@@ -361,7 +367,7 @@ export class ScriptService {
 
   public async openInstallPageByUrl(
     url: string,
-    options: { source: InstallSource; byWebRequest?: boolean }
+    options: InstallPageOptions
   ): Promise<{ success: boolean; msg: string }> {
     try {
       const installPageUrl = await this.getInstallPageUrl(url, options);
@@ -374,10 +380,7 @@ export class ScriptService {
     }
   }
 
-  public async getInstallPageUrl(
-    url: string,
-    options: { source: InstallSource; byWebRequest?: boolean }
-  ): Promise<string> {
+  public async getInstallPageUrl(url: string, options: InstallPageOptions): Promise<string> {
     const uuid = uuidv4();
     try {
       await this.openUpdateOrInstallPage(uuid, url, options, false);
@@ -1166,7 +1169,7 @@ export class ScriptService {
   async openUpdateOrInstallPage(
     uuid: string,
     url: string,
-    options: { source: InstallSource; byWebRequest?: boolean },
+    options: InstallPageOptions,
     update: boolean,
     logger?: Logger
   ) {

--- a/src/app/service/service_worker/script.ts
+++ b/src/app/service/service_worker/script.ts
@@ -74,12 +74,6 @@ export type TScriptInstallReturn = {
   updatetime: number | undefined; // 实际生效的更新时间（时间戳，毫秒）
 };
 
-type InstallPageOptions = {
-  source: InstallSource;
-  byWebRequest?: boolean;
-  openedInNewTab?: boolean;
-};
-
 export type TRestoreResult = {
   restored: string[];
   conflicts: { uuid: string; name: string }[];
@@ -143,7 +137,7 @@ export class ScriptService {
         // 读取脚本url内容, 进行安装
         const logger = this.logger.with({ url: targetUrl });
         logger.debug("install script");
-        this.openInstallPageByUrl(targetUrl, { source: "user", byWebRequest: true, openedInNewTab: true })
+        this.openInstallPageByUrl(targetUrl, { source: "user", byWebRequest: true })
           .catch((e) => {
             logger.error("install script error", Logger.E(e));
             // 不再重定向当前url
@@ -367,7 +361,7 @@ export class ScriptService {
 
   public async openInstallPageByUrl(
     url: string,
-    options: InstallPageOptions
+    options: { source: InstallSource; byWebRequest?: boolean }
   ): Promise<{ success: boolean; msg: string }> {
     try {
       const installPageUrl = await this.getInstallPageUrl(url, options);
@@ -380,7 +374,10 @@ export class ScriptService {
     }
   }
 
-  public async getInstallPageUrl(url: string, options: InstallPageOptions): Promise<string> {
+  public async getInstallPageUrl(
+    url: string,
+    options: { source: InstallSource; byWebRequest?: boolean }
+  ): Promise<string> {
     const uuid = uuidv4();
     try {
       await this.openUpdateOrInstallPage(uuid, url, options, false);
@@ -1169,7 +1166,7 @@ export class ScriptService {
   async openUpdateOrInstallPage(
     uuid: string,
     url: string,
-    options: InstallPageOptions,
+    options: { source: InstallSource; byWebRequest?: boolean },
     update: boolean,
     logger?: Logger
   ) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_scriptcat__",
-  "version": "1.5.0.1300",
+  "version": "1.5.0.1400",
   "author": "CodFrm",
   "description": "__MSG_scriptcat_description__",
   "options_ui": {

--- a/src/pages/install/useInstallData.test.ts
+++ b/src/pages/install/useInstallData.test.ts
@@ -185,6 +185,7 @@ describe("assembleInstallView 组装安装视图", () => {
 
 describe("useInstallData 数据流编排", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
     window.history.replaceState({}, "", "/install.html");
   });

--- a/src/pages/install/useInstallData.test.ts
+++ b/src/pages/install/useInstallData.test.ts
@@ -250,7 +250,7 @@ describe("useInstallData 数据流编排", () => {
   });
 
   describe("安装成功后离开安装页:独立新标签应关闭,网页链接接管的原标签应返回上一页", () => {
-    const setupReady = async (paramOptions: Record<string, unknown> = {}) => {
+    const setupReady = async () => {
       window.history.replaceState({}, "", "/install.html?uuid=u1");
       const metadata = { name: ["示例脚本"], version: ["1.0.0"], match: ["https://e.com/*"] };
       const info: ScriptInfo = {
@@ -261,7 +261,7 @@ describe("useInstallData 数据流编排", () => {
         metadata,
         source: "user",
       };
-      (scriptClient.getInstallInfo as Mock).mockResolvedValue([false, info, paramOptions]);
+      (scriptClient.getInstallInfo as Mock).mockResolvedValue([false, info, {}]);
       (getTempCode as Mock).mockResolvedValue("// code");
       (prepareScriptByCode as Mock).mockResolvedValue({ script: makeAction(metadata) });
       (scriptClient.install as Mock).mockResolvedValue(undefined);
@@ -270,11 +270,12 @@ describe("useInstallData 数据流编排", () => {
       return result;
     };
 
-    it("独立新标签即使 history.length > 1 也应 window.close()", async () => {
+    it("history.length 为 1 时应使用 window.close() 关闭", async () => {
       const result = await setupReady();
       const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
       const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
-      vi.spyOn(window.history, "length", "get").mockReturnValue(2);
+      const removeSpy = vi.spyOn(chrome.tabs, "remove").mockResolvedValue();
+      vi.spyOn(window.history, "length", "get").mockReturnValue(1);
 
       await act(async () => {
         await result.current.install();
@@ -283,14 +284,15 @@ describe("useInstallData 数据流编排", () => {
       });
 
       expect(closeSpy).toHaveBeenCalledOnce();
+      expect(removeSpy).not.toHaveBeenCalled();
       expect(backSpy).not.toHaveBeenCalled();
     });
 
-    it("byWebRequest 入口即使 history.length 为 1 也应 history.back() 而非关闭标签", async () => {
-      const result = await setupReady({ byWebRequest: true });
+    it("history.length > 1 时应返回上一页而非关闭用户标签", async () => {
+      const result = await setupReady();
       const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
       const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
-      vi.spyOn(window.history, "length", "get").mockReturnValue(1);
+      vi.spyOn(window.history, "length", "get").mockReturnValue(2);
 
       await act(async () => {
         await result.current.install();

--- a/src/pages/install/useInstallData.test.ts
+++ b/src/pages/install/useInstallData.test.ts
@@ -251,7 +251,7 @@ describe("useInstallData 数据流编排", () => {
   });
 
   describe("安装成功后离开安装页:独立新标签应关闭,网页链接接管的原标签应返回上一页", () => {
-    const setupReady = async (paramOptions: Record<string, unknown> = {}) => {
+    const setupReady = async () => {
       window.history.replaceState({}, "", "/install.html?uuid=u1");
       const metadata = { name: ["示例脚本"], version: ["1.0.0"], match: ["https://e.com/*"] };
       const info: ScriptInfo = {
@@ -262,7 +262,7 @@ describe("useInstallData 数据流编排", () => {
         metadata,
         source: "user",
       };
-      (scriptClient.getInstallInfo as Mock).mockResolvedValue([false, info, paramOptions]);
+      (scriptClient.getInstallInfo as Mock).mockResolvedValue([false, info, {}]);
       (getTempCode as Mock).mockResolvedValue("// code");
       (prepareScriptByCode as Mock).mockResolvedValue({ script: makeAction(metadata) });
       (scriptClient.install as Mock).mockResolvedValue(undefined);
@@ -271,12 +271,12 @@ describe("useInstallData 数据流编排", () => {
       return result;
     };
 
-    it("独立新标签即使 history.length > 1 也应使用 window.close() 关闭", async () => {
+    it("独立新标签 history.length 为 1 时应使用 window.close() 关闭", async () => {
       const result = await setupReady();
       const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
       const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
       const removeSpy = vi.spyOn(chrome.tabs, "remove").mockResolvedValue();
-      vi.spyOn(window.history, "length", "get").mockReturnValue(2);
+      vi.spyOn(window.history, "length", "get").mockReturnValue(1);
 
       await act(async () => {
         await result.current.install();
@@ -289,8 +289,8 @@ describe("useInstallData 数据流编排", () => {
       expect(backSpy).not.toHaveBeenCalled();
     });
 
-    it("byWebRequest 且 history.length > 1 时应返回上一页而非关闭用户标签", async () => {
-      const result = await setupReady({ byWebRequest: true });
+    it("history.length > 1 时应返回上一页而非关闭用户标签", async () => {
+      const result = await setupReady();
       const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
       const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
       vi.spyOn(window.history, "length", "get").mockReturnValue(2);
@@ -305,8 +305,8 @@ describe("useInstallData 数据流编排", () => {
       expect(closeSpy).not.toHaveBeenCalled();
     });
 
-    it("byWebRequest 但 history.length 为 1 时应关闭无处可退的标签", async () => {
-      const result = await setupReady({ byWebRequest: true });
+    it("history.length 为 1 时应关闭无处可退的标签", async () => {
+      const result = await setupReady();
       const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
       const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
       vi.spyOn(window.history, "length", "get").mockReturnValue(1);

--- a/src/pages/install/useInstallData.test.ts
+++ b/src/pages/install/useInstallData.test.ts
@@ -250,7 +250,7 @@ describe("useInstallData 数据流编排", () => {
   });
 
   describe("安装成功后离开安装页:独立新标签应关闭,网页链接接管的原标签应返回上一页", () => {
-    const setupReady = async () => {
+    const setupReady = async (paramOptions: Record<string, unknown> = {}) => {
       window.history.replaceState({}, "", "/install.html?uuid=u1");
       const metadata = { name: ["示例脚本"], version: ["1.0.0"], match: ["https://e.com/*"] };
       const info: ScriptInfo = {
@@ -261,7 +261,7 @@ describe("useInstallData 数据流编排", () => {
         metadata,
         source: "user",
       };
-      (scriptClient.getInstallInfo as Mock).mockResolvedValue([false, info, {}]);
+      (scriptClient.getInstallInfo as Mock).mockResolvedValue([false, info, paramOptions]);
       (getTempCode as Mock).mockResolvedValue("// code");
       (prepareScriptByCode as Mock).mockResolvedValue({ script: makeAction(metadata) });
       (scriptClient.install as Mock).mockResolvedValue(undefined);
@@ -270,12 +270,12 @@ describe("useInstallData 数据流编排", () => {
       return result;
     };
 
-    it("history.length 为 1 时应使用 window.close() 关闭", async () => {
+    it("独立新标签即使 history.length > 1 也应使用 window.close() 关闭", async () => {
       const result = await setupReady();
       const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
       const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
       const removeSpy = vi.spyOn(chrome.tabs, "remove").mockResolvedValue();
-      vi.spyOn(window.history, "length", "get").mockReturnValue(1);
+      vi.spyOn(window.history, "length", "get").mockReturnValue(2);
 
       await act(async () => {
         await result.current.install();
@@ -288,8 +288,8 @@ describe("useInstallData 数据流编排", () => {
       expect(backSpy).not.toHaveBeenCalled();
     });
 
-    it("history.length > 1 时应返回上一页而非关闭用户标签", async () => {
-      const result = await setupReady();
+    it("byWebRequest 且 history.length > 1 时应返回上一页而非关闭用户标签", async () => {
+      const result = await setupReady({ byWebRequest: true });
       const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
       const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
       vi.spyOn(window.history, "length", "get").mockReturnValue(2);
@@ -302,6 +302,21 @@ describe("useInstallData 数据流编排", () => {
 
       expect(backSpy).toHaveBeenCalledOnce();
       expect(closeSpy).not.toHaveBeenCalled();
+    });
+
+    it("byWebRequest 但 history.length 为 1 时应关闭无处可退的标签", async () => {
+      const result = await setupReady({ byWebRequest: true });
+      const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+      const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
+      vi.spyOn(window.history, "length", "get").mockReturnValue(1);
+
+      await act(async () => {
+        await result.current.install();
+        await new Promise((r) => setTimeout(r, 320));
+      });
+
+      expect(closeSpy).toHaveBeenCalledOnce();
+      expect(backSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/pages/install/useInstallData.test.ts
+++ b/src/pages/install/useInstallData.test.ts
@@ -440,28 +440,6 @@ describe("useInstallData 数据流编排", () => {
     expect(result.current.localFile).toBe(false);
   });
 
-  it("?url= 且 byWebRequest=1 时应把入口标记传给脚本准备流程", async () => {
-    window.history.replaceState({}, "", "/install.html?byWebRequest=1&url=https://e.com/x.user.js");
-    const metadata = { name: ["URL脚本"], version: ["1.0.0"] };
-    (fetchScriptBody as Mock).mockResolvedValue("// url code");
-    (parseMetadata as Mock).mockReturnValue(metadata);
-    (prepareScriptByCode as Mock).mockResolvedValue({
-      script: { name: "URL脚本", metadata, status: SCRIPT_STATUS_ENABLE } as unknown as Script,
-    });
-
-    const { result } = renderHook(() => useInstallData());
-    await waitFor(() => expect(result.current.state.status).toBe("ready"));
-
-    expect(prepareScriptByCode).toHaveBeenCalledWith(
-      "// url code",
-      "https://e.com/x.user.js",
-      undefined,
-      false,
-      undefined,
-      { byWebRequest: true }
-    );
-  });
-
   it("?url= 下载过程中在 loading 状态展示已接收字节与百分比", async () => {
     window.history.replaceState({}, "", "/install.html?url=https://e.com/x.user.js");
     const metadata = { name: ["URL脚本"], version: ["1.0.0"] };

--- a/src/pages/install/useInstallData.test.ts
+++ b/src/pages/install/useInstallData.test.ts
@@ -304,21 +304,6 @@ describe("useInstallData 数据流编排", () => {
       expect(closeSpy).not.toHaveBeenCalled();
     });
 
-    it("webNavigation 新开标签即使带 byWebRequest 且 history.length > 1 也应关闭", async () => {
-      const result = await setupReady({ byWebRequest: true, openedInNewTab: true });
-      const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
-      const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
-      vi.spyOn(window.history, "length", "get").mockReturnValue(2);
-
-      await act(async () => {
-        await result.current.install();
-        await new Promise((r) => setTimeout(r, 320));
-      });
-
-      expect(closeSpy).toHaveBeenCalledOnce();
-      expect(backSpy).not.toHaveBeenCalled();
-    });
-
     it("byWebRequest 但 history.length 为 1 时应关闭无处可退的标签", async () => {
       const result = await setupReady({ byWebRequest: true });
       const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});

--- a/src/pages/install/useInstallData.test.ts
+++ b/src/pages/install/useInstallData.test.ts
@@ -304,6 +304,21 @@ describe("useInstallData 数据流编排", () => {
       expect(closeSpy).not.toHaveBeenCalled();
     });
 
+    it("webNavigation 新开标签即使带 byWebRequest 且 history.length > 1 也应关闭", async () => {
+      const result = await setupReady({ byWebRequest: true, openedInNewTab: true });
+      const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+      const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
+      vi.spyOn(window.history, "length", "get").mockReturnValue(2);
+
+      await act(async () => {
+        await result.current.install();
+        await new Promise((r) => setTimeout(r, 320));
+      });
+
+      expect(closeSpy).toHaveBeenCalledOnce();
+      expect(backSpy).not.toHaveBeenCalled();
+    });
+
     it("byWebRequest 但 history.length 为 1 时应关闭无处可退的标签", async () => {
       const result = await setupReady({ byWebRequest: true });
       const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});

--- a/src/pages/install/useInstallData.test.ts
+++ b/src/pages/install/useInstallData.test.ts
@@ -440,6 +440,28 @@ describe("useInstallData 数据流编排", () => {
     expect(result.current.localFile).toBe(false);
   });
 
+  it("?url= 且 byWebRequest=1 时应把入口标记传给脚本准备流程", async () => {
+    window.history.replaceState({}, "", "/install.html?byWebRequest=1&url=https://e.com/x.user.js");
+    const metadata = { name: ["URL脚本"], version: ["1.0.0"] };
+    (fetchScriptBody as Mock).mockResolvedValue("// url code");
+    (parseMetadata as Mock).mockReturnValue(metadata);
+    (prepareScriptByCode as Mock).mockResolvedValue({
+      script: { name: "URL脚本", metadata, status: SCRIPT_STATUS_ENABLE } as unknown as Script,
+    });
+
+    const { result } = renderHook(() => useInstallData());
+    await waitFor(() => expect(result.current.state.status).toBe("ready"));
+
+    expect(prepareScriptByCode).toHaveBeenCalledWith(
+      "// url code",
+      "https://e.com/x.user.js",
+      undefined,
+      false,
+      undefined,
+      { byWebRequest: true }
+    );
+  });
+
   it("?url= 下载过程中在 loading 状态展示已接收字节与百分比", async () => {
     window.history.replaceState({}, "", "/install.html?url=https://e.com/x.user.js");
     const metadata = { name: ["URL脚本"], version: ["1.0.0"] };

--- a/src/pages/install/useInstallData.ts
+++ b/src/pages/install/useInstallData.ts
@@ -124,19 +124,19 @@ const buildScriptInfo = (uuid: string, code: string, url: string, metadata: SCMe
   source: "user",
 });
 
-// 安装页可能是专为安装打开的新标签(history.length === 1，关闭无损)，
-// 也可能是由 declarativeNetRequest 就地重定向而来的用户原浏览标签(history.length > 1)，
-// 后者若直接 window.close() 会连带关掉用户本来在看的页面，应改为返回上一页。
+// 安装页可能是专为安装打开的新标签，也可能由 declarativeNetRequest 接管用户原标签。
+// 独立新标签可能继承多条历史，DNR 入口也可能没有上一页，因此必须同时检查入口与历史栈：
+// 仅在 DNR 接管且确实有历史可退时返回，否则关闭当前独立安装标签。
 // install()/close() 等可能在短时间内被重复触发(如用户连续点击、close 与 install 的
 // setTimeout 前后脚打到)，leaveInstallPageRunning 防止 back()/close() 被并发调用多次；
 // 推到 requestAnimationFrame 里执行，让触发它的那次交互(如按钮点击态)先完成一帧渲染。
 let leaveInstallPageRunning = false;
-const leaveInstallPage = () => {
+const leaveInstallPage = (byWebRequest: boolean) => {
   if (leaveInstallPageRunning) return;
   leaveInstallPageRunning = true;
   requestAnimationFrame(() => {
     leaveInstallPageRunning = false;
-    if (window.history.length > 1) {
+    if (byWebRequest && window.history.length > 1) {
       window.history.back();
     } else {
       window.close();
@@ -190,6 +190,7 @@ export function useInstallData(): UseInstallData {
   const infoRef = useRef<ScriptInfo | null>(null);
   const handleRef = useRef<FileSystemFileHandle | null>(null);
   const skillUuidRef = useRef<string | null>(null);
+  const byWebRequestRef = useRef(false);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -199,6 +200,7 @@ export function useInstallData(): UseInstallData {
     const fid = params.get("file");
     const urlIdx = location.search.indexOf("url=");
     const rawUrl = !uuid && urlIdx !== -1 ? location.search.slice(urlIdx + 4) : null;
+    byWebRequestRef.current = params.get("byWebRequest") === "1";
     let cancelled = false;
 
     const failed = (e: unknown) => {
@@ -264,6 +266,7 @@ export function useInstallData(): UseInstallData {
           const code = await getTempCode(uuid);
           if (code === undefined) throw new Error(t("install:script_info_load_failed"));
           info.code = code;
+          byWebRequestRef.current = cached?.[2]?.byWebRequest === true;
           await loadFromInfo(info, !!cached?.[0], cached?.[2] || {});
         } else if (rawUrl) {
           // .cat.md URL → Skill 安装流程(DNR 把 *.cat.md 重定向到安装页),不走脚本解析;仅 agent 启用时
@@ -366,7 +369,7 @@ export function useInstallData(): UseInstallData {
           await scriptClient.install({ script, code: info.code });
           notify.success(t("install:success"));
         }
-        if (closeAfterInstall) setTimeout(() => leaveInstallPage(), 300);
+        if (closeAfterInstall) setTimeout(() => leaveInstallPage(byWebRequestRef.current), 300);
       } catch (e) {
         notify.error(`${t("install:failed")}: ${(e as Error)?.message || String(e)}`);
       }
@@ -390,7 +393,7 @@ export function useInstallData(): UseInstallData {
     if (opts?.noMoreUpdates && info && !info.userSubscribe) {
       void scriptClient.setCheckUpdateUrl(info.uuid, false);
     }
-    leaveInstallPage();
+    leaveInstallPage(byWebRequestRef.current);
   }, []);
 
   // 监听文件变更后自动重装,并刷新视图代码
@@ -447,7 +450,7 @@ export function useInstallData(): UseInstallData {
     try {
       await agentClient.completeSkillInstall(uuid);
       notify.success(t("install:success"));
-      setTimeout(() => leaveInstallPage(), 300);
+      setTimeout(() => leaveInstallPage(byWebRequestRef.current), 300);
     } catch (e) {
       notify.error(`${t("install:failed")}: ${(e as Error)?.message || String(e)}`);
     }
@@ -456,7 +459,7 @@ export function useInstallData(): UseInstallData {
   const cancelSkill = useCallback(() => {
     const uuid = skillUuidRef.current;
     if (uuid) void agentClient.cancelSkillInstall(uuid);
-    leaveInstallPage();
+    leaveInstallPage(byWebRequestRef.current);
   }, []);
 
   // 重新触发加载(供加载失败后的重试按钮)

--- a/src/pages/install/useInstallData.ts
+++ b/src/pages/install/useInstallData.ts
@@ -124,19 +124,19 @@ const buildScriptInfo = (uuid: string, code: string, url: string, metadata: SCMe
   source: "user",
 });
 
-// 安装页可能是专为安装打开的新标签，也可能由 declarativeNetRequest 接管用户原标签。
-// 独立新标签可能继承多条历史，DNR 入口也可能没有上一页，因此必须同时检查入口与历史栈：
-// 仅在 DNR 接管且确实有历史可退时返回，否则关闭当前独立安装标签。
+// 安装页可能是 ScriptCat 新建的独立标签，也可能由 declarativeNetRequest 接管用户原标签。
+// 前者由 chrome.tabs.create 创建且没有可返回的安装历史，后者才可能有上一页；
+// 因此只需用 history.length 区分返回与关闭，不要让入口标记承担第二种语义。
 // install()/close() 等可能在短时间内被重复触发(如用户连续点击、close 与 install 的
 // setTimeout 前后脚打到)，leaveInstallPageRunning 防止 back()/close() 被并发调用多次；
 // 推到 requestAnimationFrame 里执行，让触发它的那次交互(如按钮点击态)先完成一帧渲染。
 let leaveInstallPageRunning = false;
-const leaveInstallPage = (byWebRequest: boolean) => {
+const leaveInstallPage = () => {
   if (leaveInstallPageRunning) return;
   leaveInstallPageRunning = true;
   requestAnimationFrame(() => {
     leaveInstallPageRunning = false;
-    if (byWebRequest && window.history.length > 1) {
+    if (window.history.length > 1) {
       window.history.back();
     } else {
       window.close();
@@ -190,7 +190,6 @@ export function useInstallData(): UseInstallData {
   const infoRef = useRef<ScriptInfo | null>(null);
   const handleRef = useRef<FileSystemFileHandle | null>(null);
   const skillUuidRef = useRef<string | null>(null);
-  const byWebRequestRef = useRef(false);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -200,7 +199,6 @@ export function useInstallData(): UseInstallData {
     const fid = params.get("file");
     const urlIdx = location.search.indexOf("url=");
     const rawUrl = !uuid && urlIdx !== -1 ? location.search.slice(urlIdx + 4) : null;
-    byWebRequestRef.current = params.get("byWebRequest") === "1";
     let cancelled = false;
 
     const failed = (e: unknown) => {
@@ -266,7 +264,6 @@ export function useInstallData(): UseInstallData {
           const code = await getTempCode(uuid);
           if (code === undefined) throw new Error(t("install:script_info_load_failed"));
           info.code = code;
-          byWebRequestRef.current = cached?.[2]?.byWebRequest === true;
           await loadFromInfo(info, !!cached?.[0], cached?.[2] || {});
         } else if (rawUrl) {
           // .cat.md URL → Skill 安装流程(DNR 把 *.cat.md 重定向到安装页),不走脚本解析;仅 agent 启用时
@@ -369,7 +366,7 @@ export function useInstallData(): UseInstallData {
           await scriptClient.install({ script, code: info.code });
           notify.success(t("install:success"));
         }
-        if (closeAfterInstall) setTimeout(() => leaveInstallPage(byWebRequestRef.current), 300);
+        if (closeAfterInstall) setTimeout(() => leaveInstallPage(), 300);
       } catch (e) {
         notify.error(`${t("install:failed")}: ${(e as Error)?.message || String(e)}`);
       }
@@ -393,7 +390,7 @@ export function useInstallData(): UseInstallData {
     if (opts?.noMoreUpdates && info && !info.userSubscribe) {
       void scriptClient.setCheckUpdateUrl(info.uuid, false);
     }
-    leaveInstallPage(byWebRequestRef.current);
+    leaveInstallPage();
   }, []);
 
   // 监听文件变更后自动重装,并刷新视图代码
@@ -450,7 +447,7 @@ export function useInstallData(): UseInstallData {
     try {
       await agentClient.completeSkillInstall(uuid);
       notify.success(t("install:success"));
-      setTimeout(() => leaveInstallPage(byWebRequestRef.current), 300);
+      setTimeout(() => leaveInstallPage(), 300);
     } catch (e) {
       notify.error(`${t("install:failed")}: ${(e as Error)?.message || String(e)}`);
     }
@@ -459,7 +456,7 @@ export function useInstallData(): UseInstallData {
   const cancelSkill = useCallback(() => {
     const uuid = skillUuidRef.current;
     if (uuid) void agentClient.cancelSkillInstall(uuid);
-    leaveInstallPage(byWebRequestRef.current);
+    leaveInstallPage();
   }, []);
 
   // 重新触发加载(供加载失败后的重试按钮)

--- a/src/pages/install/useInstallData.ts
+++ b/src/pages/install/useInstallData.ts
@@ -304,9 +304,7 @@ export function useInstallData(): UseInstallData {
           });
           const metadata = parseMetadata(code);
           if (!metadata) throw new Error(t("install:script_info_load_failed"));
-          await loadFromInfo(buildScriptInfo(uuidv4(), code, parsed.href, metadata), false, {
-            byWebRequest: byWebRequestRef.current,
-          });
+          await loadFromInfo(buildScriptInfo(uuidv4(), code, parsed.href, metadata), false, {});
         } else if (fid) {
           const handle = await loadHandle(fid);
           if (!handle) throw new Error(t("install:script_info_load_failed"));

--- a/src/pages/install/useInstallData.ts
+++ b/src/pages/install/useInstallData.ts
@@ -125,18 +125,18 @@ const buildScriptInfo = (uuid: string, code: string, url: string, metadata: SCMe
 });
 
 // 安装页可能是专为安装打开的新标签，也可能由 declarativeNetRequest 接管用户原标签。
-// webNavigation 入口同样带有 byWebRequest 标记，但它通过 chrome.tabs.create() 打开独立标签，
-// 因此必须额外保留 openedInNewTab 来源；只有真正接管用户原标签且确实有历史可退时才返回。
+// 独立新标签可能继承多条历史，DNR 入口也可能没有上一页，因此必须同时检查入口与历史栈：
+// 仅在 DNR 接管且确实有历史可退时返回，否则关闭当前独立安装标签。
 // install()/close() 等可能在短时间内被重复触发(如用户连续点击、close 与 install 的
 // setTimeout 前后脚打到)，leaveInstallPageRunning 防止 back()/close() 被并发调用多次；
 // 推到 requestAnimationFrame 里执行，让触发它的那次交互(如按钮点击态)先完成一帧渲染。
 let leaveInstallPageRunning = false;
-const leaveInstallPage = (byWebRequest: boolean, openedInNewTab: boolean) => {
+const leaveInstallPage = (byWebRequest: boolean) => {
   if (leaveInstallPageRunning) return;
   leaveInstallPageRunning = true;
   requestAnimationFrame(() => {
     leaveInstallPageRunning = false;
-    if (byWebRequest && !openedInNewTab && window.history.length > 1) {
+    if (byWebRequest && window.history.length > 1) {
       window.history.back();
     } else {
       window.close();
@@ -191,7 +191,6 @@ export function useInstallData(): UseInstallData {
   const handleRef = useRef<FileSystemFileHandle | null>(null);
   const skillUuidRef = useRef<string | null>(null);
   const byWebRequestRef = useRef(false);
-  const openedInNewTabRef = useRef(false);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -202,7 +201,6 @@ export function useInstallData(): UseInstallData {
     const urlIdx = location.search.indexOf("url=");
     const rawUrl = !uuid && urlIdx !== -1 ? location.search.slice(urlIdx + 4) : null;
     byWebRequestRef.current = params.get("byWebRequest") === "1";
-    openedInNewTabRef.current = false;
     let cancelled = false;
 
     const failed = (e: unknown) => {
@@ -269,7 +267,6 @@ export function useInstallData(): UseInstallData {
           if (code === undefined) throw new Error(t("install:script_info_load_failed"));
           info.code = code;
           byWebRequestRef.current = cached?.[2]?.byWebRequest === true;
-          openedInNewTabRef.current = cached?.[2]?.openedInNewTab === true;
           await loadFromInfo(info, !!cached?.[0], cached?.[2] || {});
         } else if (rawUrl) {
           // .cat.md URL → Skill 安装流程(DNR 把 *.cat.md 重定向到安装页),不走脚本解析;仅 agent 启用时
@@ -374,8 +371,7 @@ export function useInstallData(): UseInstallData {
           await scriptClient.install({ script, code: info.code });
           notify.success(t("install:success"));
         }
-        if (closeAfterInstall)
-          setTimeout(() => leaveInstallPage(byWebRequestRef.current, openedInNewTabRef.current), 300);
+        if (closeAfterInstall) setTimeout(() => leaveInstallPage(byWebRequestRef.current), 300);
       } catch (e) {
         notify.error(`${t("install:failed")}: ${(e as Error)?.message || String(e)}`);
       }
@@ -399,7 +395,7 @@ export function useInstallData(): UseInstallData {
     if (opts?.noMoreUpdates && info && !info.userSubscribe) {
       void scriptClient.setCheckUpdateUrl(info.uuid, false);
     }
-    leaveInstallPage(byWebRequestRef.current, openedInNewTabRef.current);
+    leaveInstallPage(byWebRequestRef.current);
   }, []);
 
   // 监听文件变更后自动重装,并刷新视图代码
@@ -456,7 +452,7 @@ export function useInstallData(): UseInstallData {
     try {
       await agentClient.completeSkillInstall(uuid);
       notify.success(t("install:success"));
-      setTimeout(() => leaveInstallPage(byWebRequestRef.current, openedInNewTabRef.current), 300);
+      setTimeout(() => leaveInstallPage(byWebRequestRef.current), 300);
     } catch (e) {
       notify.error(`${t("install:failed")}: ${(e as Error)?.message || String(e)}`);
     }
@@ -465,7 +461,7 @@ export function useInstallData(): UseInstallData {
   const cancelSkill = useCallback(() => {
     const uuid = skillUuidRef.current;
     if (uuid) void agentClient.cancelSkillInstall(uuid);
-    leaveInstallPage(byWebRequestRef.current, openedInNewTabRef.current);
+    leaveInstallPage(byWebRequestRef.current);
   }, []);
 
   // 重新触发加载(供加载失败后的重试按钮)

--- a/src/pages/install/useInstallData.ts
+++ b/src/pages/install/useInstallData.ts
@@ -125,18 +125,18 @@ const buildScriptInfo = (uuid: string, code: string, url: string, metadata: SCMe
 });
 
 // 安装页可能是专为安装打开的新标签，也可能由 declarativeNetRequest 接管用户原标签。
-// 独立新标签可能继承多条历史，DNR 入口也可能没有上一页，因此必须同时检查入口与历史栈：
-// 仅在 DNR 接管且确实有历史可退时返回，否则关闭当前独立安装标签。
+// webNavigation 入口同样带有 byWebRequest 标记，但它通过 chrome.tabs.create() 打开独立标签，
+// 因此必须额外保留 openedInNewTab 来源；只有真正接管用户原标签且确实有历史可退时才返回。
 // install()/close() 等可能在短时间内被重复触发(如用户连续点击、close 与 install 的
 // setTimeout 前后脚打到)，leaveInstallPageRunning 防止 back()/close() 被并发调用多次；
 // 推到 requestAnimationFrame 里执行，让触发它的那次交互(如按钮点击态)先完成一帧渲染。
 let leaveInstallPageRunning = false;
-const leaveInstallPage = (byWebRequest: boolean) => {
+const leaveInstallPage = (byWebRequest: boolean, openedInNewTab: boolean) => {
   if (leaveInstallPageRunning) return;
   leaveInstallPageRunning = true;
   requestAnimationFrame(() => {
     leaveInstallPageRunning = false;
-    if (byWebRequest && window.history.length > 1) {
+    if (byWebRequest && !openedInNewTab && window.history.length > 1) {
       window.history.back();
     } else {
       window.close();
@@ -191,6 +191,7 @@ export function useInstallData(): UseInstallData {
   const handleRef = useRef<FileSystemFileHandle | null>(null);
   const skillUuidRef = useRef<string | null>(null);
   const byWebRequestRef = useRef(false);
+  const openedInNewTabRef = useRef(false);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -201,6 +202,7 @@ export function useInstallData(): UseInstallData {
     const urlIdx = location.search.indexOf("url=");
     const rawUrl = !uuid && urlIdx !== -1 ? location.search.slice(urlIdx + 4) : null;
     byWebRequestRef.current = params.get("byWebRequest") === "1";
+    openedInNewTabRef.current = false;
     let cancelled = false;
 
     const failed = (e: unknown) => {
@@ -267,6 +269,7 @@ export function useInstallData(): UseInstallData {
           if (code === undefined) throw new Error(t("install:script_info_load_failed"));
           info.code = code;
           byWebRequestRef.current = cached?.[2]?.byWebRequest === true;
+          openedInNewTabRef.current = cached?.[2]?.openedInNewTab === true;
           await loadFromInfo(info, !!cached?.[0], cached?.[2] || {});
         } else if (rawUrl) {
           // .cat.md URL → Skill 安装流程(DNR 把 *.cat.md 重定向到安装页),不走脚本解析;仅 agent 启用时
@@ -371,7 +374,8 @@ export function useInstallData(): UseInstallData {
           await scriptClient.install({ script, code: info.code });
           notify.success(t("install:success"));
         }
-        if (closeAfterInstall) setTimeout(() => leaveInstallPage(byWebRequestRef.current), 300);
+        if (closeAfterInstall)
+          setTimeout(() => leaveInstallPage(byWebRequestRef.current, openedInNewTabRef.current), 300);
       } catch (e) {
         notify.error(`${t("install:failed")}: ${(e as Error)?.message || String(e)}`);
       }
@@ -395,7 +399,7 @@ export function useInstallData(): UseInstallData {
     if (opts?.noMoreUpdates && info && !info.userSubscribe) {
       void scriptClient.setCheckUpdateUrl(info.uuid, false);
     }
-    leaveInstallPage(byWebRequestRef.current);
+    leaveInstallPage(byWebRequestRef.current, openedInNewTabRef.current);
   }, []);
 
   // 监听文件变更后自动重装,并刷新视图代码
@@ -452,7 +456,7 @@ export function useInstallData(): UseInstallData {
     try {
       await agentClient.completeSkillInstall(uuid);
       notify.success(t("install:success"));
-      setTimeout(() => leaveInstallPage(byWebRequestRef.current), 300);
+      setTimeout(() => leaveInstallPage(byWebRequestRef.current, openedInNewTabRef.current), 300);
     } catch (e) {
       notify.error(`${t("install:failed")}: ${(e as Error)?.message || String(e)}`);
     }
@@ -461,7 +465,7 @@ export function useInstallData(): UseInstallData {
   const cancelSkill = useCallback(() => {
     const uuid = skillUuidRef.current;
     if (uuid) void agentClient.cancelSkillInstall(uuid);
-    leaveInstallPage(byWebRequestRef.current);
+    leaveInstallPage(byWebRequestRef.current, openedInNewTabRef.current);
   }, []);
 
   // 重新触发加载(供加载失败后的重试按钮)

--- a/src/pages/install/useInstallData.ts
+++ b/src/pages/install/useInstallData.ts
@@ -124,19 +124,19 @@ const buildScriptInfo = (uuid: string, code: string, url: string, metadata: SCMe
   source: "user",
 });
 
-// 安装页可能是专为安装打开的新标签，也可能由网页脚本链接接管用户原标签。
-// history.length 无法区分两者：扩展新标签也可能继承多条历史，因此必须使用入口携带的
-// byWebRequest 信号；后者若直接 window.close() 会连带关掉用户本来在看的页面。
+// 安装页可能是专为安装打开的新标签(history.length === 1，关闭无损)，
+// 也可能是由 declarativeNetRequest 就地重定向而来的用户原浏览标签(history.length > 1)，
+// 后者若直接 window.close() 会连带关掉用户本来在看的页面，应改为返回上一页。
 // install()/close() 等可能在短时间内被重复触发(如用户连续点击、close 与 install 的
 // setTimeout 前后脚打到)，leaveInstallPageRunning 防止 back()/close() 被并发调用多次；
 // 推到 requestAnimationFrame 里执行，让触发它的那次交互(如按钮点击态)先完成一帧渲染。
 let leaveInstallPageRunning = false;
-const leaveInstallPage = (byWebRequest: boolean) => {
+const leaveInstallPage = () => {
   if (leaveInstallPageRunning) return;
   leaveInstallPageRunning = true;
   requestAnimationFrame(() => {
     leaveInstallPageRunning = false;
-    if (byWebRequest) {
+    if (window.history.length > 1) {
       window.history.back();
     } else {
       window.close();
@@ -190,7 +190,6 @@ export function useInstallData(): UseInstallData {
   const infoRef = useRef<ScriptInfo | null>(null);
   const handleRef = useRef<FileSystemFileHandle | null>(null);
   const skillUuidRef = useRef<string | null>(null);
-  const byWebRequestRef = useRef(false);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
@@ -200,7 +199,6 @@ export function useInstallData(): UseInstallData {
     const fid = params.get("file");
     const urlIdx = location.search.indexOf("url=");
     const rawUrl = !uuid && urlIdx !== -1 ? location.search.slice(urlIdx + 4) : null;
-    byWebRequestRef.current = params.get("byWebRequest") === "1";
     let cancelled = false;
 
     const failed = (e: unknown) => {
@@ -266,7 +264,6 @@ export function useInstallData(): UseInstallData {
           const code = await getTempCode(uuid);
           if (code === undefined) throw new Error(t("install:script_info_load_failed"));
           info.code = code;
-          byWebRequestRef.current = cached?.[2]?.byWebRequest === true;
           await loadFromInfo(info, !!cached?.[0], cached?.[2] || {});
         } else if (rawUrl) {
           // .cat.md URL → Skill 安装流程(DNR 把 *.cat.md 重定向到安装页),不走脚本解析;仅 agent 启用时
@@ -369,7 +366,7 @@ export function useInstallData(): UseInstallData {
           await scriptClient.install({ script, code: info.code });
           notify.success(t("install:success"));
         }
-        if (closeAfterInstall) setTimeout(() => leaveInstallPage(byWebRequestRef.current), 300);
+        if (closeAfterInstall) setTimeout(() => leaveInstallPage(), 300);
       } catch (e) {
         notify.error(`${t("install:failed")}: ${(e as Error)?.message || String(e)}`);
       }
@@ -393,7 +390,7 @@ export function useInstallData(): UseInstallData {
     if (opts?.noMoreUpdates && info && !info.userSubscribe) {
       void scriptClient.setCheckUpdateUrl(info.uuid, false);
     }
-    leaveInstallPage(byWebRequestRef.current);
+    leaveInstallPage();
   }, []);
 
   // 监听文件变更后自动重装,并刷新视图代码
@@ -450,7 +447,7 @@ export function useInstallData(): UseInstallData {
     try {
       await agentClient.completeSkillInstall(uuid);
       notify.success(t("install:success"));
-      setTimeout(() => leaveInstallPage(byWebRequestRef.current), 300);
+      setTimeout(() => leaveInstallPage(), 300);
     } catch (e) {
       notify.error(`${t("install:failed")}: ${(e as Error)?.message || String(e)}`);
     }
@@ -459,7 +456,7 @@ export function useInstallData(): UseInstallData {
   const cancelSkill = useCallback(() => {
     const uuid = skillUuidRef.current;
     if (uuid) void agentClient.cancelSkillInstall(uuid);
-    leaveInstallPage(byWebRequestRef.current);
+    leaveInstallPage();
   }, []);
 
   // 重新触发加载(供加载失败后的重试按钮)

--- a/src/pages/install/useInstallData.ts
+++ b/src/pages/install/useInstallData.ts
@@ -304,7 +304,9 @@ export function useInstallData(): UseInstallData {
           });
           const metadata = parseMetadata(code);
           if (!metadata) throw new Error(t("install:script_info_load_failed"));
-          await loadFromInfo(buildScriptInfo(uuidv4(), code, parsed.href, metadata), false, {});
+          await loadFromInfo(buildScriptInfo(uuidv4(), code, parsed.href, metadata), false, {
+            byWebRequest: byWebRequestRef.current,
+          });
         } else if (fid) {
           const handle = await loadHandle(fid);
           if (!handle) throw new Error(t("install:script_info_load_failed"));

--- a/src/pages/install/useInstallData.ts
+++ b/src/pages/install/useInstallData.ts
@@ -301,6 +301,8 @@ export function useInstallData(): UseInstallData {
           });
           const metadata = parseMetadata(code);
           if (!metadata) throw new Error(t("install:script_info_load_failed"));
+          // 直接 URL 入口保持普通脚本准备参数；网页来源身份匹配只由 UUID 暂存选项传递，
+          // 安装页离开方式统一由 history.length 决定，不要为此重新添加 query 标记。
           await loadFromInfo(buildScriptInfo(uuidv4(), code, parsed.href, metadata), false, {});
         } else if (fid) {
           const handle = await loadHandle(fid);

--- a/src/pkg/utils/script.ts
+++ b/src/pkg/utils/script.ts
@@ -178,7 +178,8 @@ export async function prepareScriptByCode(
   dao?: ScriptDAO,
   options?: {
     byEditor?: boolean; // 是否通过编辑器导入
-    byWebRequest?: boolean; // 是否通过网页连结安装或更新
+    // 仅控制网页来源脚本的身份匹配，不参与安装页 history.back()/window.close() 决策。
+    byWebRequest?: boolean;
   }
 ): Promise<{ script: Script; oldScript?: Script; oldScriptCode?: string; oldInTrash?: boolean }> {
   dao = dao ?? new ScriptDAO();


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## 背景

安装页既可能由 ScriptCat 新建为独立标签，也可能由 DNR 接管用户原标签。独立标签可能继承多条历史，DNR 入口也可能没有上一页；单独依赖 `byWebRequest` 或 `history.length` 都会让其中一类入口无法正确离开。

## 本次改动

- 仅在 `byWebRequest && history.length > 1` 时返回用户原页面；其他情况使用 `window.close()`。
- 增加三个回归分支：独立标签继承历史、DNR 有历史可退、DNR 无历史可退。
- 升级版本至 `v1.5.0-beta.3`，Manifest 版本同步为 `1.5.0.1400`。
- 忽略本地 `.opskat/` 工作目录。

## 实现考虑

保留页面原有的重入保护和 `requestAnimationFrame` 延迟。组合入口信号与实际历史栈，避免误关用户原标签，也避免执行无效的 `history.back()`。

## 关联

Fixes #1669

## 验证

- `pnpm exec vitest --no-coverage --run src/pages/install/useInstallData.test.ts`：31/31 通过。
- `pnpm exec playwright test e2e/install.spec.ts e2e/subscribe-lifecycle.spec.ts`：2/2 通过。
- `pnpm run lint`：通过（Prettier、TypeScript、i18n、issue templates、ESLint）。
- `pnpm run build`：通过；仅有现有 bundle/entrypoint size 与 Monaco 动态 `require` 警告。
- `toChromeVersion("1.5.0-beta.3")`：输出 `1.5.0.1400`。
- `git diff --check origin/main...HEAD`：通过。

## Screenshots / 截图

N/A — 行为修复与版本升级，无视觉改动。