### PR TITLE
🐛 云同步不再随 SW 冷启动触发，闹钟周期改为 30 分钟

### DIFF
--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -152,7 +152,7 @@ type PendingSyncOp = { op: "delete"; syncDelete: boolean } | { op: "push" };
 `SynchronizeService` 使用 `SYNC_SERVICE_TASK_KEY = "cloud_sync_queue"` 串行化同步任务。以下入口都会进入同一队列：
 
 - 配置启用后触发的 `syncOnce()`。
-- 定时同步，Chrome alarm 名称为 `cloudSync`，周期为 60 分钟。
+- 定时同步，Chrome alarm 名称为 `cloudSync`，周期为 30 分钟。启用后闹钟是唯一的周期性入口：SW 冷启动只确保闹钟存在，不触发同步（否则同步频率会退化成 SW 冷启动频率，见 #1670）。
 - 非 sync 来源安装脚本后的 `scriptInstall()`。push 失败时按 `PushScriptPartialError` 只保留失败文件的旧 digest，已成功文件推进到云端最新值；部分成功还会登记 `pending_sync_ops` 的 push 意图（见上）。
 - 非 sync 来源删除脚本后的 `scriptsDelete()`。执行前写前登记删除意图，成功后清除。
 

--- a/packages/filesystem/onedrive/onedrive.test.ts
+++ b/packages/filesystem/onedrive/onedrive.test.ts
@@ -186,29 +186,44 @@ describe("OneDriveFileSystem", () => {
     );
   });
 
-  it("createDir should create nested directories from root", async () => {
+  it("createDir should create nested directories through the resolved approot item id", async () => {
     const fs = new OneDriveFileSystem("/", "token");
-    const requestSpy = vi.spyOn(fs, "request").mockResolvedValue({});
+    const requestSpy = vi.spyOn(fs, "request").mockResolvedValueOnce({ id: "APPROOT!1" }).mockResolvedValue({});
 
     await expect(fs.createDir("A/B/C")).resolves.toBeUndefined();
 
-    expect(requestSpy).toHaveBeenCalledTimes(3);
-    expect(requestSpy.mock.calls[0][0]).toBe("https://graph.microsoft.com/v1.0/me/drive/special/approot/children");
-    expect(requestSpy.mock.calls[1][0]).toBe("https://graph.microsoft.com/v1.0/me/drive/special/approot:/A:/children");
-    expect(requestSpy.mock.calls[2][0]).toBe(
-      "https://graph.microsoft.com/v1.0/me/drive/special/approot:/A/B:/children"
+    expect(requestSpy).toHaveBeenCalledTimes(4);
+    expect(requestSpy.mock.calls[0][0]).toBe("https://graph.microsoft.com/v1.0/me/drive/special/approot");
+    expect(requestSpy.mock.calls[1][0]).toBe("https://graph.microsoft.com/v1.0/me/drive/items/APPROOT!1/children");
+    expect(requestSpy.mock.calls[2][0]).toBe("https://graph.microsoft.com/v1.0/me/drive/items/APPROOT!1:/A:/children");
+    expect(requestSpy.mock.calls[3][0]).toBe(
+      "https://graph.microsoft.com/v1.0/me/drive/items/APPROOT!1:/A/B:/children"
     );
-    expect(JSON.parse((requestSpy.mock.calls[2][1] as RequestInit).body as string)).toMatchObject({
+    expect(JSON.parse((requestSpy.mock.calls[3][1] as RequestInit).body as string)).toMatchObject({
       name: "C",
       folder: {},
       "@microsoft.graph.conflictBehavior": "fail",
     });
   });
 
+  it("createDir should resolve the approot item id only once per instance", async () => {
+    const fs = new OneDriveFileSystem("/", "token");
+    const requestSpy = vi.spyOn(fs, "request").mockResolvedValueOnce({ id: "APPROOT!1" }).mockResolvedValue({});
+
+    await fs.createDir("A");
+    await fs.createDir("B");
+
+    const approotLookups = requestSpy.mock.calls.filter(
+      (call) => call[0] === "https://graph.microsoft.com/v1.0/me/drive/special/approot"
+    );
+    expect(approotLookups).toHaveLength(1);
+  });
+
   it("createDir should continue when an intermediate directory already exists", async () => {
     const fs = new OneDriveFileSystem("/", "token");
     const requestSpy = vi
       .spyOn(fs, "request")
+      .mockResolvedValueOnce({ id: "APPROOT!1" })
       .mockRejectedValueOnce(
         new FileSystemError({
           provider: "onedrive",
@@ -223,10 +238,35 @@ describe("OneDriveFileSystem", () => {
 
     await expect(fs.createDir("A/B")).resolves.toBeUndefined();
 
-    expect(requestSpy).toHaveBeenCalledTimes(2);
-    expect(JSON.parse((requestSpy.mock.calls[1][1] as RequestInit).body as string)).toMatchObject({
+    expect(requestSpy).toHaveBeenCalledTimes(3);
+    expect(JSON.parse((requestSpy.mock.calls[2][1] as RequestInit).body as string)).toMatchObject({
       name: "B",
     });
+  });
+
+  // Graph 个人版对 special/ 寻址的 POST children 一律返回 400 invalidRequest，
+  // 该错误码不属于冲突码，会让已存在的同步目录把整条同步流程打断
+  it("createDir should not address approot children through the special/ alias", async () => {
+    const fs = new OneDriveFileSystem("/", "token");
+    const requestSpy = vi
+      .spyOn(fs, "request")
+      .mockResolvedValueOnce({ id: "APPROOT!1" })
+      .mockRejectedValue(
+        new FileSystemError({
+          provider: "onedrive",
+          message: "Invalid request",
+          status: 400,
+          code: "invalidRequest",
+          raw: { error: { code: "invalidRequest" } },
+        })
+      );
+
+    await expect(fs.createDir("ScriptCat/sync")).rejects.toBeInstanceOf(FileSystemError);
+
+    for (const call of requestSpy.mock.calls) {
+      expect(call[0]).not.toContain("special/approot/children");
+      expect(call[0]).not.toContain("special/approot:");
+    }
   });
 
   it("request should throw auth error when retry still gets 401", async () => {

--- a/packages/filesystem/onedrive/onedrive.test.ts
+++ b/packages/filesystem/onedrive/onedrive.test.ts
@@ -219,6 +219,17 @@ describe("OneDriveFileSystem", () => {
     expect(approotLookups).toHaveLength(1);
   });
 
+  it("createDir should reject a malformed approot response before building a child URL", async () => {
+    const fs = new OneDriveFileSystem("/", "token");
+    const requestSpy = vi.spyOn(fs, "request").mockResolvedValue({});
+
+    await expect(fs.createDir("A")).rejects.toMatchObject({
+      provider: "onedrive",
+      code: "invalidResponse",
+    });
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("createDir should continue when an intermediate directory already exists", async () => {
     const fs = new OneDriveFileSystem("/", "token");
     const requestSpy = vi

--- a/packages/filesystem/onedrive/onedrive.ts
+++ b/packages/filesystem/onedrive/onedrive.ts
@@ -82,7 +82,15 @@ export default class OneDriveFileSystem implements FileSystem {
       return this.approotId;
     }
     const data = await this.request("https://graph.microsoft.com/v1.0/me/drive/special/approot");
-    const id: string = data.id;
+    const id = data && typeof data === "object" && "id" in data ? data.id : undefined;
+    if (typeof id !== "string" || id.length === 0) {
+      throw new FileSystemError({
+        provider: "onedrive",
+        message: "OneDrive approot response is missing an item id",
+        code: "invalidResponse",
+        raw: data,
+      });
+    }
     this.approotId = id;
     return id;
   }

--- a/packages/filesystem/onedrive/onedrive.ts
+++ b/packages/filesystem/onedrive/onedrive.ts
@@ -10,6 +10,8 @@ export default class OneDriveFileSystem implements FileSystem {
 
   path: string;
 
+  private approotId?: string;
+
   constructor(path?: string, accessToken?: string) {
     this.path = path || "/";
     this.accessToken = accessToken;
@@ -47,6 +49,7 @@ export default class OneDriveFileSystem implements FileSystem {
       return;
     }
     const dirs = joinPath(this.path, dir).split("/").filter(Boolean);
+    const approotId = await this.getApprootId();
     const myHeaders = new Headers();
     myHeaders.append("Content-Type", "application/json");
 
@@ -54,7 +57,7 @@ export default class OneDriveFileSystem implements FileSystem {
       const parentPath = dirs.slice(0, i).join("/");
       const parent = parentPath ? `:/${parentPath}:` : "";
       try {
-        await this.request(`https://graph.microsoft.com/v1.0/me/drive/special/approot${parent}/children`, {
+        await this.request(`https://graph.microsoft.com/v1.0/me/drive/items/${approotId}${parent}/children`, {
           method: "POST",
           headers: myHeaders,
           body: JSON.stringify({
@@ -70,6 +73,18 @@ export default class OneDriveFileSystem implements FileSystem {
         throw error;
       }
     }
+  }
+
+  // Graph 个人版对 special/ 寻址的 POST children 一律回 400 invalidRequest，
+  // 建目录必须先把 approot 解析成 item id 再寻址；读取与上传不受影响
+  private async getApprootId(): Promise<string> {
+    if (this.approotId) {
+      return this.approotId;
+    }
+    const data = await this.request("https://graph.microsoft.com/v1.0/me/drive/special/approot");
+    const id: string = data.id;
+    this.approotId = id;
+    return id;
   }
 
   private isDirectoryAlreadyExistsError(error: unknown): boolean {

--- a/src/app/service/service_worker/index.ts
+++ b/src/app/service/service_worker/index.ts
@@ -242,12 +242,11 @@ export default class ServiceWorkerManager {
           regularScriptUpdateCheck();
           break;
         case "cloudSync":
-          // 进行一次云同步
-          systemConfig.getCloudSync().then((config) => {
-            synchronize.buildFileSystem(config).then((fs) => {
-              synchronize.syncOnce(config, fs);
-            });
-          });
+          // 闹钟是启用之后唯一的周期性同步入口（冷启动不再同步），cloudSyncOnce 自带启用校验
+          // 与失败状态写入；连接失败必须在这里收住，否则每轮闹钟都留下一个未捕获 rejection
+          synchronize
+            .cloudSyncOnce()
+            .catch((e) => this.serviceLogger.error("cloud sync alarm failed", RuntimeLogger.E(e)));
           break;
         case "checkUpdate":
           // 检查扩展更新

--- a/src/app/service/service_worker/synchronize.test.ts
+++ b/src/app/service/service_worker/synchronize.test.ts
@@ -2498,6 +2498,18 @@ console.log("ok");`
       expect(alarmCreate).toHaveBeenCalledWith("cloudSync", { periodInMinutes: 30 }, expect.any(Function));
     });
 
+    it("启动时已有旧周期的云同步闹钟会更新为 30 分钟", async () => {
+      alarmGet.mockImplementationOnce((_name, callback) =>
+        callback({ name: "cloudSync", periodInMinutes: 60 } as chrome.alarms.Alarm)
+      );
+      const { service } = createService();
+
+      service.cloudSyncConfigChange(syncConfig, undefined);
+      await flushMicrotasks();
+
+      expect(alarmCreate).toHaveBeenCalledWith("cloudSync", { periodInMinutes: 30 }, expect.any(Function));
+    });
+
     it("从关闭到启用会同步一次并确保定时闹钟存在", async () => {
       const { service, buildFileSystem, syncOnce } = createService();
       const disabled = { ...syncConfig, enable: false };

--- a/src/app/service/service_worker/synchronize.test.ts
+++ b/src/app/service/service_worker/synchronize.test.ts
@@ -2484,19 +2484,21 @@ console.log("ok");`
       });
     });
 
-    it("启动时配置已启用会同步一次并确保小时闹钟存在", async () => {
+    // MV3 的 SW 空闲即被回收，每次冷启动都会重跑 init 并用当前配置回调一次 watch。
+    // 若在这里同步，同步频率就退化成 SW 冷启动频率（#1670：实测每分钟一轮全量同步）。
+    it("启动时配置已启用只确保定时闹钟，不立即同步", async () => {
       const { service, buildFileSystem, syncOnce } = createService();
 
       service.cloudSyncConfigChange(syncConfig, undefined);
       await flushMicrotasks();
 
-      expect(buildFileSystem).toHaveBeenCalledTimes(1);
-      expect(syncOnce).toHaveBeenCalledTimes(1);
+      expect(buildFileSystem).not.toHaveBeenCalled();
+      expect(syncOnce).not.toHaveBeenCalled();
       expect(alarmGet).toHaveBeenCalledWith("cloudSync", expect.any(Function));
-      expect(alarmCreate).toHaveBeenCalledWith("cloudSync", { periodInMinutes: 60 }, expect.any(Function));
+      expect(alarmCreate).toHaveBeenCalledWith("cloudSync", { periodInMinutes: 30 }, expect.any(Function));
     });
 
-    it("从关闭到启用会同步一次并确保小时闹钟存在", async () => {
+    it("从关闭到启用会同步一次并确保定时闹钟存在", async () => {
       const { service, buildFileSystem, syncOnce } = createService();
       const disabled = { ...syncConfig, enable: false };
 
@@ -2508,7 +2510,7 @@ console.log("ok");`
       expect(alarmGet).toHaveBeenCalledTimes(1);
     });
 
-    it("从启用到关闭只清除小时闹钟", async () => {
+    it("从启用到关闭只清除定时闹钟", async () => {
       const { service, buildFileSystem, syncOnce } = createService();
 
       service.cloudSyncConfigChange({ ...syncConfig, enable: false }, syncConfig);
@@ -2601,7 +2603,8 @@ console.log("ok");`
     process.on("unhandledRejection", unhandled);
 
     try {
-      service.cloudSyncConfigChange({ ...syncConfig, enable: true });
+      // 冷启动（无 previous）只建闹钟不同步，须由「关→开」这条仍会立即同步的路径触发 buildFileSystem
+      service.cloudSyncConfigChange({ ...syncConfig, enable: true }, { ...syncConfig, enable: false });
       await flushMicrotasks();
 
       expect(errorSpy).toHaveBeenCalledWith("cloud sync config change error", expect.anything());

--- a/src/app/service/service_worker/synchronize.ts
+++ b/src/app/service/service_worker/synchronize.ts
@@ -1308,7 +1308,7 @@ export class SynchronizeService {
         chrome.alarms.create(
           "cloudSync",
           {
-            periodInMinutes: 60,
+            periodInMinutes: 30,
           },
           () => {
             const lastError = chrome.runtime.lastError;
@@ -1341,10 +1341,11 @@ export class SynchronizeService {
     this.lastCloudSyncConfig = value;
     if (knownPrevious && isCloudSyncConfigEquivalent(value, knownPrevious)) return;
 
-    // 启动时首次处理配置：按当前值恢复运行状态，避免 SW 重启后漏掉同步或小时闹钟。
+    // 启动时首次处理配置：只恢复闹钟，不同步。MV3 的 SW 空闲即被回收，每次冷启动都会重跑 init
+    // 并用当前配置回调一次 watch；在这里同步会让实际频率退化成 SW 冷启动频率（#1670）。
     if (!knownPrevious) {
       if (value.enable) {
-        this.startCloudSync(value);
+        this.ensureCloudSyncAlarm();
       } else {
         this.clearCloudSyncAlarm();
       }

--- a/src/app/service/service_worker/synchronize.ts
+++ b/src/app/service/service_worker/synchronize.ts
@@ -1304,7 +1304,7 @@ export class SynchronizeService {
       if (lastError) {
         console.error("chrome.runtime.lastError in chrome.alarms.get:", lastError);
       }
-      if (!alarm) {
+      if (!alarm || alarm.periodInMinutes !== 30) {
         chrome.alarms.create(
           "cloudSync",
           {


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## Description / 描述

Close #1670

### 背景

用户把云同步接到 S3 桶后发现「同步频率设成每天，结果每分钟调用五次接口」。

MV3 的 Service Worker 空闲即被回收，每次冷启动都会重跑 `init()` 并用当前配置回调一次
`cloud_sync` 的 `watch`（`SystemConfig.watch` 注册时会立即执行一次回调）。
`cloudSyncConfigChange` 在无 `previous` 时会直接跑一次全量 `syncOnce` ——
而 `agentTaskScheduler` 闹钟每分钟唤醒一次 SW，于是实际同步频率退化成「每分钟一轮」，
60 分钟的 `cloudSync` 闹钟形同虚设。

v1.4.0 与当前 main 都有这个问题（v1.4.0 连配置等价判重都没有，另外还多一个
`extension_initialized` 触发点）。

顺带说明：云同步并没有频率设置项，设置页上紧挨着同步卡片的「每天」是**脚本更新检查周期**，
报告人把它当成同步周期了。

### 本次改动

- 冷启动只 `ensureCloudSyncAlarm()`，不再同步；周期同步交给闹钟。
- `cloudSync` 闹钟周期 60 → **30** 分钟。
- 闹钟成为启用后唯一的周期性入口，处理器从裸的 `getCloudSync → buildFileSystem → syncOnce`
  改走 `synchronize.cloudSyncOnce()`（自带启用校验与失败状态写入）并补 `.catch` ——
  原来连接失败会在每轮闹钟留下一个未捕获 rejection。

**不变**：勾选启用的瞬间仍立即同步一次、设置页「立即同步」按钮、脚本安装/删除的事件推送。

第二个提交是顺带修的 OneDrive 建目录问题（Graph 个人版对 `special/` 寻址的 POST children
返回 400 invalidRequest，改用 `/me/drive/items/{approotId}` 寻址）。

### 验证

单元测试按 TDD 先写 RED 再实现：

```
$ npx vitest run src/app/service/service_worker/synchronize.test.ts -t "云同步配置变更调度"
AssertionError: expected "buildFileSystem" to not be called at all, but actually been called 1 times
  ❯ synchronize.test.ts:2495  expect(buildFileSystem).not.toHaveBeenCalled();

$ npx vitest run --no-coverage        # 实现后，连跑 3 次
Test Files  329 passed (329)
Tests  3732 passed (3732)

$ npx tsc --noEmit                    # exit 0
$ npx prettier --check / npx eslint   # exit 0
```

真机复现与验收（真实 MinIO，扩展的 S3 端点指向一个逐请求记账的透传代理；
脱离调试器运行，因为 CDP 附着会阻止 MV3 SW 被回收、这个 bug 就不出现）：

| 8 分钟完全空闲窗口 | 同步轮数 | S3 请求数 |
|---|---|---|
| 修复前 | 7 | 34 |
| 修复后 | **0** | **0** |

修复前的轮次起点：`02:09:57 / 02:10:57 / 02:11:58 / 02:12:57 / 02:14:00 / 02:15:59 / 02:16:57`，
每轮 `HEAD` + `LIST` + `GET` + `PUT` + `LIST`，与 issue 里贴的 5 条日志一致。

修复后仍验证了三条该保留的路径：

- 勾选「启用」瞬间同步一次（`02:37:52` 一轮）；
- 闹钟仍触发同步：把闹钟**排程**临时改成 1 分钟以免等 30 分钟，`02:39:17` 排程 →
  `02:39:17.264` 起一轮（只替换触发时刻，处理器与同步链路是真实的）；
- `chrome.alarms.getAll()` 实测 `cloudSync period=30min`。

`.catch` 单独验证：停掉代理制造真实连接失败，日志出现 `cloud sync alarm failed`，
整个会话 `[exception]` 计数为 0。

另做了一次不经过代理的独立回读（扩展页 `chrome.storage.local`）：空闲窗口后
`lastSyncAt` 仍停在 `02:39:18`、`enable=true`；而这次回读本身又是一次冷启动，
`lastSyncAt` 未推进。

### 已知限制

- 跨设备拉取延迟从「近乎实时」（此前是 bug 导致的每分钟同步）变为最长 30 分钟。
  同步周期仍是硬编码，可配置化是单独的 feature。
- `agentTaskScheduler` 仍每分钟唤醒一次 SW，无条件创建、不受 Agent 开关约束。
  修完后它不再产生 S3 请求，但每分钟冷启一次 SW 的开销仍在，属另一个 issue，本 PR 未动。
