### PR TITLE
💄 菜单展开数量为 0 时，popup 展开的菜单排在编辑/脚本设置之前

### DIFF
--- a/src/pages/popup/App.test.tsx
+++ b/src/pages/popup/App.test.tsx
@@ -450,6 +450,61 @@ describe("Popup 输入型 GM 菜单（对齐 v1.4：菜单名按钮即提交）"
   });
 });
 
+describe("Popup 菜单展开数量为 0 时的菜单位置", () => {
+  const menu = { key: "k1", name: "菜单命令", groupKey: "g1" };
+
+  function buttonTexts() {
+    return Array.from(document.querySelectorAll("button")).map((b) => b.textContent || "");
+  }
+
+  it("菜单展开数量为 0：展开脚本后，菜单排在「编辑」「脚本设置」之前", () => {
+    const script = makeScriptMenu({ uuid: "u1", menus: [menu] });
+    mockData = makeData({
+      scriptList: [script],
+      allScripts: [script],
+      fullScriptCount: 1,
+      enabledScriptCount: 1,
+      menuExpandNum: 0,
+    });
+
+    render(<App />);
+    // 未展开时不显示菜单
+    expect(screen.queryByText("菜单命令")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Script A").closest("button")!);
+
+    const texts = buttonTexts();
+    const menuIndex = texts.findIndex((s) => s.includes("菜单命令"));
+    const editIndex = texts.findIndex((s) => s.includes(t("edit")));
+    const settingIndex = texts.findIndex((s) => s.includes(t("editor:script_setting")));
+    expect(menuIndex).toBeGreaterThanOrEqual(0);
+    expect(menuIndex).toBeLessThan(editIndex);
+    expect(menuIndex).toBeLessThan(settingIndex);
+  });
+
+  it("菜单展开数量大于 0：菜单仍常驻在折叠区之外，位于「编辑」「脚本设置」之后", () => {
+    const script = makeScriptMenu({ uuid: "u1", menus: [menu] });
+    mockData = makeData({
+      scriptList: [script],
+      allScripts: [script],
+      fullScriptCount: 1,
+      enabledScriptCount: 1,
+      menuExpandNum: 5,
+    });
+
+    render(<App />);
+    expect(screen.getByText("菜单命令")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Script A").closest("button")!);
+
+    const texts = buttonTexts();
+    const menuIndex = texts.findIndex((s) => s.includes("菜单命令"));
+    const settingIndex = texts.findIndex((s) => s.includes(t("editor:script_setting")));
+    expect(settingIndex).toBeGreaterThanOrEqual(0);
+    expect(menuIndex).toBeGreaterThan(settingIndex);
+  });
+});
+
 describe("Popup 移动端宽度适配 (#686 Edge Android)", () => {
   it("popup.html 通过媒体查询在移动端（视口 >360px）将宽度切换为 100%", () => {
     const html = fs.readFileSync(path.join(process.cwd(), "src/pages/popup.html"), "utf8");

--- a/src/pages/popup/App.test.tsx
+++ b/src/pages/popup/App.test.tsx
@@ -503,6 +503,26 @@ describe("Popup 菜单展开数量为 0 时的菜单位置", () => {
     expect(settingIndex).toBeGreaterThanOrEqual(0);
     expect(menuIndex).toBeGreaterThan(settingIndex);
   });
+
+  it("负数菜单展开数量：保留原有行为显示全部菜单", () => {
+    const menus = [
+      { key: "k1", name: "菜单命令 1", groupKey: "g1" },
+      { key: "k2", name: "菜单命令 2", groupKey: "g2" },
+    ];
+    const script = makeScriptMenu({ uuid: "u1", menus });
+    mockData = makeData({
+      scriptList: [script],
+      allScripts: [script],
+      fullScriptCount: 1,
+      enabledScriptCount: 1,
+      menuExpandNum: -1,
+    });
+
+    render(<App />);
+
+    expect(screen.getByText("菜单命令 1")).toBeInTheDocument();
+    expect(screen.getByText("菜单命令 2")).toBeInTheDocument();
+  });
 });
 
 describe("Popup 移动端宽度适配 (#686 Edge Android)", () => {

--- a/src/pages/popup/App.tsx
+++ b/src/pages/popup/App.tsx
@@ -512,13 +512,11 @@ function ScriptRow({
   const allVisibleMenus = getVisibleMenuItems(script.menus);
   const [isActive, setIsActive] = useState(false);
   const [isMenuExpanded, setIsMenuExpanded] = useState(false);
-  // menuExpandNum=0 时跟随折叠面板状态；>0 时按数量截断
-  const shouldTruncateMenus = menuExpandNum > 0 && allVisibleMenus.length > menuExpandNum;
-  const visibleMenus = (() => {
-    if (menuExpandNum === 0) return isActive ? allVisibleMenus : [];
-    if (shouldTruncateMenus && !isMenuExpanded) return allVisibleMenus.slice(0, menuExpandNum);
-    return allVisibleMenus;
-  })();
+  // menuExpandNum=0 时菜单移入折叠面板并排在编辑等操作项之前（菜单比操作项更常用）；>0 时常驻行下方并按数量截断
+  const menusInCollapsible = menuExpandNum === 0;
+  const shouldTruncateMenus = !menusInCollapsible && allVisibleMenus.length > menuExpandNum;
+  const visibleMenus =
+    shouldTruncateMenus && !isMenuExpanded ? allVisibleMenus.slice(0, menuExpandNum) : allVisibleMenus;
   const excludeSite = showSiteScopeActions
     ? onExcludeFromMatch
       ? () => onExcludeFromMatch(script.uuid)
@@ -528,6 +526,35 @@ function ScriptRow({
       : undefined;
   const statusBadge = getStatusBadge(script, isPageScript, t);
   const displayName = script.name;
+
+  const menuNodes = visibleMenus.map((menuItem) =>
+    menuItem.options?.inputType ? (
+      <InputMenuItem
+        key={menuItem.groupKey}
+        menuItem={menuItem}
+        allMenus={script.menus}
+        uuid={script.uuid}
+        onMenuClick={onMenuClick}
+      />
+    ) : (
+      <ActionItem
+        key={menuItem.groupKey}
+        icon={<MenuIcon className="w-3.5 h-3.5" />}
+        title={menuItem.options?.title}
+        onClick={() => {
+          const sameGroup = script.menus.filter((m) => m.groupKey === menuItem.groupKey && !m.options?.inputType);
+          onMenuClick(script.uuid, sameGroup);
+        }}
+      >
+        {menuItem.name}
+        {menuItem.options?.accessKey && (
+          <span className="ml-auto text-[10px] text-muted-foreground">
+            {`(${menuItem.options.accessKey.toUpperCase()})`}
+          </span>
+        )}
+      </ActionItem>
+    )
+  );
 
   // 运行次数 tooltip
   const runTitle = !script.enable
@@ -570,6 +597,7 @@ function ScriptRow({
       {/* 折叠区域：操作按钮（点击展开） */}
       <CollapsiblePrimitive.Content className="overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down">
         <div className={cn("flex flex-col gap-0.5", compact ? "pl-9 pr-3 pt-0.5 pb-1" : "pl-11 pr-4 pt-1 pb-2")}>
+          {menusInCollapsible && menuNodes}
           {/* 运行/停止（仅后台脚本） */}
           {!isPageScript && onRun && onStop && (
             <>
@@ -632,38 +660,9 @@ function ScriptRow({
       </CollapsiblePrimitive.Content>
 
       {/* 始终可见区域：GM 菜单、用户配置（与旧版一致，不在折叠内） */}
-      {(visibleMenus.length > 0 || script.hasUserConfig) && (
+      {((!menusInCollapsible && visibleMenus.length > 0) || script.hasUserConfig) && (
         <div className={cn("flex flex-col gap-0.5", compact ? "pl-9 pr-3 pb-0.5" : "pl-11 pr-4 pb-1")}>
-          {visibleMenus.map((menuItem) =>
-            menuItem.options?.inputType ? (
-              <InputMenuItem
-                key={menuItem.groupKey}
-                menuItem={menuItem}
-                allMenus={script.menus}
-                uuid={script.uuid}
-                onMenuClick={onMenuClick}
-              />
-            ) : (
-              <ActionItem
-                key={menuItem.groupKey}
-                icon={<MenuIcon className="w-3.5 h-3.5" />}
-                title={menuItem.options?.title}
-                onClick={() => {
-                  const sameGroup = script.menus.filter(
-                    (m) => m.groupKey === menuItem.groupKey && !m.options?.inputType
-                  );
-                  onMenuClick(script.uuid, sameGroup);
-                }}
-              >
-                {menuItem.name}
-                {menuItem.options?.accessKey && (
-                  <span className="ml-auto text-[10px] text-muted-foreground">
-                    {`(${menuItem.options.accessKey.toUpperCase()})`}
-                  </span>
-                )}
-              </ActionItem>
-            )
-          )}
+          {!menusInCollapsible && menuNodes}
           {/* 菜单展开/收起 */}
           {shouldTruncateMenus && (
             <button

--- a/src/pages/popup/App.tsx
+++ b/src/pages/popup/App.tsx
@@ -514,7 +514,7 @@ function ScriptRow({
   const [isMenuExpanded, setIsMenuExpanded] = useState(false);
   // menuExpandNum=0 时菜单移入折叠面板并排在编辑等操作项之前（菜单比操作项更常用）；>0 时常驻行下方并按数量截断
   const menusInCollapsible = menuExpandNum === 0;
-  const shouldTruncateMenus = !menusInCollapsible && allVisibleMenus.length > menuExpandNum;
+  const shouldTruncateMenus = menuExpandNum > 0 && allVisibleMenus.length > menuExpandNum;
   const visibleMenus =
     shouldTruncateMenus && !isMenuExpanded ? allVisibleMenus.slice(0, menuExpandNum) : allVisibleMenus;
   const excludeSite = showSiteScopeActions


### PR DESCRIPTION
## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

N/A — 本次为主动优化，没有关联 issue。

## 背景

用户提出的用户体验优化

设置里「菜单展开数量」填 0 表示「展开脚本后才显示菜单」。但当时的实现只是把菜单的可见性挂到折叠面板状态上，菜单节点本身仍渲染在折叠区**之外**（`CollapsiblePrimitive.Content` 之后）。结果是展开脚本后，DOM/视觉顺序是：编辑 → 脚本设置 →（站点范围操作）→ 删除 → 菜单。用户为了点一个 GM 菜单，要先越过一整列低频操作项。

## 本次改动

`menuExpandNum === 0` 时，把 GM 菜单移入折叠面板内部并置于最前，展开脚本后第一眼就是菜单，「编辑 / 脚本设置 / 删除」跟在其后。

`menuExpandNum > 0` 的行为完全不变：菜单仍常驻在脚本行下方（不在折叠区内），超出数量的部分折叠并显示展开/收起按钮。用户配置项也保持原位（始终可见区域），不随本次改动移动。

## 实现考虑

- 菜单项 JSX 抽成 `menuNodes` 变量，两处按 `menusInCollapsible` 择一渲染，避免同一段渲染逻辑复制两份。
- 0 模式下不再需要 `isActive ? allVisibleMenus : []` 这个手动可见性判断：Radix `Collapsible.Content` 在关闭时本就不挂载子节点，收起时菜单自然不渲染（测试里断言了收起态查不到菜单项）。
- 截断相关状态（`shouldTruncateMenus` / `isMenuExpanded`）只在 `menuExpandNum > 0` 时有意义，条件里显式排除了 0 模式。

## 建议审查重点

- 后台脚本行：0 模式下菜单现在排在「运行一次 / 停止」之前。这是刻意的（菜单比操作项高频），如果更希望运行/停止保持首位可以提出。
- 0 模式 + 有用户配置的脚本：用户配置仍在折叠区外常驻，与菜单不在同一区块，这是既有行为，未改动。

## 已知限制

仅做了单元测试层面的 DOM 顺序验证，没有跑真实浏览器扩展做视觉确认。

## 验证

```
npx vitest run src/pages/popup/App.test.tsx   # 31 passed
npx vitest run src/pages                      # 181 files / 1326 tests passed
npx tsc --noEmit                              # 无输出
npx eslint src/pages/popup/App.tsx src/pages/popup/App.test.tsx   # 无输出
npx prettier --write <两个改动文件>            # unchanged
```

新增两条测试（先失败后通过）：

- 「菜单展开数量为 0：展开脚本后，菜单排在「编辑」「脚本设置」之前」—— 改动前失败（`expected 10 to be less than 7`）。
- 「菜单展开数量大于 0：菜单仍常驻在折叠区之外，位于「编辑」「脚本设置」之后」—— 改动前后均通过，作为回归护栏。
