### PR TITLE
🐛 修复 Firefox content world 沙盒自引用逃逸与接口物件被剥空

### DIFF
--- a/src/app/service/content/create_context.test.ts
+++ b/src/app/service/content/create_context.test.ts
@@ -238,3 +238,102 @@ describe.concurrent("createProxyContext", () => {
     expect(Object.hasOwn(sandbox, "addEventListener")).toBe(true);
   });
 });
+
+// Firefox 的 content / USER_SCRIPT world 全局是 Cu.Sandbox：globalThis 与 window 分属两个 realm，
+// 沙盒的原型链在 Xray window 处截断，EventTarget.prototype 上的成员只能经 window 取得。
+// happy-dom 里 globalThis === window，只能用一个「仅存在于 window 原型链上」的成员模拟该拓扑。
+describe("Firefox content world：globalThis 与 window 分属不同 realm", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("沙盒补齐只能经 window 原型链取得的成员 (#1692)", async () => {
+    const windowProto = Object.create(null);
+    // 原生 DOM 方法没有 prototype，这里必须用同样形状（方法简写），否则模型不成立
+    windowProto.onlyReachableViaWindow = {
+      onlyReachableViaWindow(this: unknown) {
+        return this;
+      },
+    }.onlyReachableViaWindow;
+    const fakeWindow = Object.create(windowProto);
+    vi.stubGlobal("window", fakeWindow);
+    vi.resetModules();
+
+    const module = await import("./create_context.js");
+    const context = module.createContext(
+      createScriptInfo(),
+      { script: { name: "create-context-test" }, scriptMetaStr: "" },
+      "vitest",
+      undefined as any,
+      undefined as any,
+      new Set<string>()
+    );
+    const sandbox = module.createProxyContext(context);
+
+    expect(typeof sandbox.onlyReachableViaWindow).toBe("function");
+    // bind 目标必须跟随该轮的根物件，否则跨 realm 呼叫会触发 brand check 失败
+    expect(sandbox.onlyReachableViaWindow()).toBe(fakeWindow);
+  });
+
+  it("接口物件保留 prototype 与静态常量，不被 bind 剥空", async () => {
+    // bind 的产物没有 prototype、也丢掉全部静态成员。Firefox 的 Cu.Sandbox 上
+    // Node / NodeFilter 之类不是自有属性，会走到 protoBaseDescs 分支，
+    // 无差别 bind 会让 Node.ELEMENT_NODE / NodeFilter.SHOW_TEXT 全变成 undefined。
+    const windowProto = Object.create(null);
+    // 构造函数形状（Node、Event、XMLHttpRequest）
+    const NodeLike = function NodeLike() {};
+    (NodeLike as any).ELEMENT_NODE = 1;
+    windowProto.NodeLike = NodeLike;
+    // 回调接口形状（NodeFilter）：大写字头但没有 prototype
+    const FilterLike = () => undefined;
+    (FilterLike as any).SHOW_TEXT = 4;
+    windowProto.FilterLike = FilterLike;
+
+    const fakeWindow = Object.create(windowProto);
+    vi.stubGlobal("window", fakeWindow);
+    vi.resetModules();
+
+    const module = await import("./create_context.js");
+    const sandbox = module.createProxyContext(
+      module.createContext(
+        createScriptInfo(),
+        { script: { name: "create-context-test" }, scriptMetaStr: "" },
+        "vitest",
+        undefined as any,
+        undefined as any,
+        new Set<string>()
+      )
+    );
+
+    expect(sandbox.NodeLike.ELEMENT_NODE).toBe(1);
+    expect(sandbox.NodeLike.prototype).toBe(NodeLike.prototype);
+    expect(sandbox.FilterLike.SHOW_TEXT).toBe(4);
+  });
+
+  it("window / self 指向沙盒自身，不逃逸到页面 window", async () => {
+    // Firefox 下 globalThis.window 是页面 Window 的 Xray 包装，不等于 global；
+    // 只按 global 判定自引用会让沙盒里的 window / self 指回页面，
+    // 脚本写在 self 上的东西（例如沉浸式翻译的 GM_fetch）就落到了页面而不是沙盒。
+    const pageWindow: Record<string, any> = Object.create(null);
+    pageWindow.window = pageWindow;
+    pageWindow.self = pageWindow;
+    vi.stubGlobal("window", pageWindow);
+    vi.resetModules();
+
+    const module = await import("./create_context.js");
+    const sandbox = module.createProxyContext(
+      module.createContext(
+        createScriptInfo(),
+        { script: { name: "create-context-test" }, scriptMetaStr: "" },
+        "vitest",
+        undefined as any,
+        undefined as any,
+        new Set<string>()
+      )
+    );
+
+    expect(sandbox.window).toBe(sandbox);
+    expect(sandbox.self).toBe(sandbox);
+  });
+});

--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -155,6 +155,18 @@ export const shouldFnBind = (f: any) => {
   return false;
 };
 
+// 判断是否为「需要 this 的方法」。沿用 shouldFnBind 的结构判定（有 prototype 即为 Class；
+// 小写字头才是可直接呼叫的方法，大写字头是 Node / NodeFilter 之类接口物件），但不做原生代码
+// toString 测试 —— 被扩展 Proxy 封装过的方法同样需要 bind。
+const isBindableMethod = (f: any) => {
+  if (typeof f !== "function") return false;
+  if ("prototype" in f) return false;
+  const { name } = f as typeof Function.prototype;
+  if (!name) return false;
+  const e = name.charCodeAt(0);
+  return e >= 97 && e <= 122 && !name.includes(" ");
+};
+
 type ForEachCallback<T> = (value: T, index: number, array: T[]) => void;
 
 // 取物件本身及所有父类(不包含Object)的PropertyDescriptor
@@ -183,57 +195,72 @@ const protoBaseDescs: Record<string, PropertyDescriptor> = Object.create(null);
 
 // 包含物件本身及所有父类(不包含Object)的PropertyDescriptor
 // 主要是找出哪些 function值， setter/getter 需要替换 global window
-getAllPropertyDescriptors(global, ([key, desc]) => {
-  if (!desc || descsCache.has(key) || typeof key !== "string") return;
+// bind 目标跟随该轮的根物件 root，因为两个根分属不同 realm，互相绑定会触发 brand check 失败
+const collectPropertyDescriptors = (root: any) =>
+  getAllPropertyDescriptors(root, ([key, desc]) => {
+    if (!desc || descsCache.has(key) || typeof key !== "string") return;
 
-  if (desc.writable) {
-    // 属性 value
+    if (desc.writable) {
+      // 属性 value
 
-    const value = desc.value;
+      const value = desc.value;
 
-    // 替换 function 的 this 为 实际的 global window
-    // 例：父类的 addEventListener
-    // 对于构造函数和类（有 prototype 属性），shouldFnBind 会返回 false，跳过绑定
-    // 因此被封装的属性，会略过封装层，继续向父类寻找原生属性
-    if (shouldFnBind(value)) {
-      const boundValue = value.bind(global);
-      overridedDescs[key] = {
-        ...desc,
-        value: boundValue,
-      };
-      descsCache.add(key); // 必须：子类属性覆盖父类属性
-    } else if (!(key in initOwnDescs) && !Object.hasOwn(global, key)) {
-      if (!protoBaseDescs[key]) {
-        if (typeof value === "function") {
-          const boundValue = value.bind(global);
-          protoBaseDescs[key] = {
+      // 替换 function 的 this 为 实际的 global window
+      // 例：父类的 addEventListener
+      // 对于构造函数和类（有 prototype 属性），shouldFnBind 会返回 false，跳过绑定
+      // 因此被封装的属性，会略过封装层，继续向父类寻找原生属性
+      if (shouldFnBind(value)) {
+        const boundValue = value.bind(root);
+        overridedDescs[key] = {
+          ...desc,
+          value: boundValue,
+        };
+        descsCache.add(key); // 必须：子类属性覆盖父类属性
+      } else if (!(key in initOwnDescs) && !Object.hasOwn(root, key)) {
+        if (!protoBaseDescs[key]) {
+          // 只有「需要 this 的方法」才 bind。接口物件（Node、NodeFilter、Event、XMLHttpRequest…）
+          // bind 之后会丢掉 prototype 和全部静态成员，Node.ELEMENT_NODE / NodeFilter.SHOW_TEXT
+          // 之类的常量全部变成 undefined，DOM 遍历会静默失效。
+          // Chrome 下 global 就是 window，这些键都在 initOwnDescs 里、走不到这一支；
+          // Firefox 的 Cu.Sandbox 没有这些自有属性，不加判断就会把接口物件剥成 length/name。
+          if (isBindableMethod(value)) {
+            protoBaseDescs[key] = {
+              ...desc,
+              value: value.bind(root),
+            };
+          } else {
+            protoBaseDescs[key] = { ...desc };
+          }
+        }
+      }
+    } else {
+      if (desc.configurable && desc.get && desc.set && desc.enumerable && key.startsWith("on")) {
+        // 替换 onxxxxx 事件赋值操作
+        // 例：(window.)onload, (window.)onerror
+        eventDescs[key] = desc;
+      } else {
+        if (desc.get || desc.set) {
+          // 替换 getter setter 的 this 为 实际的 global window
+          // 例：(window.)location, (window.)document
+          overridedDescs[key] = {
             ...desc,
-            value: boundValue,
+            get: desc?.get?.bind(root),
+            set: desc?.set?.bind(root),
           };
-        } else {
-          protoBaseDescs[key] = { ...desc };
+          descsCache.add(key); // 必须：子类属性覆盖父类属性
         }
       }
     }
-  } else {
-    if (desc.configurable && desc.get && desc.set && desc.enumerable && key.startsWith("on")) {
-      // 替换 onxxxxx 事件赋值操作
-      // 例：(window.)onload, (window.)onerror
-      eventDescs[key] = desc;
-    } else {
-      if (desc.get || desc.set) {
-        // 替换 getter setter 的 this 为 实际的 global window
-        // 例：(window.)location, (window.)document
-        overridedDescs[key] = {
-          ...desc,
-          get: desc?.get?.bind(global),
-          set: desc?.set?.bind(global),
-        };
-        descsCache.add(key); // 必须：子类属性覆盖父类属性
-      }
-    }
-  }
-});
+  });
+
+// 第一趟 globalThis：Firefox 的 content / USER_SCRIPT world 是独立 realm，JS 内置物件只有在这里
+// 才完整；经 Xray 看页面 window 的内置物件会被剥到只剩 length / name / prototype（Number.isNaN、
+// Math 的全部静态成员都会消失）。
+collectPropertyDescriptors(global);
+// 第二趟 window：同一个 sandbox 的原型链在 Xray window 处截断，够不到 EventTarget.prototype，
+// addEventListener / removeEventListener / dispatchEvent 只能由真实 window 的原型链补齐。
+// descsCache 先到先得，第一趟收下的键不会被覆盖；Chrome 下 window === globalThis，此趟全部跳过。
+window !== global && collectPropertyDescriptors(window);
 descsCache.clear(); // 内存释放
 
 // sharedInitCopy: 完全继承Window.prototype 及 自定义 OwnPropertyDescriptor
@@ -286,6 +313,12 @@ type GMWorldContext = typeof globalThis & Record<PropertyKey, any>;
 
 const isPrimitive = (x: any) => x !== Object(x);
 
+// 判断某个值是否为「本 realm 的 window」，即沙盒自引用应当改写成 mySandbox 的目标。
+// Chrome 的 USER_SCRIPT world 里 global 本身就是 Window（window === global），只有一个候选；
+// Firefox 的 content world 里 global 是 Cu.Sandbox、window 是页面 Window 的 Xray 包装，
+// 两者都要算，否则 window / self / top / parent 会指回页面而不是沙盒。
+const isRealmWindow = (o: any) => o === global || o === window;
+
 // 拦截上下文
 export const createProxyContext = <const Context extends GMWorldContext>(context: any): Context => {
   // let withContext: Context | undefined | { [key: string]: any } = undefined;
@@ -299,7 +332,7 @@ export const createProxyContext = <const Context extends GMWorldContext>(context
   const createFuncWrapper = (f: () => any) => {
     return function (this: any) {
       const ret = f.call(global);
-      if (ret === global) return mySandbox;
+      if (isRealmWindow(ret)) return mySandbox;
       return ret;
     };
   };
@@ -358,8 +391,11 @@ export const createProxyContext = <const Context extends GMWorldContext>(context
   }
 
   for (const key of ["window", "self", "globalThis", "top", "parent", "frames"]) {
-    const desc = ownDescs[key];
-    if (desc?.value === global) {
+    // Firefox 的 content world 里 window / self / top / parent 都不是 Cu.Sandbox 的自有属性，
+    // 结构反射也拿不到（Sandbox 的原型是一个原型为 null 的 Window 包装），沙盒因此完全没有这些键，
+    // with(this.$) 会穿透到外层直接解析到页面 window。按真实取值补出描述符，交给下面的自引用改写。
+    const desc = (ownDescs[key] ??= { value: (<any>window)[key], enumerable: true, configurable: true });
+    if (isRealmWindow(desc.value)) {
       // globalThis
       // 避免 self referencing, 改以 getter 形式
       desc.get = function () {
@@ -369,7 +405,7 @@ export const createProxyContext = <const Context extends GMWorldContext>(context
       // 为了 value 转 getter/setter，必须删除 writable 和 value
       delete desc.writable;
       delete desc.value;
-    } else if (desc?.get) {
+    } else if (desc.get) {
       // 真实的 window 物件中部份属性(self, parent) 存在setter. 意义不明
       // 为避免做成混乱，ScriptCat脚本的沙盒不提供setter（即不能修改）
       // (像window.document, 能写 window.document = null 不会报错但赋值不变)

--- a/src/app/service/content/create_context.ts
+++ b/src/app/service/content/create_context.ts
@@ -183,68 +183,57 @@ const protoBaseDescs: Record<string, PropertyDescriptor> = Object.create(null);
 
 // 包含物件本身及所有父类(不包含Object)的PropertyDescriptor
 // 主要是找出哪些 function值， setter/getter 需要替换 global window
-// bind 目标跟随该轮的根物件 root，因为两个根分属不同 realm，互相绑定会触发 brand check 失败
-const collectPropertyDescriptors = (root: any) =>
-  getAllPropertyDescriptors(root, ([key, desc]) => {
-    if (!desc || descsCache.has(key) || typeof key !== "string") return;
+getAllPropertyDescriptors(global, ([key, desc]) => {
+  if (!desc || descsCache.has(key) || typeof key !== "string") return;
 
-    if (desc.writable) {
-      // 属性 value
+  if (desc.writable) {
+    // 属性 value
 
-      const value = desc.value;
+    const value = desc.value;
 
-      // 替换 function 的 this 为 实际的 global window
-      // 例：父类的 addEventListener
-      // 对于构造函数和类（有 prototype 属性），shouldFnBind 会返回 false，跳过绑定
-      // 因此被封装的属性，会略过封装层，继续向父类寻找原生属性
-      if (shouldFnBind(value)) {
-        const boundValue = value.bind(root);
-        overridedDescs[key] = {
-          ...desc,
-          value: boundValue,
-        };
-        descsCache.add(key); // 必须：子类属性覆盖父类属性
-      } else if (!(key in initOwnDescs) && !Object.hasOwn(root, key)) {
-        if (!protoBaseDescs[key]) {
-          if (typeof value === "function") {
-            const boundValue = value.bind(root);
-            protoBaseDescs[key] = {
-              ...desc,
-              value: boundValue,
-            };
-          } else {
-            protoBaseDescs[key] = { ...desc };
-          }
-        }
-      }
-    } else {
-      if (desc.configurable && desc.get && desc.set && desc.enumerable && key.startsWith("on")) {
-        // 替换 onxxxxx 事件赋值操作
-        // 例：(window.)onload, (window.)onerror
-        eventDescs[key] = desc;
-      } else {
-        if (desc.get || desc.set) {
-          // 替换 getter setter 的 this 为 实际的 global window
-          // 例：(window.)location, (window.)document
-          overridedDescs[key] = {
+    // 替换 function 的 this 为 实际的 global window
+    // 例：父类的 addEventListener
+    // 对于构造函数和类（有 prototype 属性），shouldFnBind 会返回 false，跳过绑定
+    // 因此被封装的属性，会略过封装层，继续向父类寻找原生属性
+    if (shouldFnBind(value)) {
+      const boundValue = value.bind(global);
+      overridedDescs[key] = {
+        ...desc,
+        value: boundValue,
+      };
+      descsCache.add(key); // 必须：子类属性覆盖父类属性
+    } else if (!(key in initOwnDescs) && !Object.hasOwn(global, key)) {
+      if (!protoBaseDescs[key]) {
+        if (typeof value === "function") {
+          const boundValue = value.bind(global);
+          protoBaseDescs[key] = {
             ...desc,
-            get: desc?.get?.bind(root),
-            set: desc?.set?.bind(root),
+            value: boundValue,
           };
-          descsCache.add(key); // 必须：子类属性覆盖父类属性
+        } else {
+          protoBaseDescs[key] = { ...desc };
         }
       }
     }
-  });
-
-// 第一趟 globalThis：Firefox 的 content / USER_SCRIPT world 是独立 realm，JS 内置物件只有在这里
-// 才完整；经 Xray 看页面 window 的内置物件会被剥到只剩 length / name / prototype（Number.isNaN、
-// Math 的全部静态成员都会消失）。
-collectPropertyDescriptors(global);
-// 第二趟 window：同一个 sandbox 的原型链在 Xray window 处截断，够不到 EventTarget.prototype，
-// addEventListener / removeEventListener / dispatchEvent 只能由真实 window 的原型链补齐。
-// descsCache 先到先得，第一趟收下的键不会被覆盖；Chrome 下 window === globalThis，此趟全部跳过。
-window !== global && collectPropertyDescriptors(window);
+  } else {
+    if (desc.configurable && desc.get && desc.set && desc.enumerable && key.startsWith("on")) {
+      // 替换 onxxxxx 事件赋值操作
+      // 例：(window.)onload, (window.)onerror
+      eventDescs[key] = desc;
+    } else {
+      if (desc.get || desc.set) {
+        // 替换 getter setter 的 this 为 实际的 global window
+        // 例：(window.)location, (window.)document
+        overridedDescs[key] = {
+          ...desc,
+          get: desc?.get?.bind(global),
+          set: desc?.set?.bind(global),
+        };
+        descsCache.add(key); // 必须：子类属性覆盖父类属性
+      }
+    }
+  }
+});
 descsCache.clear(); // 内存释放
 
 // sharedInitCopy: 完全继承Window.prototype 及 自定义 OwnPropertyDescriptor


### PR DESCRIPTION
## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

N/A — 无对应 open issue，问题来自用户直接反馈（沉浸式翻译在 Firefox 上不翻译，Chrome 正常）。

> 本 PR 已强制推送整体重写，`26b7e9d0` 的原内容不再保留，详见「与上一版的差异」。

## 背景

带 `@grant`（非 `none`）的 `@inject-into content` 脚本在 Firefox 上完全不工作。以沉浸式翻译为例：Chrome 正常翻译，Firefox 下**一个翻译请求都发不出去**，页面无任何译文。

该类脚本走 `world: "USER_SCRIPT"`，Firefox 的这个 world 全局是 `Cu.Sandbox`，与 Chrome 有两点结构差异（`@grant none` 不建沙盒、走 `exec_script.ts` 的 `execContext = global`，因此**不受影响，也复现不出来**）：

- `globalThis !== window`；
- `window` / `self` / `Node` / `NodeFilter` 等**都不是 `global` 的自有属性**，它们在原型上那个 982 属性的 Window 包装器里，而**该包装器的原型是 `null`** —— 从 `global` 出发的结构反射到此截断。

实测原型链（Firefox 154，`@grant none`）：

```
globalThis (Cu.Sandbox, 78 个自有属性: Number/Math 等 JS 内置)
  └─ [object Window] (982 个自有属性, 有 window/self/fetch/document, 无 addEventListener)
       └─ null                                    ← 断在这里

window (同一个 982 属性 Window)
  └─ Window(0) → EventTarget(0) → EventTarget(4, addEventListener 在这) → Object.prototype
```

注意 Xray 的不对称：**取值**能解析到继承成员（裸 content world 里 `globalThis.addEventListener` 是 function），但 `getOwnPropertyNames` / `getPrototypeOf` 这条**结构反射**路径被过滤。沙盒是按描述符复制构造的，因此只丢在结构那一侧。

## 本次改动

三处，都只在 Firefox 的 content world 触发。Chrome 下 `global` 本身就是 Window，三处判断都恒等成立，**行为不变**（已用 Chrome e2e 对照确认）。

**① 自引用逃逸** — 自引用改写只认 `desc.value === global`，`initOwnDescs` 又只取 `global` 的自有描述符，于是沙盒里根本没有 `window` / `self`，`with(this.$)` 穿透到外层解析到**页面 window**。

沉浸式翻译的传输层正好踩中：写 `self.GM_fetch = <基于 GM.xmlHttpRequest 的 fetch>`，消费时读 `{ fetchPolyfill: globalThis.GM_fetch }` —— 一写一读落到两个对象。修复前实测：

```
globalThis.GM_fetch = undefined        ← 读的这个
self.GM_fetch       = function(imt)    ← 写的这个（落到页面 window）
window.GM_fetch     = function(imt)
```

于是 `fetchPolyfill: undefined` → 回退原生 `fetch` → 跨域被拦 → 请求发不出去。

改为 `isRealmWindow(o) = o === global || o === window`，并在描述符缺失时按真实 `window` 取值补出描述符，交给既有的自引用改写。

**② 接口物件被 `bind` 剥空** — `protoBaseDescs` 分支对任何函数无差别 `value.bind(root)`，而 `bind` 的产物**没有 `prototype`、也丢掉全部静态成员**。实测沙盒里 `Node` 的自有属性只剩 `length,name`：

| | 裸 content world | 修复前沙盒 |
| --- | --- | --- |
| `Node.ELEMENT_NODE` | `1` | `undefined` |
| `NodeFilter.SHOW_TEXT` | `4` | `undefined` |
| `XMLHttpRequest.DONE` | `4` | `undefined` |
| `getPrototypeOf(body) === HTMLBodyElement.prototype` | `true` | `false` |

任何 `node.nodeType === Node.ELEMENT_NODE` 的 DOM 遍历都会全量落空（沉浸式翻译因此一个段落都不标记、一个包装节点都不建）。

新增 `isBindableMethod`，只 bind「小写字头且无 prototype」的方法。这条规则不是新发明的 —— `shouldFnBind` 的注释里早就写着「要求函数名字小写字头 能筛选掉 NodeFilter 之类 Interface（大写开头不用于直接呼叫）」，只是 `protoBaseDescs` 这一支没有照做。

**③ 恢复两趟描述符收集**（#1692，本分支第一个提交先把它 revert 掉，第二个提交连同上述修复一起补回）。经消融实验确认必需，不是靠推理保留的：关掉第二趟后 `globalThis.addEventListener` 回到 `undefined`。同时 `Math` 从 `window` 看是 **0** 个静态成员、从 `global` 看是 **45** 个，所以两个根必须分别取 —— 一刀切换成 `window` 会改成丢 JS 内置。

## 实现考虑

**为什么 ① 和 ② 都要修。** 三者互相独立，缺一不可，逐项消融验证过：只修 ① 请求能发出去但页面不渲染（段落遍历落空）；①+② 才走到渲染；缺 ③ 则 `globalThis.addEventListener` 直接抛 TypeError。

**为什么 ② 用命名规则而不是「有 prototype 就不 bind」。** 先按 `!("prototype" in value)` 试过，`Node` / `Event` / `XMLHttpRequest` / `HTMLBodyElement` 都恢复了，但 `NodeFilter` 仍是 `undefined` —— 它是回调接口，本身**没有** `prototype`。小写字头这条规则同时覆盖两种形状，且与 `shouldFnBind` 既有判定一致。

**`isBindableMethod` 与 `shouldFnBind` 的区别。** 前者不做原生代码 `toString` 测试：走到 `protoBaseDescs` 分支的函数已经被 `shouldFnBind` 拒绝过一次（可能因为被扩展 Proxy 封装而 `toString` 不匹配），这类方法同样需要 bind 才能正确取到 `this`。

## 已知限制

以下两项**本 PR 未处理**，与本次改动无因果关系（修复前后均稳定复现），建议单独开 issue：

1. `resource://gre/modules/Schemas.sys.mjs:159 TypeError: can't access property "call", getter is null` —— Firefox 的 WebExtension API 用一次性 `exportLazyGetter`，`create_context` 捕获其 `get` 后二次调用会命中已清空的闭包。**上一版 PR 内容（`26b7e9d0`）曾尝试用 `bindPropertyDescriptorToRoot` 修这一条，本次强制覆盖后已不在分支上。**
2. Firefox 的 popup 把 3 个菜单列成 6 条（同一 document 内重复注册未去重，Chrome 只有 3 条）。

另：验证只覆盖 Firefox 154.0.1 与 Chrome，未测其他 Firefox 版本；顶层 frame 场景已验，iframe 下 `top` / `parent` 的自引用行为仅由代码路径推导（`window.top !== window` 时不改写），未实测。

## 与上一版的差异

`26b7e9d0` 走的是「硬编码 12 个 DOM 构造器名单，从 `window` 覆盖到沙盒」+「lazy getter 改用 `Reflect.get` 透传」。本版不用白名单：`isBindableMethod` 从成因上解决同一类问题（不止那 12 个，`XMLHttpRequest.DONE`、`KeyboardEvent.DOM_KEY_LOCATION_*` 等同样恢复），代价是不再包含上述 lazy getter 修复。

## 建议审查重点

- `isRealmWindow` 把 `window` 也算作「本 realm 的 window」是否会误伤 iframe 场景：`top` / `parent` 在子 frame 中 `window.top !== window`，应保持指向真实 top，不被改写为沙盒。
- `ownDescs[key] ??= { value: window[key], ... }` 合成的描述符缺少 `writable`（刻意，随后若命中自引用会转成 getter；未命中时保持不可写，与真实 Window 一致）。
- `isBindableMethod` 放宽了「原生代码 toString」检查，确认不会把页面注入的同名普通函数错误 bind。
- Chrome 路径确为恒等：`window === global` ⇒ `isRealmWindow` 退化为 `o === global`；`ownDescs[key]` 恒存在 ⇒ `??=` 不触发；`Node` 等在 `initOwnDescs` 内 ⇒ 走不到 `protoBaseDescs` 分支。

## 验证

head SHA `80ebd8cd0b13954523078935f1cbea6a3e4e3d97`，base `origin/main` = `f8cc26e6`。最终 diff 仅两个文件：

```
$ git diff --stat origin/main...80ebd8cd
 src/app/service/content/create_context.test.ts | 99 +++++++++++++++++++++
 src/app/service/content/create_context.ts      | 39 +++++++--
 2 files changed, 131 insertions(+), 7 deletions(-)
```

### 单元测试

```
npx vitest run src/app/service/content/            → 11 files / 196 tests passed
npx vitest run .../create_context.test.ts          → 15 passed
```

新增 3 条回归测试，在修复前的 `create_context.ts` 上**全部为红**（`git stash` 掉实现后运行）：

```
× 沙盒补齐只能经 window 原型链取得的成员 (#1692)
× 接口物件保留 prototype 与静态常量，不被 bind 剥空
× window / self 指向沙盒自身，不逃逸到页面 window
  → 3 failed | 12 passed
```

happy-dom 里 `globalThis === window`，该拓扑无区分力，因此用 `vi.stubGlobal("window", …)` + `vi.resetModules()` 构造「`window` 与 `globalThis` 分属不同物件、成员只在 `window` 原型链上」来建模；该文件已在 `vitest.config.ts` 的 `ISOLATED` 名单内（模块级 `sharedInitCopy` 需要独立模块环境）。

`tsc --noEmit` / `prettier --check` / `eslint` 由 pre-commit 钩子在两个提交上各跑一次，均通过。**未跑全量 `vitest run`**（仅跑了 `src/app/service/content/`）。

### Firefox 真实扩展验证

`pnpm run build` 产物 + `createFirefoxManifest()` 生成**解包**目录，经 geckodriver（`--allow-system-access`）安装为临时扩展。`userScripts` 与 `<all_urls>` 在 Firefox MV3 下是可选权限且需用户手势，headless 无法点授权弹窗，改由 chrome context 调 `ExtensionPermissions.add()` 预置（等价于用户点「允许」）。脚本经 `serviceWorker/script/installByCode` 种入。环境：Firefox 154.0.1 / geckodriver 0.37.1 / macOS，目标页 `https://example.com/`。

独立复现脚本（`@inject-into content` + `@grant GM_getValue`，不依赖沉浸式翻译，10 项断言）：

| | 修复前 | 修复后 |
| --- | --- | --- |
| 复现脚本 | **0 / 10** | **10 / 10** |

修复前逐项输出：

```
failed: window === globalThis            → window !== globalThis
failed: self === globalThis              → self !== globalThis
failed: GM API 在 window 上可见           → typeof window.GM_getValue = undefined
failed: 写 self 能从 globalThis 读回       → globalThis.__scReproProbe = undefined
failed: Node.ELEMENT_NODE 常量存在        → Node.ELEMENT_NODE = undefined
failed: NodeFilter.SHOW_TEXT 常量存在     → NodeFilter.SHOW_TEXT = undefined
failed: XMLHttpRequest.DONE 常量存在      → XMLHttpRequest.DONE = undefined
failed: 接口物件保留 prototype            → HTMLBodyElement.prototype = [object HTMLElement]
failed: globalThis.addEventListener 可用  → typeof = undefined
failed: EventTarget 事件生命周期可用       → THREW: globalThis.addEventListener is not a function
```

沉浸式翻译 v1.32.7 真脚本（`installByCode` 种入，经 popup `menuClick` 触发「翻译网页」）：

| | 修复前 | 修复后 |
| --- | --- | --- |
| GM 请求数 | **0** | **36** |
| 裸 `fetch` 数 | 全部 | 1（谷歌统计，Chrome 亦失败） |
| 段落标记 `data-imt-p` | 无 | 3 |
| 译文节点 | 0 | `targets: 11`，`cjk: true` |

修复后页面实际渲染结果：

```
Example Domain  示例领域

This domain is for use in documentation examples without needing permission. Avoid use in operations.
这个域名可以用于文档示例的展示，无需获得许可即可使用。但请勿在正式操作中使用该域名。

Learn more  了解更多
```

### Chrome 对照（无回归）

同一份仪表化脚本经 Playwright + `testWithUserScripts` 跑 Chrome：`win===gt=true`、全程 `GM.xmlHttpRequest`、`targets: 2`，与修复前逐项一致。

> 上述 Firefox/Chrome 驱动脚本放在 `e2e/scratch/`（已 gitignore），不随本 PR 提交。

## Screenshots / 截图

N/A — 非视觉改动，证据为上文终端输出与页面文本。

## 关联

- #1692 —— 本分支第一个提交 revert 了它，第二个提交在补齐 ① ② 后将其恢复（消融实验证明其必需）。

无其他关联 issue。本问题来自用户直接反馈，仓库内未找到对应的 open issue。
