### PR TITLE
✅ 补充 context-menu 执行时机回归测试

### DIFF
--- a/src/app/service/content/utils.test.ts
+++ b/src/app/service/content/utils.test.ts
@@ -275,6 +275,55 @@ describe("utils", () => {
     });
   });
 
+  describe("@run-at context-menu 执行时机", () => {
+    it("页面加载时只注册菜单，点击后才执行脚本正文", async () => {
+      let menuListener: (() => void) | undefined;
+      const GM_registerMenuCommand = vi.fn((_name: string, listener: () => void) => {
+        menuListener = listener;
+      });
+      const GM_openInTab = vi.fn();
+      const context = {
+        GM: { registerMenuCommand: GM_registerMenuCommand },
+        GM_openInTab,
+        GM_registerMenuCommand,
+        window: { GM_registerMenuCommand },
+      };
+      const script = compileScript(
+        compileScriptCode({
+          uuid: "issue-1691",
+          name: "Go to Website.Net",
+          namespace: "http://tampermonkey.net/",
+          type: 1,
+          status: 1,
+          sort: 0,
+          runStatus: "complete",
+          createtime: Date.now(),
+          checktime: Date.now(),
+          code: 'GM_openInTab("https://website.net");',
+          value: {},
+          flag: "issue-1691-flag",
+          resource: {},
+          metadata: {
+            include: ["*"],
+            grant: ["GM_openInTab"],
+            "run-at": ["context-menu"],
+          },
+          originalMetadata: {},
+        })
+      );
+
+      await script(context, "Go to Website.Net");
+
+      expect(GM_registerMenuCommand).toHaveBeenCalledWith("Go to Website.Net", expect.any(Function), { nested: false });
+      expect(GM_openInTab).not.toHaveBeenCalled();
+
+      menuListener?.();
+
+      expect(GM_openInTab).toHaveBeenCalledOnce();
+      expect(GM_openInTab).toHaveBeenCalledWith("https://website.net");
+    });
+  });
+
   describe("compileInjectScript", () => {
     const createMockScript = (overrides: Partial<ScriptRunResource> = {}): ScriptRunResource => ({
       uuid: "inject-test-uuid",


### PR DESCRIPTION
## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

N/A — 本 PR 仅补充现有行为的回归覆盖；当前 main 未复现 #1691 所述生产缺陷，因此不声明已修复 issue。

## 背景

#1691 报告带 `@run-at context-menu` 和 `GM_openInTab` 的脚本被判定为不执行。当前实现会在页面加载阶段把脚本正文注册为菜单回调，只有点击菜单后才执行正文；原有测试只检查生成代码包含特定字符串，没有直接观察执行时机。

在 `f8cc26e60f7910b1d653eee1b3297e7476ab1070` 上使用 issue 原脚本做 Chromium 扩展验证时，脚本匹配 `https://example.com/`、注册了 `Go to Website.Net` 菜单数据，并在触发共用 `menuClick` 服务边界后通过 `GM_openInTab` 打开 `https://website.net/`，因此当前 main 未复现生产缺陷。

## 本次改动

- 使用 #1691 的脚本名称、匹配规则、grant、run-at 和正文补充行为级回归测试。
- 断言页面加载阶段只调用 `GM_registerMenuCommand`，不会调用 `GM_openInTab`。
- 执行注册的菜单监听器后，断言 `GM_openInTab("https://website.net")` 恰好调用一次。

## 已知限制

- macOS 拒绝当前自动化进程的辅助访问权限，无法观察和点击 Chrome 原生右键菜单；真实浏览器验证覆盖菜单注册数据及共用的 Service Worker → Content/Inject → 回调 → `GM_openInTab` 路径，不覆盖原生 `chrome.contextMenus` UI 和 `onClicked` 入口。
- `pnpm test` 两次完整运行分别出现 11 个和 3 个分散在无关 UI/Repo 测试中的 850ms/340ms 超时，失败集合不稳定；第二轮失败的 3 个文件单独重跑 27/27 通过。aggregate gate 因此未获得一次提交态全绿结果，本 PR 保持 Draft。

## 关联

- Related to #1691

## 验证

基线 `origin/main`: `f8cc26e60f7910b1d653eee1b3297e7476ab1070`

提交态 head: `4d8797d1fa00f096343c83a58d04ea640d0b1dd8`

```text
pnpm exec vitest run src/app/service/content/utils.test.ts
  1 file passed, 38 tests passed

pnpm run lint
  passed: Prettier, tsc --noEmit, i18n, issue templates, ESLint

pnpm run build
  passed with existing bundle-size and Monaco dynamic-require warnings

pnpm exec vitest run --reporter=dot --maxWorkers=4
  340 files passed, 3 files timed out
  4295 tests passed, 3 tests timed out

pnpm exec vitest run \
  src/pages/components/UserConfigPanel/index.test.tsx \
  src/pages/options/routes/Agent/Tasks/TaskHistorySheet.test.tsx \
  src/app/repo/agent_task.test.ts
  3 files passed, 27 tests passed

git diff f8cc26e60f7910b1d653eee1b3297e7476ab1070...4d8797d1fa00f096343c83a58d04ea640d0b1dd8 --check
  passed
```

## Screenshots / 截图

未附图：本次变更仅为测试；原生右键菜单验收受 macOS 辅助访问权限限制。
