### PR TITLE
🐛 修复新建脚本按钮点击被 hover 菜单吞掉，改为直接新建用户脚本

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -20,10 +20,18 @@ function getRecordVideoOptions() {
   return process.env.E2E_RECORD_VIDEO_DIR ? { recordVideo: { dir: process.env.E2E_RECORD_VIDEO_DIR } } : {};
 }
 
+// 无头 Linux（CI）检测不到任何输入设备，会把 (hover: hover) / (pointer: fine) 报成 false，
+// 而无头 macOS 报 true —— 同一套用例在两个平台跑出不同的媒体查询结果。显式声明「有鼠标」，
+// 让默认环境稳定对应真实桌面；需要触摸语义的用例自行启动上下文覆盖（见 options.spec.ts）。
+// 取值为 Blink 枚举：HoverType hover=2，PointerType fine=4。
+const POINTER_ARGS =
+  "--blink-settings=availableHoverTypes=2,primaryHoverType=2,availablePointerTypes=4,primaryPointerType=4";
+
 const chromeArgs = [
   `--disable-extensions-except=${pathToExtension}`,
   `--load-extension=${pathToExtension}`,
   "--disable-gpu",
+  POINTER_ARGS,
 ];
 
 // CI（GitHub Actions）跑在非 root 用户下不会自动应用 --no-sandbox，关掉沙箱能省下每次

--- a/e2e/options.spec.ts
+++ b/e2e/options.spec.ts
@@ -50,6 +50,9 @@ test.describe("Options 选项页", () => {
 
   test("新建脚本按钮 hover 应展开下拉菜单", async ({ context, extensionId }) => {
     const page = await openOptionsPage(context, extensionId);
+    // 前置条件：菜单只在指针可 hover 时走 hover 展开。断言一下，环境若报成无指针
+    // （无头 Linux 的默认行为）能直接看出是环境问题而非功能回归。
+    expect(await page.evaluate(() => matchMedia("(hover: hover)").matches)).toBe(true);
     await page.getByTestId("create-script").hover();
 
     const menuItems = page.locator('[role="menuitem"]');

--- a/e2e/options.spec.ts
+++ b/e2e/options.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from "./fixtures";
 import { openOptionsPage } from "./utils";
 
 // new-ui 选项页（shadcn）：侧边栏为 React Router NavLink（HashRouter → a[href="#/..."]），
-// 主题切换为循环按钮(data-testid="theme-toggle")，新建脚本为 Radix 下拉
-// (data-testid="create-script")，脚本列表空状态 data-testid="script-list-empty"。
+// 主题切换为循环按钮(data-testid="theme-toggle")，新建脚本按钮(data-testid="create-script")
+// 点击直接新建用户脚本、hover 才展开 Radix 下拉，脚本列表空状态 data-testid="script-list-empty"。
 test.describe("Options 选项页", () => {
   test("应加载并显示 ScriptCat 标题和 Logo", async ({ context, extensionId }) => {
     const page = await openOptionsPage(context, extensionId);
@@ -44,13 +44,20 @@ test.describe("Options 选项页", () => {
     await expect.poll(() => themeBtn.locator("svg").getAttribute("class"), { timeout: 5_000 }).not.toBe(before);
   });
 
-  test("新建脚本按钮应展开下拉菜单", async ({ context, extensionId }) => {
+  test("新建脚本按钮 hover 应展开下拉菜单", async ({ context, extensionId }) => {
     const page = await openOptionsPage(context, extensionId);
-    await page.getByTestId("create-script").click();
+    await page.getByTestId("create-script").hover();
 
     const menuItems = page.locator('[role="menuitem"]');
     await expect(menuItems.first()).toBeVisible({ timeout: 10_000 });
     expect(await menuItems.count()).toBeGreaterThanOrEqual(3);
+  });
+
+  test("新建脚本按钮点击应直接进入编辑器", async ({ context, extensionId }) => {
+    const page = await openOptionsPage(context, extensionId);
+    await page.getByTestId("create-script").click();
+
+    await expect.poll(() => page.url(), { timeout: 10_000 }).toContain("#/script/editor");
   });
 
   test("脚本列表为空时应显示空状态", async ({ context, extensionId }) => {

--- a/e2e/options.spec.ts
+++ b/e2e/options.spec.ts
@@ -1,9 +1,13 @@
+import path from "path";
+import { chromium } from "@playwright/test";
 import { test, expect } from "./fixtures";
+import { headlessArgs } from "./launch-args";
 import { openOptionsPage } from "./utils";
 
 // new-ui 选项页（shadcn）：侧边栏为 React Router NavLink（HashRouter → a[href="#/..."]），
 // 主题切换为循环按钮(data-testid="theme-toggle")，新建脚本按钮(data-testid="create-script")
-// 点击直接新建用户脚本、hover 才展开 Radix 下拉，脚本列表空状态 data-testid="script-list-empty"。
+// 在可 hover 的指针下点击直接新建用户脚本、hover 才展开 Radix 下拉，脚本列表空状态
+// data-testid="script-list-empty"。
 test.describe("Options 选项页", () => {
   test("应加载并显示 ScriptCat 标题和 Logo", async ({ context, extensionId }) => {
     const page = await openOptionsPage(context, extensionId);
@@ -63,5 +67,59 @@ test.describe("Options 选项页", () => {
   test("脚本列表为空时应显示空状态", async ({ context, extensionId }) => {
     const page = await openOptionsPage(context, extensionId);
     await expect(page.getByTestId("script-list-empty")).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+// 平板横屏 / 触屏笔记本：视口够宽(≥768px)会渲染桌面工具栏，但指针不支持 hover。
+// 若这种设备也走 hover 菜单，下拉里的后台/定时脚本与三种导入入口将完全无法触达，
+// 因此需要独立启动一个触摸模拟的浏览器验证降级为点击展开。共享 fixture 固定了启动参数，
+// 这里参照 gm-api.spec.ts 的做法自行启动。
+test.describe("Options 选项页 · 触摸设备", () => {
+  test("桌面视口下无 hover 能力时，点击新建脚本按钮应展开菜单而非直接新建", async () => {
+    const pathToExtension = path.resolve(__dirname, "../dist/ext");
+    const context = await chromium.launchPersistentContext("", {
+      headless: false,
+      args: [
+        ...headlessArgs(),
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+        "--disable-gpu",
+      ],
+      viewport: { width: 1200, height: 800 },
+      hasTouch: true,
+      isMobile: true,
+      timeout: 60_000,
+    });
+    try {
+      await context.addInitScript(() => {
+        try {
+          localStorage.setItem("firstUse", "false");
+        } catch {
+          // about:blank 等不透明来源无法访问 localStorage，忽略即可
+        }
+      });
+
+      let sw = context.serviceWorkers()[0];
+      if (!sw) sw = await context.waitForEvent("serviceworker", { timeout: 30_000 });
+      const extensionId = new URL(sw.url()).host;
+      const page = await openOptionsPage(context, extensionId);
+
+      // 先确认模拟到位：宽度仍走桌面工具栏，但指针不可 hover
+      const media = await page.evaluate(() => ({
+        canHover: matchMedia("(hover: hover)").matches,
+        width: innerWidth,
+      }));
+      expect(media.canHover).toBe(false);
+      expect(media.width).toBeGreaterThanOrEqual(768);
+
+      await page.getByTestId("create-script").tap();
+
+      const menuItems = page.locator('[role="menuitem"]');
+      await expect(menuItems.first()).toBeVisible({ timeout: 10_000 });
+      expect(await menuItems.count()).toBeGreaterThanOrEqual(3);
+      expect(page.url()).not.toContain("#/script/editor");
+    } finally {
+      await context.close();
+    }
   });
 });

--- a/src/pages/components/use-can-hover.test.ts
+++ b/src/pages/components/use-can-hover.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+import { useCanHover } from "./use-can-hover";
+
+afterEach(cleanup);
+
+// 可控的 matchMedia mock:matches 可变、change 监听器可手动触发
+function stubMatchMedia(initialMatches: boolean) {
+  let matches = initialMatches;
+  const listeners = new Set<() => void>();
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    get matches() {
+      return matches;
+    },
+    media: query,
+    onchange: null,
+    addEventListener: (_: string, cb: () => void) => listeners.add(cb),
+    removeEventListener: (_: string, cb: () => void) => listeners.delete(cb),
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }));
+  return {
+    setMatches(next: boolean) {
+      matches = next;
+      listeners.forEach((cb) => cb());
+    },
+  };
+}
+
+describe("useCanHover 指针 hover 能力", () => {
+  it("触摸屏返回 false,接上鼠标后更新为 true", () => {
+    const mql = stubMatchMedia(false);
+    const { result } = renderHook(() => useCanHover());
+    expect(result.current).toBe(false);
+    act(() => mql.setMatches(true));
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/pages/components/use-can-hover.ts
+++ b/src/pages/components/use-can-hover.ts
@@ -1,0 +1,19 @@
+import { useSyncExternalStore } from "react";
+
+const QUERY = "(hover: hover)";
+
+const getSnapshot = () => window.matchMedia(QUERY).matches;
+
+const subscribe = (onChange: () => void) => {
+  const media = window.matchMedia(QUERY);
+  media.addEventListener("change", onChange);
+  return () => media.removeEventListener("change", onChange);
+};
+
+/**
+ * 指针能否 hover（鼠标/触控板为 true,触摸屏为 false）,随设备变化更新。
+ * 用于给触摸设备准备点击替代路径:纯 hover 触发的交互在触摸屏上完全够不着。
+ */
+export function useCanHover(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, () => true);
+}

--- a/src/pages/options/routes/ScriptList/CreateScriptMenu.test.tsx
+++ b/src/pages/options/routes/ScriptList/CreateScriptMenu.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeAll, afterEach, beforeEach } from "vite
 import { render, cleanup, screen, fireEvent, act } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { initTestLanguage } from "@Tests/initTestLanguage";
+import { mockMatchMedia } from "@Tests/mockMatchMedia";
 import { CreateScriptMenu } from "./CreateScriptMenu";
 import * as filePicker from "./filePicker";
 
@@ -12,6 +13,8 @@ afterEach(cleanup);
 beforeAll(() => initTestLanguage("zh-CN"));
 beforeEach(() => {
   vi.clearAllMocks();
+  // 默认桌面：具备 hover 能力
+  mockMatchMedia((query) => query === "(hover: hover)");
 });
 
 function LocationProbe() {
@@ -93,7 +96,7 @@ describe("CreateScriptMenu 下拉菜单", () => {
       expect(screen.getByTestId("location")).toHaveTextContent("/script/editor");
     });
 
-    it("未 hover 时直接点击（触摸屏无 hover）同样应新建用户脚本", async () => {
+    it("未 hover 时直接点击同样应新建用户脚本", async () => {
       const { container } = renderMenu();
       const trigger = container.querySelector("button")!;
 
@@ -118,6 +121,42 @@ describe("CreateScriptMenu 下拉菜单", () => {
         fireEvent.keyDown(trigger, { key: "Enter" });
       });
       expect(screen.getByTestId("location")).toHaveTextContent("/script/editor");
+    });
+  });
+
+  describe("触摸设备（无 hover 能力）", () => {
+    beforeEach(() => {
+      mockMatchMedia(false);
+    });
+
+    it("点击按钮应展开菜单，而不是直接进编辑器（否则菜单在触摸屏上够不着）", async () => {
+      const { container } = renderMenu();
+      const trigger = container.querySelector("button")!;
+
+      await act(async () => {
+        fireEvent.pointerDown(trigger, { button: 0 });
+        fireEvent.click(trigger);
+      });
+
+      expect(screen.getByText("导入本地脚本")).toBeInTheDocument();
+      expect(screen.getByTestId("location")).toHaveTextContent("/");
+      expect(screen.getByTestId("location")).not.toHaveTextContent("/script/editor");
+    });
+
+    it("展开后按 Esc 应能关闭（不被 hover 菜单的 dismiss 拦截而卡住）", async () => {
+      const { container } = renderMenu();
+      const trigger = container.querySelector("button")!;
+
+      await act(async () => {
+        fireEvent.pointerDown(trigger, { button: 0 });
+        fireEvent.click(trigger);
+      });
+      expect(screen.getByText("导入本地脚本")).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.keyDown(document.activeElement || document.body, { key: "Escape" });
+      });
+      expect(screen.queryByText("导入本地脚本")).toBeNull();
     });
   });
 

--- a/src/pages/options/routes/ScriptList/CreateScriptMenu.test.tsx
+++ b/src/pages/options/routes/ScriptList/CreateScriptMenu.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, afterEach, beforeEach } from "vitest";
 import { render, cleanup, screen, fireEvent, act } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { initTestLanguage } from "@Tests/initTestLanguage";
 import { CreateScriptMenu } from "./CreateScriptMenu";
 import * as filePicker from "./filePicker";
@@ -14,10 +14,16 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+function LocationProbe() {
+  const { pathname, search } = useLocation();
+  return <div data-testid="location">{pathname + search}</div>;
+}
+
 function renderMenu(variant: "default" | "icon" = "default") {
   return render(
     <MemoryRouter>
       <CreateScriptMenu variant={variant} />
+      <LocationProbe />
     </MemoryRouter>
   );
 }
@@ -67,6 +73,52 @@ describe("CreateScriptMenu 下拉菜单", () => {
 
     // Dialog 应出现
     expect(screen.getByTestId("link-import-textarea")).toBeInTheDocument();
+  });
+
+  describe("桌面按钮（variant=default）", () => {
+    it("hover 展开后点击按钮应新建用户脚本，而不是把菜单点掉", async () => {
+      const { container } = renderMenu();
+      const trigger = container.querySelector("button")!;
+
+      await act(async () => {
+        fireEvent.mouseEnter(trigger);
+      });
+      expect(screen.getByText("导入本地脚本")).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.pointerDown(trigger, { button: 0 });
+        fireEvent.click(trigger);
+      });
+
+      expect(screen.getByTestId("location")).toHaveTextContent("/script/editor");
+    });
+
+    it("未 hover 时直接点击（触摸屏无 hover）同样应新建用户脚本", async () => {
+      const { container } = renderMenu();
+      const trigger = container.querySelector("button")!;
+
+      await act(async () => {
+        fireEvent.pointerDown(trigger, { button: 0 });
+        fireEvent.click(trigger);
+      });
+
+      expect(screen.getByTestId("location")).toHaveTextContent("/script/editor");
+    });
+
+    it("键盘 Enter 应新建用户脚本，ArrowDown 才展开菜单", async () => {
+      const { container } = renderMenu();
+      const trigger = container.querySelector("button")!;
+
+      await act(async () => {
+        fireEvent.keyDown(trigger, { key: "ArrowDown" });
+      });
+      expect(screen.getByText("导入本地脚本")).toBeInTheDocument();
+
+      await act(async () => {
+        fireEvent.keyDown(trigger, { key: "Enter" });
+      });
+      expect(screen.getByTestId("location")).toHaveTextContent("/script/editor");
+    });
   });
 
   describe("移动端图标菜单（variant=icon）", () => {

--- a/src/pages/options/routes/ScriptList/CreateScriptMenu.tsx
+++ b/src/pages/options/routes/ScriptList/CreateScriptMenu.tsx
@@ -1,3 +1,4 @@
+import type React from "react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Plus, ChevronDown } from "lucide-react";
@@ -17,8 +18,9 @@ import { handleImportFiles, handleImportUrls } from "./importHandler";
 import { LinkImportDialog } from "./LinkImportDialog";
 
 /**
- * 新建脚本下拉(hover 触发)。Toolbar 用带文字按钮(variant="default"),
- * 移动 header 用 32×32 图标按钮(variant="icon")。含导入分组:本地/链接/Skill。
+ * 新建脚本入口。Toolbar 用带文字按钮(variant="default"):点击直接新建用户脚本,
+ * 菜单由 hover / ArrowDown 展开;移动 header 用 32×32 图标按钮(variant="icon"),点击展开菜单。
+ * 含导入分组:本地/链接/Skill。
  */
 export function CreateScriptMenu({ variant = "default" }: { variant?: "default" | "icon" }) {
   const { t } = useTranslation();
@@ -32,6 +34,17 @@ export function CreateScriptMenu({ variant = "default" }: { variant?: "default" 
   const handleCreate = (path: string) => {
     close();
     void navigate(path);
+  };
+  const createUserScript = () => handleCreate("/script/editor");
+  // Radix Trigger 用 composeEventHandlers 挂载「切换菜单」,遇到 defaultPrevented 会跳过。
+  // 桌面按钮的激活语义归「新建用户脚本」,因此在这里拦掉:否则 hover 已展开时点击只会把菜单收起,
+  // 看起来像点了没反应(#1699)。ArrowDown 不拦,留给 Radix 展开菜单。
+  const suppressTriggerToggle = (e: { preventDefault: () => void }) => e.preventDefault();
+  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      createUserScript();
+    }
   };
   const importLocal = async () => {
     close();
@@ -65,6 +78,9 @@ export function CreateScriptMenu({ variant = "default" }: { variant?: "default" 
               data-tour="install-entry"
               className="gap-1.5 h-[34px] px-4"
               {...hoverProps}
+              onPointerDown={suppressTriggerToggle}
+              onClick={createUserScript}
+              onKeyDown={handleTriggerKeyDown}
             >
               <Plus className="w-4 h-4" />
               <span className="text-[13px] font-medium">{t("script:create_script")}</span>
@@ -76,9 +92,7 @@ export function CreateScriptMenu({ variant = "default" }: { variant?: "default" 
           <DropdownMenuLabel className="text-xs font-medium text-muted-foreground">
             {t("script:create_group")}
           </DropdownMenuLabel>
-          <DropdownMenuItem onClick={() => handleCreate("/script/editor")}>
-            {t("script:create_user_script")}
-          </DropdownMenuItem>
+          <DropdownMenuItem onClick={createUserScript}>{t("script:create_user_script")}</DropdownMenuItem>
           <DropdownMenuItem onClick={() => handleCreate("/script/editor?template=background")}>
             {t("script:create_background_script")}
           </DropdownMenuItem>

--- a/src/pages/options/routes/ScriptList/CreateScriptMenu.tsx
+++ b/src/pages/options/routes/ScriptList/CreateScriptMenu.tsx
@@ -12,23 +12,26 @@ import {
   DropdownMenuTrigger,
 } from "@App/pages/components/ui/dropdown-menu";
 import { useHoverMenu } from "@App/pages/components/ui/use-hover-menu";
+import { useCanHover } from "@App/pages/components/use-can-hover";
 import { useTranslation } from "react-i18next";
 import { pickScriptFiles, pickSkillZip } from "./filePicker";
 import { handleImportFiles, handleImportUrls } from "./importHandler";
 import { LinkImportDialog } from "./LinkImportDialog";
 
 /**
- * 新建脚本入口。Toolbar 用带文字按钮(variant="default"):点击直接新建用户脚本,
- * 菜单由 hover / ArrowDown 展开;移动 header 用 32×32 图标按钮(variant="icon"),点击展开菜单。
- * 含导入分组:本地/链接/Skill。
+ * 新建脚本入口。Toolbar 用带文字按钮(variant="default"),移动 header 用 32×32 图标按钮(variant="icon")。
+ * 仅在「带文字按钮 + 指针支持 hover」时走 hover 菜单:点击直接新建用户脚本,菜单由 hover / ArrowDown 展开;
+ * 其余情况(图标按钮、触摸屏)一律点击展开菜单。含导入分组:本地/链接/Skill。
  */
 export function CreateScriptMenu({ variant = "default" }: { variant?: "default" | "icon" }) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { close, rootProps, hoverProps, contentProps } = useHoverMenu();
-  // 移动端图标按钮用普通点击菜单（移动端无 hover；hover 触发 + dismiss 拦截会让菜单卡住关不掉），
-  // 仅桌面带文字按钮使用 hover 展开。
-  const isHoverMenu = variant === "default";
+  // 图标按钮和触摸屏都用普通点击菜单（无 hover；hover 触发 + dismiss 拦截会让菜单卡住关不掉），
+  // 仅「桌面带文字按钮 + 指针可 hover」使用 hover 展开。
+  // 触摸屏的桌面视口（平板横屏、触屏笔记本）若也走 hover，菜单会完全够不着。
+  const canHover = useCanHover();
+  const isHoverMenu = variant === "default" && canHover;
   const [linkOpen, setLinkOpen] = useState(false);
 
   const handleCreate = (path: string) => {
@@ -36,16 +39,22 @@ export function CreateScriptMenu({ variant = "default" }: { variant?: "default" 
     void navigate(path);
   };
   const createUserScript = () => handleCreate("/script/editor");
-  // Radix Trigger 用 composeEventHandlers 挂载「切换菜单」,遇到 defaultPrevented 会跳过。
-  // 桌面按钮的激活语义归「新建用户脚本」,因此在这里拦掉:否则 hover 已展开时点击只会把菜单收起,
-  // 看起来像点了没反应(#1699)。ArrowDown 不拦,留给 Radix 展开菜单。
-  const suppressTriggerToggle = (e: { preventDefault: () => void }) => e.preventDefault();
-  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      createUserScript();
-    }
-  };
+  // hover 菜单下按钮的激活语义归「新建用户脚本」。Radix Trigger 用 composeEventHandlers 挂载「切换菜单」,
+  // 遇到 defaultPrevented 会跳过,故在此拦掉:否则 hover 已展开时点击只会把菜单收起,看起来像点了没反应(#1699)。
+  // Enter/Space 同理自行接管(Radix 会 preventDefault 吃掉原生 click);ArrowDown 不拦,留给 Radix 展开菜单。
+  const triggerActionProps = isHoverMenu
+    ? {
+        ...hoverProps,
+        onPointerDown: (e: React.PointerEvent) => e.preventDefault(),
+        onClick: createUserScript,
+        onKeyDown: (e: React.KeyboardEvent) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            createUserScript();
+          }
+        },
+      }
+    : {};
   const importLocal = async () => {
     close();
     const items = await pickScriptFiles();
@@ -77,10 +86,7 @@ export function CreateScriptMenu({ variant = "default" }: { variant?: "default" 
               data-testid="create-script"
               data-tour="install-entry"
               className="gap-1.5 h-[34px] px-4"
-              {...hoverProps}
-              onPointerDown={suppressTriggerToggle}
-              onClick={createUserScript}
-              onKeyDown={handleTriggerKeyDown}
+              {...triggerActionProps}
             >
               <Plus className="w-4 h-4" />
               <span className="text-[13px] font-medium">{t("script:create_script")}</span>


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## 背景

Fix #1699。报告人指出「不能直接點擊 Create Script」，并猜测「Create Script 的點擊跟 hover 撞了」——这个猜测是对的。

桌面工具栏的 `+ Create Script` 按钮同时承担两个角色：

1. Radix 的 `DropdownMenuTrigger`（`asChild`，pointerdown 会 `onOpenToggle`）；
2. `useHoverMenu()` 的 hover 触发目标（`onMouseEnter` → `setIsOpen(true)`）。

菜单 `open` 由 `useHoverMenu` 受控。鼠标移上按钮 → hover 已把菜单打开；此时按下鼠标 → Radix 调 `onOpenChange(!open)` = `false` → 菜单被关掉。而鼠标并未离开按钮，不会再触发 `mouseEnter`，所以要移开再移回、或者再点一次才能重新展开。

**复现（本地 vitest，改动前）**：`mouseEnter` trigger → 菜单展开；原地 `pointerDown` + `click` → 菜单**消失**；再点一次 → 又展开。用户视角就是「鼠标移上去菜单弹出来，手一按菜单没了，点了没反应」。

除此之外还有一层预期落差：按钮长得像主操作按钮（`+` 图标 + `Create Script` 文案），但整块区域**只是**下拉触发器，没有任何直接新建脚本的行为；要新建必须再进菜单点 `Create User Script`。

该按钮自新 UI 重写（#1514）引入后一直是这个行为；现有单测只覆盖了 hover 展开与菜单项点击，没有覆盖「hover 之后点 trigger」这条路径。

## 本次改动

把「点击」的语义交给新建脚本，同时保证没有 hover 能力的设备仍能打开菜单。判据是 `(hover: hover)` 媒体查询而非视口宽度：

- **可 hover 的指针 + 带文字按钮**：hover / `ArrowDown` 展开菜单，点击 / `Enter` / `Space` 直接新建用户脚本。
- **其余情况**（移动 header 的 `+` 图标按钮、以及触摸设备上的桌面工具栏）：一律点击展开菜单，与原行为一致。

| 场景 | 输入 | 改动前 | 改动后 |
| --- | --- | --- | --- |
| 鼠标 / 触控板 | 悬停 | 展开菜单 | 展开菜单（不变） |
| 鼠标 / 触控板 | 点击（菜单已由 hover 展开） | 菜单被关掉，无其他动作 | 进入编辑器新建用户脚本 |
| 鼠标 / 触控板 | `Enter` / `Space` | 展开菜单 | 进入编辑器新建用户脚本 |
| 鼠标 / 触控板 | `ArrowDown` | 展开菜单 | 展开菜单（不变） |
| 触摸屏（桌面视口） | 点击 | 展开菜单 | 展开菜单（不变） |
| 移动 header 的 `+` 图标 | 点击 | 展开菜单 | 展开菜单（不变） |

新增 `src/pages/components/use-can-hover.ts`（`useCanHover`），与既有的 `use-is-mobile.ts` 同构：`useSyncExternalStore` 订阅 `(hover: hover)`，接上/拔掉鼠标时会更新。

菜单内容、导入分组、`LinkImportDialog` 均未改动；菜单里的 `Create User Script` 项改为复用同一个 `createUserScript` 函数。无视觉变化。

## 实现考虑

**为什么按 hover 能力而不是视口宽度分支。** 桌面工具栏在视口 ≥768px 就渲染（`useIsMobile` 的断点），平板横屏、触屏笔记本都落在这个区间但没有 hover。若这些设备也走 hover 菜单，下拉里的「后台脚本 / 定时脚本 / 导入本地 / 链接导入 / 导入 Skill」五个入口将**完全无法触达**——这会是比原 issue 更严重的回归。因此触摸设备复用已有的点击菜单路径（`isHoverMenu === false`），该路径本身已有测试覆盖，且不套用 `useHoverMenu` 的 dismiss 拦截，Esc 与点击外部都能正常关闭。

**为什么用 `preventDefault()` 拦 Radix 的 toggle。** `DropdownMenuTrigger` 用 `composeEventHandlers(props.onPointerDown, …)` 挂载 toggle，而 `composeEventHandlers` 在 `event.defaultPrevented` 时会跳过自己那一半；`asChild` 走 `Slot`，其 `mergeProps` 对 `on[A-Z]*` 属性的合成顺序是「先子元素 handler，后 slot handler」。因此在 `Button` 上挂 `onPointerDown={(e) => e.preventDefault()}` 可以稳定拦掉 toggle，同时不影响 `click` 照常派发（取消 `pointerdown` 只阻止兼容鼠标事件与聚焦，不阻止 `click`）。这一依赖已写进代码注释。版本已核对：`@radix-ui/react-slot@1.2.5`、`@radix-ui/react-dropdown-menu@2.1.17`（`radix-ui@1.5.0`）。

**e2e 环境需要显式声明指针能力。** 首次推送后 CI 的 `Run E2E tests (2/4)` 失败：两条桌面用例挂掉、触摸用例通过——正是 `canHover === false` 的症状。原因是无头 Linux 检测不到任何输入设备，把 `(hover: hover)` / `(pointer: fine)` 报成 `false`，而无头 macOS 报 `true`，同一套用例在两个平台结果不同。因此在 `e2e/fixtures.ts` 的共享启动参数里加上 `--blink-settings=availableHoverTypes=2,primaryHoverType=2,availablePointerTypes=4,primaryPointerType=4`，让默认环境稳定对应「有鼠标的桌面」；触摸用例自建上下文覆盖，不受影响。同时给 hover 用例加了一行前置断言 `(hover: hover) === true`，以后环境再变能一眼区分「环境问题」与「功能回归」。

**键盘单独处理。** Radix 在 `Enter`/`Space` 上除了 toggle 还会 `preventDefault()`（顺带吃掉原生 click），所以这两个键在自己的 `onKeyDown` 里拦下并直接调用 `createUserScript()`；`ArrowDown` 不拦，仍交给 Radix 展开菜单——即「带默认操作的菜单按钮」的常规键盘模型。

## 已知限制

- 按钮上的 `ChevronDown` 在可 hover 的设备上不再是「点这里展开」的可点击 affordance，而只是「还有更多选项」的提示。本 PR 未调整其样式。
- `preventDefault()` 拦截 pointerdown 会同时抑制该按钮的鼠标聚焦。由于点击后即导航到编辑器，实际影响可忽略；键盘 Tab 聚焦不受影响。
- 触摸设备上没有「一步直达新建用户脚本」，需经菜单第一项，与移动端 `+` 按钮一致。
- 依赖 Radix `Slot` 的 handler 合成顺序与 `composeEventHandlers` 的 `defaultPrevented` 短路，属于 Radix 的公开行为约定，但升级 Radix 大版本时值得回归这几条测试。
- `(hover: hover)` 取决于浏览器检测到的**主指针**。若某些环境（远程桌面、部分 Linux 配置）在有鼠标时仍报 `hover: none`，这些用户会退化为「点击展开菜单」，即本 PR 之前、且不含 #1699 碰撞的行为。降级方向是安全的：判据只会导致「少一个直达入口」，不会导致「菜单够不着」。

## 建议审查重点

- 鼠标：hover 展开后点击，是否稳定进入编辑器且菜单不残留。
- 触摸：平板横屏 / 触屏笔记本上点击按钮应展开菜单（而非直接进编辑器），且 Esc / 点击外部能关闭。
- 移动 header 的 `+` 图标是否仍为点击展开、Esc 可关（`variant="icon"` 未改）。
- 键盘：`ArrowDown` 展开菜单、`Enter` / `Space` 新建脚本。
- 引导流程 `data-tour="install-entry"`（`src/pages/options/onboarding/steps.ts`）仍指向同一按钮，未受影响。

## 关联

Fix #1699

## 验证

两处行为改动均先写失败测试再改实现：`CreateScriptMenu.test.tsx` 先加 3 条（hover 后点击、无 hover 直接点击、键盘 Enter/ArrowDown）确认全红；触摸降级再加 2 条（点击展开菜单不导航、Esc 可关）确认全红。

```
npx vitest run src/pages/options/routes/ScriptList/CreateScriptMenu.test.tsx
  → 各阶段修复前分别 3 failed / 2 failed；最终 10 passed (10)

npx vitest run src/pages
  → Test Files 182 passed (182)，Tests 1358 passed (1358)（连续 3 次全绿）

npx tsc --noEmit                                   → 通过
npx eslint <5 个改动文件>                           → 无输出
npx prettier --check <5 个改动文件>                 → All matched files use Prettier code style!

pnpm build                                         → Rspack compiled with 4 warnings（均为既有的
                                                      monaco-editor critical dependency 警告，与本改动无关）
pnpm exec playwright test e2e/options.spec.ts      → 7 passed
pnpm exec playwright test                          → 64 passed (2.8m，全量，因改了共享 fixture)
```

e2e 侧：把原来断言「点击展开菜单」的用例改为 hover 版，新增「点击应直接进入编辑器」，并新增一条触摸设备用例。Playwright 的 `.click()` 会先把鼠标移到元素上（触发 hover 展开）再点击，因此那条用例正好在真实 Chromium 中覆盖 #1699 的原始路径。

CI 上的 e2e 失败已定位并修复，过程留档：先用 `--blink-settings=...HoverTypes=1...PointerTypes=1`（强制「无指针」）在本地复现，两条桌面用例以与 CI **完全相同**的报错失败、触摸用例通过，确认是环境的指针能力而非功能问题；再用探针验证该 flag 双向可控（默认 `hover:true` → 强制 none 得 `false` → 强制 hover 得 `true`），据此在共享 fixture 中固定为「有鼠标的桌面」。因改动了共享 fixture，本地跑了**全量** e2e：64 passed。

触摸用例需要真实的无 hover 环境：CDP `Emulation.setEmulatedMedia` 的 `hover`/`pointer` 特性对 `chrome-extension://` 页面不生效（实测 `(hover: hover)` 仍为 `true`），因此该用例自行以 `hasTouch: true` + `isMobile: true` + `viewport 1200×800` 启动持久化上下文（参照 `gm-api.spec.ts` 自建上下文的做法），并在断言前先探测确认 `(hover: hover) === false` 且 `innerWidth ≥ 768`，再 `tap()` 断言菜单展开且 URL 未跳转。

一处需要说明的观测：期间有两次 `src/pages` 全量运行出现 1–3 条**无关文件**（`SubscribeListMobile` / `GeneralSection` / `SettingsPane` / `StoragePane`）的失败，每次失败集合不同，单独重跑均通过；随后在本分支与干净 `main` 上各连续跑 3 次全量，均 100% 通过（本分支 1358/1358，`main` 1355/1355）。判断为 `vitest.config.ts` 中 `ui` project 已知的超时预算在机器满载时的偶发抖动（该文件注释已记录此问题），与本改动无关。

## Screenshots / 截图

无视觉变化——按钮外观、布局、菜单内容均未改动，本次仅改变点击/键盘的行为语义，详见上文行为对照表。
