### PR TITLE
🐛 修复 @run-at context-menu：设置覆写不生效、菜单注册不上、脚本体自己的菜单被屏蔽

### DIFF
--- a/src/app/service/content/utils.test.ts
+++ b/src/app/service/content/utils.test.ts
@@ -214,8 +214,26 @@ describe("utils", () => {
 
       expect(result).toBeDefined();
       expect(result).toContain(
-        `GM_registerMenuCommand(("ScriptCat's demo for \\"context-menu\\""), ()=>{let GM_registerMenuCommand=window.GM_registerMenuCommand=GM.registerMenuCommand=undefined;\nconsole.log(567); // testing\n}, {nested:false});\n`
+        `GM_registerMenuCommand(("ScriptCat's demo for \\"context-menu\\""), ()=>{\nconsole.log(567); // testing\n}, {nested:false});\n`
       );
+    });
+
+    it.concurrent("@run-at context-menu 的包装不得屏蔽脚本体自己的 GM_registerMenuCommand", () => {
+      const scriptRes = createMockScriptRes({
+        name: "menu registering script",
+        code: 'GM_registerMenuCommand("Own Item", () => {});',
+        metadata: {
+          "run-at": ["context-menu"],
+        },
+      });
+
+      const result = compileScriptCode(scriptRes);
+
+      // 曾经在回调开头把 GM_registerMenuCommand 连同 window./GM. 上的引用一起置为 undefined，
+      // 于是任何在脚本体里注册菜单的脚本一点菜单就 TypeError 中断，自己的菜单项也永远注册不上
+      expect(result).not.toContain("GM_registerMenuCommand=undefined");
+      expect(result).not.toContain("window.GM_registerMenuCommand");
+      expect(result).not.toContain("GM.registerMenuCommand");
     });
   });
 

--- a/src/app/service/content/utils.ts
+++ b/src/app/service/content/utils.ts
@@ -141,7 +141,8 @@ export function compileScriptCodeByResource(resource: CompileScriptCodeResource)
   // 在UserScripts API中，由于执行不是在物件导向里呼叫，使用arrow function的话会把this改变。须使用 .call(this) [ 或 .bind(this)() ]
 
   if (resource.isContextMenu) {
-    code = `GM_registerMenuCommand((${JSON.stringify(resource.name)}), ()=>{let GM_registerMenuCommand=window.GM_registerMenuCommand=GM.registerMenuCommand=undefined;\n${code}\n}, {nested:false});\n`;
+    // 脚本体整体延后到菜单回调里执行，它自己的 GM_registerMenuCommand 也随之推迟到点击后才注册
+    code = `GM_registerMenuCommand((${JSON.stringify(resource.name)}), ()=>{\n${code}\n}, {nested:false});\n`;
   }
 
   const joinedCode = [

--- a/src/app/service/service_worker/gm_api/gm_api.ts
+++ b/src/app/service/service_worker/gm_api/gm_api.ts
@@ -36,7 +36,7 @@ import type {
 } from "../types";
 import type { TScriptMenuRegister, TScriptMenuUnregister } from "../../queue";
 import type { NotificationOptionCache } from "../utils";
-import { BrowserNoSupport, notificationsUpdate } from "../utils";
+import { BrowserNoSupport, getCombinedMeta, notificationsUpdate } from "../utils";
 import {
   getSkillScriptGrantsByUuid,
   getSkillScriptNameByUuid,
@@ -415,6 +415,10 @@ export default class GMApi {
       script = await this.scriptDAO.get(data.uuid);
       if (!script) {
         throw new Error("script is not found");
+      }
+      // 设置面板改的运行时机等只写 selfMetadata，GM API 校验要看合并后的生效值（#1649）
+      if (script.selfMetadata) {
+        script = { ...script, metadata: getCombinedMeta(script.metadata, script.selfMetadata) };
       }
     }
     // 订阅脚本的 connect 使用订阅声明的 connect 覆盖脚本自身的

--- a/src/app/service/service_worker/gm_api/gm_api_self_metadata.test.ts
+++ b/src/app/service/service_worker/gm_api/gm_api_self_metadata.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ScriptDAO, SCRIPT_TYPE_NORMAL, SCRIPT_STATUS_ENABLE, SCRIPT_RUN_STATUS_COMPLETE } from "@App/app/repo/scripts";
+import type { Script } from "@App/app/repo/scripts";
+import GMApi, { MockGMExternalDependencies } from "./gm_api";
+import { initTestEnv } from "@Tests/utils";
+import { MockMessage } from "@Packages/message/mock_message";
+import { Server, type IGetSender } from "@Packages/message/server";
+import type { ExtMessageSender } from "@Packages/message/types";
+import EventEmitter from "eventemitter3";
+import { MessageQueue } from "@Packages/message/message_queue";
+import { SystemConfig } from "@App/pkg/config/config";
+import PermissionVerify, { PermissionVerifyApiGet } from "../permission_verify";
+import type { ValueService } from "../value";
+
+initTestEnv();
+
+const makeSender = (): IGetSender => ({
+  getSender: () => ({}) as chrome.runtime.MessageSender,
+  getType: () => 0,
+  isType: (_type: any) => false,
+  getExtMessageSender: () => null as unknown as ExtMessageSender,
+  getConnect: () => undefined,
+});
+
+const createGMApi = () => {
+  const ee = new EventEmitter<string, any>();
+  const message = new MockMessage(ee);
+  const messageQueue = new MessageQueue();
+  const systemConfig = new SystemConfig(messageQueue);
+  const server = new Server("serviceWorker", message);
+  const permissionVerify = new PermissionVerify(server.group("permissionVerify"), messageQueue);
+  const gmApi = new GMApi(
+    systemConfig,
+    permissionVerify,
+    server.group("runtime"),
+    message,
+    messageQueue,
+    {} as ValueService,
+    new MockGMExternalDependencies()
+  );
+  return { gmApi, permissionVerify };
+};
+
+// 设置面板把运行时机改成 context-menu 只写 selfMetadata，脚本自带 metadata 不变；
+// GM API 请求若只带自带 metadata，免 @grant 的菜单豁免就判不出来，菜单项注册不上（#1649）。
+describe("parseRequest 用户覆写的 metadata", () => {
+  let scriptDAO: ScriptDAO;
+
+  beforeEach(() => {
+    scriptDAO = new ScriptDAO();
+  });
+
+  it("selfMetadata 覆写 run-at=context-menu 的脚本，GM_registerMenuCommand 无需 @grant 即可通过校验", async () => {
+    const script: Script = {
+      uuid: "uuid-context-menu-override",
+      name: "test-script",
+      namespace: "test",
+      metadata: { grant: ["none"], "run-at": ["document-idle"] },
+      selfMetadata: { "run-at": ["context-menu"] },
+      type: SCRIPT_TYPE_NORMAL,
+      status: SCRIPT_STATUS_ENABLE,
+      sort: 0,
+      runStatus: SCRIPT_RUN_STATUS_COMPLETE,
+      createtime: Date.now(),
+      checktime: Date.now(),
+    };
+    await scriptDAO.save(script);
+    const { gmApi, permissionVerify } = createGMApi();
+
+    const req = await gmApi.parseRequest({
+      uuid: script.uuid,
+      api: "GM_registerMenuCommand",
+      runFlag: "",
+      params: [],
+    });
+
+    await expect(
+      permissionVerify.verify(req, PermissionVerifyApiGet("GM_registerMenuCommand")!, makeSender(), gmApi)
+    ).resolves.toBe(true);
+  });
+});

--- a/src/app/service/service_worker/runtime.test.ts
+++ b/src/app/service/service_worker/runtime.test.ts
@@ -1192,3 +1192,83 @@ describe("MQ 事件处理效果（enableScripts / deleteScripts / sortedScripts�
     expect((runtime as any).cachedPatterns.has(uuid)).toBe(false);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("restoreJSCodeFromCompiledResource 还原代码时的生效 metadata", () => {
+  // 设置面板改运行时机只写 selfMetadata，脚本自带 metadata 原封不动；
+  // 还原路径若只看自带 metadata，重新注册后用户覆写就会静默失效（#1649）。
+  const createContext = (script: Script) => {
+    const { runtime, mockScriptService } = _createRuntimeContext();
+    const scriptRes = _createScriptRunResource(script);
+    const compiledResource: CompiledResource = {
+      name: script.name,
+      flag: `#-${script.uuid}`,
+      uuid: script.uuid,
+      require: [],
+      matches: ["https://www.example.com/*"],
+      includeGlobs: [],
+      excludeMatches: [],
+      excludeGlobs: [],
+      allFrames: false,
+      world: "MAIN",
+      runAt: "document_idle",
+      scriptUrlPatterns: scriptURLPatternResults(scriptRes)!.scriptUrlPatterns,
+      originalUrlPatterns: null,
+    };
+    mockScriptService.buildScriptRunResource.mockResolvedValue(scriptRes);
+    (runtime as any).script = {
+      ...mockScriptService,
+      scriptCodeDAO: { get: vi.fn().mockResolvedValue({ code: "console.log(1);" }) },
+    };
+    (runtime as any).resource = { resourceDAO: { get: vi.fn().mockResolvedValue(undefined) } };
+    return { runtime, compiledResource };
+  };
+
+  it("selfMetadata 覆写 run-at=context-menu 时，还原的代码应包裹 GM_registerMenuCommand", async () => {
+    const script = _createMockScript({
+      metadata: { match: ["https://www.example.com/*"], "run-at": ["document-idle"] },
+      selfMetadata: { "run-at": ["context-menu"] },
+    });
+    const { runtime, compiledResource } = createContext(script);
+
+    const code = await runtime.restoreJSCodeFromCompiledResource(script, compiledResource);
+
+    expect(code).toContain("GM_registerMenuCommand");
+  });
+
+  it("selfMetadata 覆写为 early-start 时，还原的代码应走预注入编译", async () => {
+    const script = _createMockScript({
+      metadata: { match: ["https://www.example.com/*"], "run-at": ["document-idle"] },
+      selfMetadata: { "early-start": [""], "run-at": ["document-start"] },
+    });
+    const { runtime, compiledResource } = createContext(script);
+
+    const code = await runtime.restoreJSCodeFromCompiledResource(script, compiledResource);
+
+    expect(code).toContain("performance.dispatchEvent");
+  });
+});
+
+describe("pushValueUpdate 判断是否需要为 early-start 脚本重新编译", () => {
+  // early-start 会把 GM 值编进预注入代码，值变了必须重编；
+  // 该脚本的 early-start 可能来自用户覆写，不能只看脚本自带 metadata。
+  it("selfMetadata 覆写为 early-start 的脚本，值更新后应重新编译注册", async () => {
+    const { runtime } = _createRuntimeContext();
+    const script = _createMockScript({
+      metadata: { match: ["https://www.example.com/*"], "run-at": ["document-idle"] },
+      selfMetadata: { "early-start": [""], "run-at": ["document-start"] },
+    });
+    const updateSpy = vi.spyOn(runtime, "updateResourceOnScriptChange").mockResolvedValue(undefined);
+
+    await runtime.pushValueUpdate(script, {
+      entries: [],
+      uuid: script.uuid,
+      storageName: "test-storage",
+      sender: { runFlag: "", tabId: -1 },
+      valueUpdated: true,
+    });
+
+    expect(updateSpy).toHaveBeenCalledWith(script);
+  });
+});

--- a/src/app/service/service_worker/runtime.ts
+++ b/src/app/service/service_worker/runtime.ts
@@ -13,6 +13,7 @@ import { runScript, stopScript } from "../offscreen/client";
 import {
   buildScriptRunResourceBasic,
   compileInjectionCode,
+  getCombinedMeta,
   getUserScriptRegister,
   parseUrlSRI,
   scriptURLPatternResults,
@@ -485,7 +486,10 @@ export class RuntimeService {
 
       // valueUpdate 消息用于 early script 的处理
       if (sendData.valueUpdated) {
-        if (script.status === SCRIPT_STATUS_ENABLE && isEarlyStartScript(script.metadata)) {
+        if (
+          script.status === SCRIPT_STATUS_ENABLE &&
+          isEarlyStartScript(getCombinedMeta(script.metadata, script.selfMetadata))
+        ) {
           // 如果是预加载脚本，需要更新脚本代码重新注册
           // scriptMatchInfo 里的 value 改变 => compileInjectionCode -> injectionCode 改变
           await this.updateResourceOnScriptChange(script);
@@ -902,15 +906,19 @@ export class RuntimeService {
 
   // 从CompiledResource中还原脚本代码
   async restoreJSCodeFromCompiledResource(script: Script, result: CompiledResource) {
+    // 用户在设置面板改运行时机只写 selfMetadata，脚本自带 metadata 不变，
+    // 所以编译分支必须按合并后的生效 metadata 选，否则重新注册会丢掉覆写（#1649）
+    const metadata = getCombinedMeta(script.metadata, script.selfMetadata);
+
     // 如果是 Scriptlet (unwrap) 脚本，需要另外的处理方式
-    if (isScriptletUnwrap(script.metadata)) {
+    if (isScriptletUnwrap(metadata)) {
       const scriptRes = await this.script.buildScriptRunResource(script);
       if (!scriptRes) return "";
       return compileScriptletCode(scriptRes, scriptRes.code, result.scriptUrlPatterns);
     }
 
     // 如果是预加载脚本，需要另外的处理方式
-    if (isEarlyStartScript(script.metadata)) {
+    if (isEarlyStartScript(metadata)) {
       const scriptRes = await this.script.buildScriptRunResource(script);
       if (!scriptRes) return "";
       return compileInjectionCode(scriptRes, scriptRes.code, result.scriptUrlPatterns);
@@ -931,7 +939,7 @@ export class RuntimeService {
         name: result.name,
         code: originalCode?.code || "",
         require,
-        isContextMenu: isContextMenuScript(script.metadata),
+        isContextMenu: isContextMenuScript(metadata),
       })
     );
   }

--- a/src/app/service/service_worker/utils.ts
+++ b/src/app/service/service_worker/utils.ts
@@ -137,7 +137,7 @@ export async function notificationsUpdate(
   }
 }
 
-export function getCombinedMeta(metaBase: SCMetadata, metaCustom: SCMetadata): SCMetadata {
+export function getCombinedMeta(metaBase: SCMetadata, metaCustom: SCMetadata | undefined): SCMetadata {
   const metaRet = { ...metaBase };
   if (!metaCustom) {
     return metaRet;


### PR DESCRIPTION
## Checklist / 检查清单

- [x] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

## 背景

脚本设置面板的「运行时机」下拉可以把一个原本自动执行的脚本改成 `context-menu`（手动/菜单触发），
但 #1649 反馈实测无效：菜单里不出现执行项，脚本仍然照常自动执行。

设置面板改运行时机只写 `script.selfMetadata`，脚本自带 `script.metadata` 不变，生效值要靠
`getCombinedMeta` 合并出来。排查后确认有**两处**代码直接读了未合并的 `script.metadata`，
因此脚本自己在 metadata 里写 `@run-at context-menu` 是好的，只有「UI 覆写」这条路会坏
（这也是用 demo 脚本复现不出来的原因）。

## 本次改动

**1. `RuntimeService.restoreJSCodeFromCompiledResource`（`runtime.ts`）**

全量重新注册时会从 `CompiledResource` 缓存还原脚本代码，选编译分支用的是脚本自带 metadata。
用户覆写的 `run-at` / `early-start` 在这里被丢弃：

- `context-menu` 覆写 → 还原出的是裸代码，没有 `GM_registerMenuCommand(...)` 包装 → 脚本恢复自动执行；
- `early-start` 覆写 → 退化成普通注入。

改为先算 `getCombinedMeta(script.metadata, script.selfMetadata)`，三个分支判断（`isScriptletUnwrap`
/ `isEarlyStartScript` / `isContextMenuScript`）都基于生效 metadata。

触发这条路径的是任何一次全量重新注册：扩展更新（`CompiledResourceNamespace` 变更强制清理重建）、
切换「启用脚本」、修改黑名单、userScripts 权限重新授予。所以表现是「刚设置完像是生效了，之后就永久失效」。

顺带修掉同文件 `pushValueUpdate` 里同源的一处：覆写而来的 early-start 脚本在 GM 值变更后不会重新编译，
预注入代码里的值会过期。

**2. `GMApi.parseRequest`（`gm_api/gm_api.ts`）**

`GMApiRequest.script` 直接用 `scriptDAO.get()` 的原始 Script，metadata 未合并。
`PermissionVerify.verify` 对 context-menu 脚本的 `GM_registerMenuCommand` 免 `@grant` 豁免
（`permission_verify.ts:135`）因此判不出来，浏览器里直接报
`verify error {"api":"GM_registerMenuCommand","error":"permission not requested"}`，菜单项注册不上。
在从 DAO 取出脚本后合并一次 `selfMetadata`，位置在订阅 `connect` 覆盖之前，订阅覆盖仍然优先。

**3. `compileScriptCodeByResource`（`content/utils.ts`）**

`@run-at context-menu` 的包装把脚本体塞进菜单回调时，回调开头把 `GM_registerMenuCommand` 连同
`window.` / `GM.` 上的引用一起置为 `undefined`。任何在脚本体里注册菜单的脚本，点菜单执行就会
`TypeError: GM_registerMenuCommand is not a function` 当场中断，它自己的菜单项也永远注册不上 ——
表现为「GM_registerMenuCommand 的菜单显示不出来」。该置空还会污染页面 `window` 与该脚本的 `GM` 物件，
且是持久的（不止这一次调用）。

这一处与 selfMetadata 无关：脚本直接在 metadata 里写 `@run-at context-menu` 同样中招，已实测确认。
去掉这行后脚本体里的菜单注册照常工作。

**4. `getCombinedMeta`（`service_worker/utils.ts`）** 第二参数放宽为 `SCMetadata | undefined`。
函数体本来就有 `if (!metaCustom) return metaRet` 守卫，此前所有调用点都在外面先判一次，该分支实际是死代码。

## 实现考虑

- 两处都选择在「读到 Script 之后、做判断之前」合并，而不是在每个判断点各打一次补丁 —— 根因是
  「该用生效 metadata 的地方用了原始 metadata」，在源头合并可以覆盖同一对象的其它消费者
  （如 `getConnectMatched(request.script.metadata.connect, …)`）。
- `parseRequest` 里合并时新建对象（`{...script, metadata: …}`），不就地改写 DAO 返回的对象。
- 今天 UI 能写进 `selfMetadata` 的只有 match/include/exclude/run-in/run-at/early-start/tag，
  其中只有 `run-at` 影响 GM 权限校验，所以第 2 点在当前 UI 下等价于只修 context-menu 豁免，
  但按生效 metadata 走的语义与 runtime 其余部分一致。

## 已知限制

- 已经被错误注册过的脚本，需要再发生一次重新注册（或改动脚本触发 `installScript`）才会重编译成正确代码。
  没有加迁移/一次性修复逻辑 —— 扩展更新本身就会触发全量重新注册。
- 浏览器验证里「点菜单执行脚本」这一步用的是 popup 与 `chrome.contextMenus.onClicked` 共用的
  `serviceWorker/popup/menuClick` 消息，未覆盖 `chrome.contextMenus` 条目创建与浏览器原生点击派发本身。
- 去掉包装里的置空后，脚本体每次被点执行都会重新注册一次自己的菜单，内部条目累积。
  显示层按 `groupKey` 去重，不会出现重复菜单项；但同名项的回调会被触发多次（实测：脚本体跑过 2 次后，
  点它注册的菜单项回调执行 2 次）。这是「脚本体按次执行」的固有结果，本 PR 未额外去重。
- #1649 里另一条反馈「菜单状态只认第一个窗口的分页」（`chrome.contextMenus` 是全局的、按活动标签页渲染）
  不在本 PR 范围内，未处理。

## 建议审查重点

- `restoreJSCodeFromCompiledResource` 的三个分支现在都基于合并后的 metadata，
  其中前两个分支内部又调用 `buildScriptRunResource`（本身会再合并一次），确认没有语义漂移。
- `parseRequest` 合并的位置：在订阅 `connect` 覆盖**之前**，保证订阅声明的 connect 仍然覆盖脚本自身的。
- 非 context-menu 脚本的 GM 权限校验路径没有被这次合并改变行为。
- 包装里去掉 `GM_registerMenuCommand=undefined` 后是否有其它依赖该屏蔽的行为（我没找到，但这是行为契约变更）。

## 关联

close #1649

## 验证

Base/head：`61164f6920e736fd3a03b269fb907e7aa7975432...1e811242c6ecb67225a008ea43fb5b2921856203`，
`git diff --stat` 共 7 个文件（4 个生产文件 + 3 个测试文件），无其它清理。

**单元测试（先 RED 后 GREEN）**

新增 4 条回归测试。先 `git stash` 掉生产改动确认全部失败，恢复后全部通过：

```
$ npx vitest run src/app/service/service_worker/runtime.test.ts      # 52 passed
$ npx vitest run src/app/service/service_worker/gm_api/              # 61 passed
$ npx vitest run src/app/service/content/utils.test.ts               # 38 passed
$ npx vitest run src/app/service/service_worker/                     # 586 tests, 2 failing 文件单独跑全过（本机负载所致）
```

RED 时的失败输出与浏览器现象一致，例如 `gm_api_self_metadata.test.ts` 报的就是
`Error: permission not requested`。

**真实浏览器验证**（`e2e/session.mjs`，Chrome + `dist/ext`，探针脚本 `@run-at document-idle` + `@grant none`，
匹配本地 `127.0.0.1:8765` 页面）

修复前（用 `origin/main` 的两份文件构建）复现了 issue 的两个症状：

```
01:51:42 [error] (src/service_worker.js) verify error
         {"api":"GM_registerMenuCommand","error":"permission not requested"}   ← 菜单注册不上
01:53:24 sw getScripts() → [{"id":"aaa16bad-…","hasMenuWrapper":false}]        ← 切「启用脚本」关→开后包装丢失
01:53:32 [log] (http://127.0.0.1:8765/?after-reregister) SC-PROBE-EXECUTED     ← 脚本恢复自动执行
```

修复后同一套操作：

```
sw getScripts() → [{"id":"88af7526-…","hasMenuWrapper":true}]                  ← 重新注册后包装仍在
sw storage.session['tabScript:…'] → menus:["run-at override probe"]            ← 菜单项注册成功
goto http://127.0.0.1:8765/?r2-after-reregister → 之后无 SC-PROBE-EXECUTED，无权限报错
触发 menuClick 后 → 02:04:39 SC-PROBE-EXECUTED                                 ← 点菜单才执行
```

第三处（包装屏蔽菜单注册）同样是浏览器里先复现的：装一个脚本体里注册
`Own Item A` / `Own Item B` 的脚本，改成 context-menu 后

```
menus: ["own menu probe"]                                  ← 自己的两项没了
点菜单 → TypeError: GM_registerMenuCommand is not a function ← 脚本体从这行中断
```

改完之后：

```
点菜单 → OWN-MENU-RUN，无报错
menus: ["own menu probe","Own Item A","Own Item B"]
contextMenus.create: ScriptCat → own menu probe → Own Item A / Own Item B
```

同样的复现在「脚本自己声明 `@run-at context-menu`」时也成立，证实与 selfMetadata 那条路无关。

**未跑完的检查**：`pnpm test` 全量在本次会话中被同机其它项目的构建占满 CPU（load average 141），
跑出大量 UI 用例超时失败，单独跑均通过；改动前在同一机器空闲时有 4505/4505 全绿基线。
`prettier --check` / `tsc --noEmit` / `check:i18n` / `check:issue-templates` / `eslint` 均 exit 0。
