### PR TITLE
📄 补充 Agent 自主操作边界、指令冲突裁决与人类可读写作规范

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,10 @@
 - [ ] Code reviewed by human / 代码通过人工检查
 - [ ] Changes tested / 已完成测试
 
+<!-- Tick a box only if it actually happened. "Code reviewed by human" means a person reviewed it, not the author's
+     own agent. If an item does not apply, leave it unticked and add a short "N/A — why" line below the checklist,
+     so a reviewer can tell "not applicable" from "not done". -->
+
 ## Description / 描述
 
 <!-- Description / PR 描述 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,14 @@ quick-map; concrete mechanics belong to the routed docs. Compatibility entry poi
 separate contract. Use [`docs/README.md`](docs/README.md) as the index and follow the owning doc instead of
 duplicating its rules.
 
+When two instructions collide, the doc that owns the subject wins over a summary of it, a specific rule wins over
+a general one, and a narrower exception wins over the default it names. If that still does not settle it, the
+collision is itself a finding: take the more conservative reading, say which one you took, and report the conflict
+so the doc set can be repaired — do not resolve it silently. A request from the user or a maintainer sets the goal
+and authorizes the work, and it can waive a preference; it does not by itself satisfy a rule that this doc set
+states as a prohibition. Say so once, in a sentence, and if the request is reaffirmed, carry it out and record it
+in the change as a named, accepted deviation — never as compliance.
+
 ## Route the task before acting
 
 | Before you… | Read |
@@ -18,8 +26,10 @@ duplicating its rules.
 | manually confirm a feature works | [`docs/verification.md`](docs/verification.md) — drive a throwaway session against the built extension, not the committed suite |
 
 For tasks matching multiple rows, read every applicable owner before that work; do not front-load unrelated
-docs. For tasks matching none, inspect `docs/README.md` and nearby implementation/tests before inventing a rule
-or abstraction.
+docs. Routing is continuous, not a classification you make once: when the work turns out to touch a row you did
+not match at the start — a rename that crosses a persistence or message boundary, a UI fix that needs a new
+entity — read that owner then, before continuing. For tasks matching none, inspect `docs/README.md` and nearby
+implementation/tests before inventing a rule or abstraction.
 
 ## DeepWiki Context
 
@@ -38,9 +48,11 @@ These are repo-wide defaults. A linked, narrow exception in its owning doc is pa
 downstream prose does not override it.
 
 - **Fix root causes, not symptoms — refactor over patch.** No `as any`, `// @ts-ignore`, swallowed errors, or
-  defensive skips or try-catch swallowing (宁愿重构也不要打补丁). When a test fails, fix the code rather than the test, except for a wrong
-  test contract or valueless test as defined in
-  [`docs/references/develop-testing.md`](docs/references/develop-testing.md#writing-meaningful-tests-what-to-clean-up--not-write).
+  defensive skips or try-catch swallowing (宁愿重构也不要打补丁). When a test fails, fix the code rather than
+  the test, and never weaken an assertion to make it pass. Which failures are an exception — an obsolete contract, a
+  no-value test, a flake, work misclassified as a unit test — is decided by the classification table in
+  [`docs/references/develop-testing.md`](docs/references/develop-testing.md#cleaning-up-tests-safely), not by this
+  summary.
 - **Confirm before fixing.** Reproduce and confirm a reported bug before changing it; capture the reproduction
   first (确定 bug 存在 → 写测试或记录验证证据 → 修复). Use [`docs/verification.md`](docs/verification.md) and
   the TDD principle in this section for the evidence standard.
@@ -74,6 +86,11 @@ downstream prose does not override it.
   observations; normative specifications, compatibility contracts, security policies, accepted contracts or oracles, and
   maintainer decisions determine correctness. A request/issue/PR does not prove a bug, necessity, or correctness.
   Label inferences, unverified, and contradicted claims.
+- **A change is material when a reviewer could not accept it from inspection alone.** That covers anything able
+  to alter runtime behavior, a public or persisted contract, security/privacy posture, permissions, cross-context
+  messaging, or build/release output. Everything else is routine and takes the light path: say what changed and
+  what you checked. Where the call is genuinely close, say which way you read it instead of quietly taking the
+  cheaper one.
 - **State rationale before summary.** For material changes, connect problem/requirement → affected
   scope/consequence → premise evidence → justification → remedy/trade-off → acceptance evidence → limitation/risk.
   A diff shows what changed, not why.
@@ -82,6 +99,10 @@ downstream prose does not override it.
 - **Match claim strength to evidence.** Static reasoning, executed tests, browser runs, and external integrations
   prove different scopes. A negative claim needs the relevant channel observed through its closure window or a
   causal proof that the side effect cannot occur.
+- **Do not write a caveat you could have converted into a fact.** Before recording a concern, a risk, or a
+  "worth checking" note, check it — an unchecked worry moves the work to the reader and tells them nothing they
+  could not already guess. If you record one regardless, say why you did not check it and what would settle it.
+  Hedging is not caution when it costs the reader more than it saves you.
 - **Bound readiness.** Do not call a material change review-ready with failed acceptance, a critical contradiction
   or evidence gap, unjustified scope, or stale final-patch evidence. A requested draft/investigation may proceed
   when labeled; report the blocker and clearing condition.
@@ -92,6 +113,81 @@ downstream prose does not override it.
 - **Require a witness and impact for findings.** Report only a concrete trigger/proof path, material consequence,
   useful location, and actionable contract to restore; do not turn an unverified repository assumption into a
   finding.
+
+## Autonomous operation
+
+These govern what an agent does on its own between two human decisions — the acting as much as the bounds on it.
+Within the work you were asked for you are the contributor, not a proposal generator: decide, do the work, and say
+what you decided. Authority over the goal is not authority over every act taken to reach it, which is what the
+later bullets bound.
+
+- **Decide inside the scope you were given.** Three situations get confused as one. If you do not know something,
+  find out — read the code, run it, write the probe; a question you could have answered yourself is not a question.
+  If it cannot be known yet, take the cheapest reasonable reading, state the assumption where the work will be
+  read, and continue. Only the third is escalation: a decision needing authority you do not have — something
+  irreversible or outward-facing, a product or policy trade-off the maintainer owns, or accepting a residual risk
+  on their behalf. Difficulty, ambiguity, and ordinary risk are not authority problems. Resolve them and record how.
+- **Hand a decision back only with its owner and its blocker named.** When you do escalate, say who owns the
+  decision, what specifically only they can supply, and what you will do by default if they say nothing. Without
+  those three it is not an escalation, it is unfinished work moved into someone else's queue. The same test governs
+  anything you notice in passing: if the task actually requires it, do it and say you did; if it merely happens to
+  be nearby, record a follow-up and move on — the boundary is the scope-discipline principle above, not the set of
+  files you happen to have open. Recommending work you were in a position to finish is not a lighter-touch option;
+  it is a smaller deliverable.
+- **Stop and hand back rather than proceed on a broken premise.** Stop when the reported problem does not
+  reproduce, the confirmed cause lies outside the authorized scope, an observation contradicts the task's premise,
+  or the only remaining repair would remove supported behavior or violate a principle here. A failing check is not
+  one of these triggers — fix its cause. Stopping is a deliverable, not a failure: report the attempt, the
+  evidence, the contradiction, and the decision the human now owns. Do not substitute a smaller change that is
+  easier to justify for the one that was asked for. Submitting an explicitly requested draft or investigation
+  instead stays governed by [`docs/pull-request.md`](docs/pull-request.md#decision-evidence-and-readiness).
+- **Bind the declared scope before committing or publishing.** The task statement, the commit type (gitmoji), and
+  the title declare a scope class — a test change, a fix, a refactor, a documentation change. Compare the actual
+  final diff against that class before you commit or push. Anything outside it is a checkpoint, not a judgement
+  call: move it into its own change with its own justification, or restate the scope. Do not carry an unexplained
+  edit forward because it looks harmless — a reviewer who cannot account for a hunk has to treat the whole change
+  as unreviewed. Mechanics live in [`docs/develop.md`](docs/develop.md#revision-scope-and-publication-binding).
+- **Keep outward-facing and irreversible acts under explicit authorization.** Local work — reading, editing,
+  building, running the suite, driving a verification session — proceeds freely. Acts that leave the working tree
+  or are hard to undo need authorization for that specific act: pushing, opening or updating a pull request,
+  commenting on or closing an issue or pull request, deleting or rewriting a branch, and any command with real
+  external side effects. The task that asked for such an act is that authorization — this is not a rule to ask
+  permission twice — but a neighboring act it did not ask for is a separate decision.
+- **Budget the reviewer's attention, not only your own.** An agent produces far more change per human review-minute
+  than a human contributor, so reviewability is part of the deliverable. Order the work so each commit is
+  independently reviewable and states the one thing it does; keep a confirmed behavior fix separate from cleanup
+  that merely travels with it; and when a correct repair is unavoidably large, say what makes it large and name
+  the seam a reviewer should check first.
+- **Never let a provisional fix pose as the correct model.** The root-cause principle decides whether a
+  result-correct but mechanism-wrong change is acceptable at all; this decides what must be visible once one is
+  accepted anyway. A workaround taken for schedule, a compatibility shim, or a symptom suppressed with the cause
+  identified but unfixed must say so in the change itself — not only in a review thread later readers will not
+  see. A later agent reads merged code as the intended design and builds on it, so an unmarked workaround becomes
+  a false foundation that compounds.
+- **Do not manufacture an oracle.** A self-generated score, grade, simulated pass rate, or persona review is your
+  own output, not an accepted oracle, and it cannot establish that a change is correct or good; report it, if at
+  all, as what it is. The same holds for an attestation that belongs to someone else — never record a human
+  review, a maintainer acceptance, or released behavior as satisfied on their behalf.
+
+## Writing for a human reader
+
+Everything an agent writes for people — pull request bodies, review comments, issue replies, hand-back reports — is
+read by someone deciding what to do next. Being understood is part of delivering, and length is a cost the reader
+pays rather than the writer.
+
+- **Write to the reader's next decision.** They are deciding whether to merge, what to change, or what to look at
+  first. Anything that does not move that decision is padding, however true it is. Lead with the outcome and then
+  the reasoning; do not make the reader assemble the conclusion out of a narrative of how you reached it.
+- **Prose is the default; structure has to earn its place.** A table of three sentences is harder to read than
+  three sentences. Headings, bullet lists, and severity labels help when the content is genuinely parallel or
+  enumerable, and get in the way when it is not. Match the shape of the write-up to the size of the change, not to
+  the longest template you were offered.
+- **Say each thing once.** A fact repeated across sections is one fact and several copies, and a reader who notices
+  the copies differ now has to work out which is current. State it where it belongs and refer back.
+- **Shorten by selecting, never by omitting.** Cut what does not change the reader's decision. Never cut a check
+  you ran, a limitation, an uncertainty, or evidence the change requires — dropping those is not concision, it is
+  an inaccurate report. And when emphasis is everywhere it is nowhere: reserve it for the one or two things you
+  would say aloud if you had the reader's attention for ten seconds.
 
 ## Architecture
 

--- a/docs/DOC-MAINTENANCE.md
+++ b/docs/DOC-MAINTENANCE.md
@@ -63,6 +63,16 @@ Every hit is a review-queue entry, not an automatic rewrite — confirm whether 
 correct (some are intentional non-negotiables) before loosening it, and confirm a downstream doc's exception
 survives when you touch the upstream rule it narrows.
 
+## Instruction budget
+
+Agent-facing instructions are loaded on every task, so each rule carries a standing cost and competes for
+attention with the rules already there. Before adding one, establish that it is not already derivable from a rule
+present in the doc set, that it states a principle rather than replaying one incident, and that it belongs to the
+doc that owns the subject rather than the doc most likely to be read. Prefer correcting or narrowing an existing
+rule to appending a new one, and prefer one rule stated once in its owning doc to the same rule restated for
+visibility — a rule that has to be repeated to be followed is usually stated in the wrong place. Deleting a rule
+that a later rule superseded is maintenance, not loss of coverage.
+
 ## Lint / config documentation depth
 
 When a doc describes an ESLint rule, tsconfig setting, or similar config-driven behavior, record the

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -208,4 +208,10 @@ branch, bind the artifact, revision, and scope to the current remote state:
    to its returned head SHA. Any new commit, force-push, rebase, base change, conflict resolution, or scope-claim
    edit invalidates earlier evidence; rerun the affected review, checks, and final-diff audit.
 
+The same binding applies to the scope you declared for your own change. A commit's gitmoji type and title, and the
+task statement they serve, name a scope class; compare the final diff against that class before committing or
+pushing. Move anything outside it into its own commit with its own justification, or restate the scope. A
+production behavior change that arrives inside a test-cleanup or refactor commit is not reviewable as either, and
+stays unreviewable no matter how correct it is on its own.
+
 **Review policy**: review **all** modified files (including `.md`/`.json`); PR description is context only — judge from the diff. Verify every code path touched.

--- a/docs/pull-request.md
+++ b/docs/pull-request.md
@@ -10,7 +10,9 @@ the change needs more context.
 
 Whatever headings you use, this guide's checklist and evidence expectations still apply — `## Summary` /
 `## Test plan` headings don't exempt a PR from them. Use the structure below; its sections are
-recommended, not all mandatory (see below for which ones).
+recommended, not all mandatory (see below for which ones). It is a list of things worth considering, not a form to
+complete: a section you have nothing load-bearing to put in is one to leave out, and a description longer than the
+diff it explains has usually stopped helping its reviewer.
 
 ## Recommended structure
 
@@ -74,7 +76,7 @@ For a material behavior, configuration, security, performance, compatibility, pe
 6. acceptance evidence; and
 7. the remaining limitation or risk.
 
-Keep this chain proportional. A confirmed one-line correction or a small documentation fix needs only the material parts; a non-trivial design choice should explain why doing nothing or a plausible smaller alternative was not selected and what would reopen the decision.
+Keep this chain proportional. A confirmed one-line correction or a small documentation fix needs only the relevant parts; a non-trivial design choice should explain why doing nothing or a plausible smaller alternative was not selected and what would reopen the decision.
 
 Keep these roles separate:
 
@@ -90,6 +92,12 @@ Consider risk for every material change. Use an explicit limitation or rollback 
 An agent must not present a change as review-ready when a material acceptance condition fails, a critical claim is unverified or contradicted, the diff exceeds the justified scope, required verification is missing without an adequate substitute, a known correctness/security/privacy/compatibility defect remains, or the description no longer matches the final patch. An explicitly requested draft or investigation may still be submitted when labeled as such. Report the blocker, the evidence, and the condition that would clear it.
 
 Verification claims bind to a revision or clearly identified worktree. If code, configuration, generated artifacts, or a decision-relevant description changes after a check, rerun every affected check before claiming readiness. A final commit SHA is sufficient identity for ordinary GitHub work; a cryptographic evidence ledger is not required by default.
+
+A check that does not reproduce its own result is not yet evidence. When a run is unstable — intermittent
+timeouts, order-dependent failures, an environment-blocked step — record what actually ran, which failures
+recurred and which did not, and how you separated them from the change under review. Report the residual
+uncertainty instead of resolving it in the change's favor: a green rerun does not retract a red run, and
+"unrelated to this change" is a claim that needs its own evidence rather than being the default reading.
 
 ### Scope claims and final-diff evidence
 


### PR DESCRIPTION
## Checklist / 检查清单

- [ ] Fixes mentioned issues / 修复已提及的问题
- [ ] Code reviewed by human / 代码通过人工检查
- [x] Changes tested / 已完成测试

N/A — 不对应单个 issue；尚无人工复核。`Changes tested` 指文档验证，不是产品测试，见「验证」。

## 背景

我们的 agent 文档把「改动要达到什么质量」写得很全，但漏了三件事，而这三件事恰好决定 agent 用起来舒不舒服。

**一、文档从没把 agent 写成决策者。** `decide` 的每一处主语都是别的东西：

```bash
git grep -nE 'decide[sd]? by|decides whether' -- AGENTS.md docs/
#   AGENTS.md:53   … is decided by the classification table in …
#   AGENTS.md:142  The root-cause principle decides whether …
```

`proceed` 也一样，要么是许可，要么是限制。整套文档是约束语料，从未授予判断权，所以 agent 遇到自己完全能解决的
判断题时会写成「建议」交回来——把活推回给人。本 PR 前两版自己就这样：发现 PR 模板缺 checklist 诚实性提示，
却写成「应由维护者决定，不属于本 PR 范围」。那不是审慎，是把一行可回滚的编辑推给别人。本版直接做掉了。

**二、写给人看的东西该怎么写，全套文档一个字都没有。** `develop.md` 的 Language Conventions 只管用哪种语言。
而 `pull-request.md` 给的是九级标题骨架 + 七项决策链 + 十行证据表——一张表格。Agent 会把表格填满，
于是产出前三版这份 PR 描述那样的东西：两百行、四个表格、同一件事在五个章节里各说一遍。人读起来很累。

**三、几个具体的分歧点**，都能在 `main` 上 grep 复核。`material` 是决定「要不要写七段 rationale chain、
要不要风险段、能不能算 ready」的门槛词，被引用九次、从未定义，而且 `pull-request.md:77` 的
“needs only the material parts” 用的还是另一个意思。测试失败的例外在常驻的 `AGENTS.md` 里只有两条，
owner 的分类表实际有六种处置，其中 Flaky 和 Misclassified integration 两种不在例外里——
「popup.test.ts flaky，修稳定」按常驻文件读要改生产代码，按 owner 读多半是修测试隔离。
路由表是一次性分类，跨边界的重命名做到一半发现该读架构文档时，没有规则叫你回去。
执行期没有冲突裁决规则（`DOC-MAINTENANCE.md` 那套是给改文档的人用的），agent 只能静默选边。
「人工指令能覆盖什么」也没写——面对「先 `as any` 顶一下」，手上是三块互不衔接的文本。

## 本次改动

给 agent 判断权，同时把边界写清楚。`AGENTS.md` 的 `## Autonomous operation` 改成「acting as much as the
bounds on it」，并新增两条：`Decide inside the scope you were given` 区分三种被混为一谈的情况——**不知道**就去查
（自己能回答的不算问题）、**还不可知**就取最省的合理读法并写明假设、**无权决定**才是升级；难度、歧义、
一般风险不是授权问题。`Hand a decision back only with its owner and its blocker named` 要求升级时指名谁拥有该决定、
只有他们能提供什么、没回音时你的默认动作；顺带发现的事，任务确实需要就做掉，只是恰好在旁边就记 follow-up，
边界是 scope discipline 而不是你打开了哪些文件。把本可做完的事写成「建议」不是更轻的选项，是更小的交付物。

新增 `## Writing for a human reader`：写到读者的下一个决定为止；散文是默认，结构要自己挣来位置；
每件事只说一次；靠**取舍**变短而不是靠**省略**——查过的检查、限制、不确定性一个都不能删。
配套把 `pull-request.md` 的结构说明改成「待考虑项，不是待填表格」，并点明描述比 diff 还长通常已经帮倒忙。

其余是修正已有规则：前言补指令冲突裁决与人工指令的覆盖边界（可豁免 preference，不满足写成禁止的规则；
说明一次，被重申则执行并记为具名的已接受偏离）；路由改成持续的；测试失败例外整体交给 owner 分类表裁决，
链接改指 `#cleaning-up-tests-safely`；`pull-request.md:77` 一处 `material` 改 `relevant` 消除一词两义。
新增 `material` 的可操作定义、声明范围与最终 diff 的绑定、不稳定检查结果的报告口径
（绿色重跑不撤销红色运行）、临时性修复必须自我披露、禁止自造 oracle，以及 `DOC-MAINTENANCE.md` 的
Instruction budget（约束以后往这套文档里加规则，也约束本 PR 自己）。

`.github/pull_request_template.md` 加了三行**不渲染**的注释：只有真做了才勾、`Code reviewed by human` 指人
而不是作者自己的 agent、不适用就留空并写一行 `N/A — why`。`pull-request.md` 要求模板保持 lightweight
并保留 Checklist，两条都守住了——去掉全部 HTML 注释后模板输出与改前逐字节相同。它是唯一能触达
不读 `AGENTS.md` 的外部 agent 的位置。若认为模板一个字符都不该动，删掉这三行即可。

## 已知限制

这是静态审查。上面每条都能在 `main` 上 grep 复核，属可验证的文本事实；但「改完之后真实模型行为会变好」
本 PR 不提供证据。我用任务 trace 走查了这些分歧点（flaky 测试、`as any` 豁免请求、跨边界重命名、
一行修复的 materiality、owner 间冲突、以及本 PR 自己的 deferral 和这份描述本身），trace 用于定位文本缺陷，
不构成验收依据——本 PR 新增的规则之一就是禁止把自造评分当 oracle，所以这里没有分数。

`material` 的定义放在 `AGENTS.md`（shared contract），`pull-request.md` 靠常驻加载继承。
若认为该由 `pull-request.md` 拥有，位置可以调，但不该两处各写一份。

## 建议审查重点

1. `Decide inside the scope you were given` 的三分法是不是你们要的升级门槛。
2. `Hand a decision back` 与 scope discipline 的边界：现在切在「任务确实需要就做，只是在旁边就记 follow-up」。
3. `## Writing for a human reader` 会不会和 `pull-request.md` 的证据要求打架——写的是「靠取舍变短，
   不靠省略」，查过的检查和限制不许删，请确认这个防线够不够。
4. 测试失败规则改交 owner 分类表后，`AGENTS.md` 是否仍保住足够强的非可协商部分。
5. PR 模板那三行注释是否接受。

## 验证

只改 Markdown。`pnpm run lint` 的 prettier 只覆盖 `**/*.{ts,tsx,js,jsx,mjs}`，Markdown 不在其内，
所以跑的是 `pull-request.md#documentation-only-prs` 要求的文档验证。

```text
base 61164f6920e736fd3a03b269fb907e7aa7975432 → head 017872bf2b8c4a33ba6bf4b30861c4f665d9fa55

git diff --numstat        .github/pull_request_template.md  +4/-0
                          AGENTS.md                        +101/-5
                          docs/DOC-MAINTENANCE.md           +10/-0
                          docs/develop.md                    +6/-0
                          docs/pull-request.md              +10/-2
                          5 files changed, 131 insertions(+), 7 deletions(-)

链接完整性   DOC-MAINTENANCE.md 的 one-shot 脚本，HEAD 全部 tracked Markdown → 0 BROKEN
锚点         #cleaning-up-tests-safely / #revision-scope-and-publication-binding /
             #decision-evidence-and-readiness → 各 1 命中
重复标题     ## Autonomous operation、## Writing for a human reader 仅在 AGENTS.md；
             ## Instruction budget 仅在 DOC-MAINTENANCE.md
模板渲染     去掉全部 HTML 注释后与改前逐字节相同，Checklist 三项与顺序未动
政策一致性   绝对语气 grep 命中 6 处，逐条确认为有意的 non-negotiable
术语         'material' 在 pull-request.md 的第二种含义已改为 "the relevant parts"
隐私扫描     clean
行宽         新增行均 ≤120 列
```

未跑 `pnpm test` / `pnpm run lint` / `pnpm run build`：不触及产品代码、测试、生成文件或翻译，
且本 worktree 无 `node_modules`，Markdown 也不在这些检查范围内。无 UI 变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
